### PR TITLE
Change caching strategy from tonic clients to tonic channels.

### DIFF
--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -1,5 +1,5 @@
 use crate::KeyComparisonType;
-use std::{fmt::Display, io};
+use std::{fmt::Display, io, sync::Arc};
 use thiserror::Error as ThisError;
 
 /// Errors that map directly from the Oxia gRPC service responses (excluding success/OK)
@@ -134,6 +134,12 @@ pub enum Error {
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    #[error("Shared error: {0}")]
+    Shared(#[source] Arc<Error>),
+
+    #[error("Cancelled")]
+    Cancelled,
 }
 
 impl Error {
@@ -218,6 +224,12 @@ impl From<io::Error> for Error {
         } else {
             Error::Io(value)
         }
+    }
+}
+
+impl From<Arc<Error>> for Error {
+    fn from(value: Arc<Error>) -> Self {
+        Error::Shared(value)
     }
 }
 

--- a/crates/client/src/pool.rs
+++ b/crates/client/src/pool.rs
@@ -1,0 +1,287 @@
+use std::collections::hash_map::Entry;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
+use tokio::sync::broadcast;
+use tonic::transport::{Channel, Endpoint};
+use tracing::{info, warn};
+
+use crate::Error;
+use crate::Result;
+use crate::config;
+use crate::config::Config;
+
+type CompletionResult = std::result::Result<Channel, Arc<Error>>;
+
+mod inner {
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    pub(super) enum Item {
+        Channel(Channel),
+        Pending(broadcast::Sender<CompletionResult>),
+    }
+
+    #[derive(Debug, Default)]
+    pub(super) struct State {
+        pub(super) clients: HashMap<String, Item>,
+        // todo: metrics
+    }
+
+    #[derive(Clone, Debug)]
+    pub(super) struct Inner {
+        pub(super) config: Arc<config::Config>,
+        pub(super) state: Arc<RwLock<State>>,
+    }
+
+    impl Inner {
+        pub(super) fn new(config: Arc<config::Config>) -> Self {
+            Self {
+                config,
+                state: Arc::new(RwLock::new(State::default())),
+            }
+        }
+    }
+} // mod inner
+
+pub trait ChannelFactory: Clone + Send + Sync {
+    async fn create(&self, config: &Arc<Config>, target: &str) -> Result<Channel>;
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultChannelFactory;
+
+impl ChannelFactory for DefaultChannelFactory {
+    async fn create(&self, _: &Arc<Config>, target: &str) -> Result<Channel> {
+        let target = target.as_bytes().to_vec();
+        let endpoint = Endpoint::from_shared(target)?;
+        endpoint.connect().await.map_err(Error::from)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ChannelPool<F = DefaultChannelFactory> {
+    inner: Arc<inner::Inner>,
+    factory: F,
+}
+
+#[allow(dead_code)]
+impl ChannelPool<DefaultChannelFactory> {
+    pub fn new(config: &Arc<Config>) -> Self {
+        Self {
+            inner: Arc::new(inner::Inner::new(config.clone())),
+            factory: DefaultChannelFactory {},
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl<F: ChannelFactory> ChannelPool<F> {
+    pub fn with_channel_factory(config: &Arc<Config>, factory: F) -> Self {
+        Self {
+            inner: Arc::new(inner::Inner::new(config.clone())),
+            factory,
+        }
+    }
+
+    async fn await_pending_op(mut rx: broadcast::Receiver<CompletionResult>) -> CompletionResult {
+        let rv = rx.recv().await;
+        match rv {
+            Ok(Ok(r)) => Ok(r),
+            Ok(Err(e)) => Err(e),
+            Err(e) => {
+                let boxed: Box<dyn std::error::Error + Send + Sync> = Box::new(e);
+                Err(Arc::new(Error::from(boxed)))
+            }
+        }
+    }
+
+    // Return a pooled item, waiting for a pending insert if one is in progress.
+    // The pending insert may fail, which is why this is wrapped in Result<>
+    async fn try_get(&self, target: &str) -> Option<CompletionResult> {
+        use inner::*;
+        let guard = self.inner.state.read().await;
+        let item = guard.clients.get(target)?;
+        match item {
+            Item::Channel(c) => Some(Ok(c.clone())),
+            Item::Pending(tx) => {
+                let rx = tx.subscribe();
+                drop(guard); // allow pending operation to complete
+                Some(Self::await_pending_op(rx).await)
+            }
+        }
+    }
+
+    async fn create_channel(&self, target: &str) -> Result<Channel> {
+        self.factory.create(&self.inner.config, target).await
+    }
+
+    async fn send_completion(
+        &self,
+        target: &str,
+        tx: broadcast::Sender<CompletionResult>,
+        r: CompletionResult,
+    ) {
+        let mut guard = self.inner.state.write().await;
+
+        match tx.send(r.clone()) {
+            Err(err) => warn!(?err, "ChannelPool::get() send completion failed"),
+            Ok(subscriptions) => {
+                info!(subscriptions, "ChannelPool::get() send completion")
+            }
+        }
+
+        if let Ok(c) = r {
+            guard
+                .clients
+                .insert(target.to_string(), inner::Item::Channel(c));
+        } else {
+            match tx.send(r) {
+                Err(err) => warn!(?err, "ChannelPool::get() send completion failed"),
+                Ok(subscriptions) => {
+                    info!(subscriptions, "ChannelPool::get() send completion")
+                }
+            }
+            guard.clients.remove(target);
+        }
+    }
+
+    async fn complete(
+        &self,
+        target: &str,
+        tx: broadcast::Sender<CompletionResult>,
+        r: Result<Channel>,
+    ) -> Result<Channel> {
+        use inner::*;
+
+        // If the entry was removed while we had the lock dropped, discard the channel.
+        // There's no need to notify anyone waiting for a completion, when the the
+        // last sender is dropped, they'll see a cancellation
+        let mut guard = self.inner.state.write().await;
+        match guard.clients.entry(target.to_string()) {
+            Entry::Vacant(_) => Err(Error::Cancelled),
+            Entry::Occupied(mut o) => {
+                match o.get() {
+                    Item::Pending(otx) => {
+                        // While the lock was dropped, our request could have been cancelled and replaced
+                        // by anoter request.  Verify we still "own" the pending state.
+                        if otx.same_channel(&tx) {
+                            // Still our pending operation, so complete it
+                            let notification = match r {
+                                Ok(c) => {
+                                    o.insert(Item::Channel(c.clone()));
+                                    Ok(c)
+                                }
+                                Err(e) => {
+                                    o.remove();
+                                    Err(Arc::new(e))
+                                }
+                            };
+
+                            match tx.send(notification.clone()) {
+                                Err(err) => {
+                                    warn!(?err, "ChannelPool::get() send completion failed")
+                                }
+                                Ok(subscriptions) => {
+                                    info!(subscriptions, "ChannelPool::get() send completion")
+                                }
+                            };
+
+                            // Now map the notification back to a cloneable Result
+                            notification.map_err(Error::from)
+                        } else {
+                            // Our operation was cancelled, so don't notify and return an error.
+                            // Waiting for the new operation is likely useless: we got caoncelled for a
+                            // reason.
+                            Err(Error::Cancelled)
+                        }
+                    }
+                    Item::Channel(c) => Ok(c.clone()),
+                }
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn get(&self, target: &str) -> Result<Channel> {
+        use inner::*;
+
+        // Already there, we're done and don't need the write lock
+        if let Some(item) = self.try_get(target).await {
+            return item.map_err(Error::from);
+        }
+
+        let state = &self.inner.state;
+        let mut guard = state.write().await;
+        let entry = guard.clients.entry(target.to_string());
+
+        if let Entry::Occupied(item) = entry {
+            return match item.get() {
+                Item::Channel(c) => Ok(c.clone()),
+                Item::Pending(tx) => {
+                    let rx = tx.subscribe();
+                    drop(guard); // allow pending operation to complete
+                    Self::await_pending_op(rx).await.map_err(Error::from)
+                }
+            };
+        }
+
+        // Set up the notification channel, let's others know we're working on it...
+        let tx = {
+            let (tx, _) = broadcast::channel(1);
+            entry.insert_entry(Item::Pending(tx.clone()));
+            tx
+        };
+
+        // Create the channel without the write lock to avoid blocking all
+        drop(guard);
+        let cr = self.create_channel(target).await;
+
+        self.complete(target, tx, cr).await
+    }
+
+    pub(crate) async fn create(&self, target: &str) -> Result<Channel> {
+        // We could try to be smarter here, but this method is unlikely to be called often
+        self.inner.state.write().await.clients.remove(target);
+        self.get(target).await
+    }
+
+    pub(crate) async fn remove(&self, target: &str) -> Option<Channel> {
+        let state = &self.inner.state;
+        let mut guard = state.write().await;
+        if let Some(inner::Item::Channel(c)) = guard.clients.remove(target) {
+            Some(c)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test_log::test(tokio::test(flavor = "current_thread"))]
+    async fn test_construct() -> anyhow::Result<()> {
+        let config = config::Builder::new().service_addr("localhost").build()?;
+        let pool = ChannelPool::new(&config);
+        let _ = pool.get("").await;
+        Ok(())
+    }
+
+    #[derive(Clone)]
+    struct FailDefaultChannelFactory;
+
+    impl ChannelFactory for FailDefaultChannelFactory {
+        async fn create(&self, _: &Arc<Config>, _: &str) -> Result<Channel> {
+            Err(Error::Custom("not implemented".to_string()))
+        }
+    }
+
+    #[test_log::test(tokio::test(flavor = "current_thread"))]
+    async fn test_construct_factory() -> anyhow::Result<()> {
+        let config = config::Builder::new().service_addr("localhost").build()?;
+        let pool = ChannelPool::with_channel_factory(&config, FailDefaultChannelFactory {});
+        assert!(pool.get("").await.is_err());
+        Ok(())
+    }
+}


### PR DESCRIPTION
A Channel represents a connection to a remote host and is worth re-using, while tonic clients are designed to be cheap to clone.

This is a preliminary rework.  In particular, it's probably not a good idea that the shard assignment task creates a connection to every leader node in the cluster early.  What if the shard assignment map changes before any of the chennels are ever used?

Notable changes:
 * pool::ChannelPool - cloneable pool of channels, minimize contention between access to channels from different hosts

 * pool::ChannelPoolFactory - trait to inject a factory to create channels.  Currnetly only useable for unit testing.

 * GrpcClientCache - removed