### PR TITLE
Simplify Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,87 +1,90 @@
+# TARGETARCH value will be set automatically
+
+# Configuration, unlikely to change
+ARG USER=runner
+ARG HOME=/home/${USER}
+ARG CARGO_HOME=${HOME}/.cargo
+ARG RUSTUP_HOME=${HOME}/.rustup
+
 FROM ubuntu:24.04 AS build
 
-# ===== 1. OS packages (long-lived layer) =====
+# Import defaults
+ARG USER
+ARG HOME
+ARG CARGO_HOME
+ARG RUSTUP_HOME
+
+# Versions
+ARG RUST_VERSION=1.89
+ARG GO_VERSION=go1.25.0
+
+ARG TARGETARCH
+ARG GO_ARCH=${TARGETARCH}
+
+# ===== OS packages (long-lived layer), runs as root =====
+
 RUN apt-get update && apt-get install -y \
     build-essential \
-    pkg-config \
-    libssl-dev \
-    clang \
-    cmake \
-    git \
-    curl \
-    unzip \
     ca-certificates \
-    protobuf-compiler \
+    curl \
+    git \
+    gnupg \
     jq \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler \
     python3 \
     python3-pip \
-    gnupg \
+    unzip \
+    zstd \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# ===== 2. Create non-root build user =====
-RUN useradd -ms /bin/bash runner
-USER runner
-WORKDIR /home/runner
+# ===== Create non-root build user and switch =====
+RUN useradd -ms /bin/bash ${USER}
+USER ${USER}
+WORKDIR /home/${USER}
 
-# ===== 3. Install Rust (latest 1.89.y patch) =====
-ENV RUST_MINOR=1.89
-RUN latest=$(curl -s https://api.github.com/repos/rust-lang/rust/releases \
-      | jq -r '.[].tag_name' \
-      | grep "^${RUST_MINOR}\." \
-      | sort -Vr | head -n1) && \
-    echo "Installing Rust $latest" && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-      | sh -s -- -y --default-toolchain "$latest" --profile minimal && \
-    echo 'source $HOME/.cargo/env' >> ~/.bashrc
-ENV PATH=/home/runner/.cargo/bin:$PATH
+ENV \
+    CARGO_HOME=${CARGO_HOME} \
+    RUSTUP_HOME=${RUSTUP_HOME} \
+    PATH=${RUSTUP_HOME}/bin:${CARGO_HOME}/bin:/home/${USER}/go/bin:$PATH
 
-# ===== 4. Install Cargo tools =====
-RUN . $HOME/.cargo/env && \
-    cargo install sccache \
-                  cargo-nextest \
-                  cargo-edit \
-                  cargo-outdated \
-                  ripgrep \
-                  fd-find
+# ===== Install Rust =====
 
-# ===== 5. Install Go (latest 1.24.x patch) =====
-ENV GO_MINOR=1.24
-RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ]; then GO_ARCH="amd64"; \
-    elif [ "$ARCH" = "arm64" ]; then GO_ARCH="arm64"; \
-    else echo "Unsupported architecture: $ARCH" && exit 1; fi && \
-    LATEST=$(curl -s https://go.dev/dl/?mode=json \
-      | jq -r '.[].version' \
-      | grep "^go${GO_MINOR}\." \
-      | sort -Vr | head -n1) && \
-    echo "Installing Go $LATEST" && \
-    curl -fsSL "https://go.dev/dl/${LATEST}.linux-${GO_ARCH}.tar.gz" \
-      | tar -C /home/runner -xzf - && \
-    mv /home/runner/go /home/runner/.go && \
-    echo 'export PATH=$HOME/.go/bin:$PATH' >> ~/.bashrc
-ENV PATH=/home/runner/.go/bin:$PATH
+# build time env: also add to final image
+ENV \
+    CARGO_HOME=${CARGO_HOME} \
+    RUSTUP_HOME=${RUSTUP_HOME} \
+    PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:$PATH
 
-# ===== --hack--. Add rust components left out of minimal install we'll need later.
-# TODO: just switch profiles, this is a hack to re-use existing layers
-RUN rustup component add clippy rustfmt
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain ${RUST_VERSION} -y
 
-# --hack-- set rust for future builds. get rid of this when we do the next big rebuild
-RUN rustup default $(rustc --version | awk '{print $2}')
+# ===== Install Cargo tools =====
+RUN cargo install cargo-binstall && cargo binstall cargo-nextest sccache
 
+# ===== Install Go =====
+RUN curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-${GO_ARCH}.tar.gz" | tar -C ${HOME} -xzf -
 
-ENV RUSTUP_HOME=/home/runner/.rustup \
-    CARGO_HOME=/home/runner/.cargo
+# ====== Fetch current dependencies =====
+RUN --mount=type=bind,dst=/src cargo fetch --locked --manifest-path=/src/Cargo.toml
 
-# --hack-- install zstd
-USER root
-RUN apt-get update && apt-get install -y zstd \
-    && rm -rf /var/lib/apt/lists/*
-
+# ===== ================== =====
+# ===== Create final image =====
+# ===== ================== =====
 
 FROM scratch AS final
+
+# Import defaults
+ARG USER
+ARG HOME
+ARG CARGO_HOME
+ARG RUSTUP_HOME
+
+ENV \
+    CARGO_HOME=${CARGO_HOME} \
+    RUSTUP_HOME=${RUSTUP_HOME} \
+    PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:${HOME}/go/bin:$PATH
+
 COPY --from=build / /
-ENV PATH=/home/runner/.cargo/bin:/home/runner/.go/bin:$PATH \
-    CARGO_HOME=/home/runner/.cargo \
-    RUSTUP_HOME=/home/runner/.rustup 


### PR DESCRIPTION
* Use ARG for common settings
* Collapse hack layers
* Be specific on Go version  + update to go1.25.0
* Fetch current dependencies for build tree