### PR TITLE
Speed up build of oxia-bin-util

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,12 +71,6 @@ jobs:
           cargo update --dry-run # update crate index
           cargo fetch --locked   # fetch dependencies: last network dependency
 
-      - name: prepare go cache
-        run: |
-          cache="$PWD/target/.gocache"
-          test -d $cache || mkdir -p $cache
-          echo "GOCACHE=$cache" >> $GITHUB_ENV
-
       - name: build
         run: cargo build --frozen --all-targets
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,12 +290,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -447,6 +485,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -900,6 +948,10 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "oxia-bin-util"
 version = "0.1.0"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1250,6 +1302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1334,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1660,6 +1732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1766,22 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1786,6 +1880,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/oxia-bin-util/Cargo.toml
+++ b/oxia-bin-util/Cargo.toml
@@ -6,3 +6,7 @@ publish = false
 
 [lints]
 workspace = true
+
+[build-dependencies]
+sha2 = "0.10.9"
+walkdir = "2.5.0"

--- a/oxia-bin-util/build.rs
+++ b/oxia-bin-util/build.rs
@@ -13,10 +13,15 @@
 // limitations under the License.
 
 use std::env;
+use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Instant;
 
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+// Derive .../target/{profile} from OUT_DIR
 fn get_target_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
     let profile = env::var("PROFILE")?;
@@ -32,43 +37,72 @@ fn get_target_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
     Err("Could not find target directory root".into())
 }
 
-fn build_oxia_cli() {
+fn build_oxia_cli() -> io::Result<()> {
     const OXIA_MOD: &str = "github.com/oxia-db/oxia";
+    let tools_src_dir = Path::new("go");
+    let vendor_root = tools_src_dir.join("vendor").join(OXIA_MOD);
 
     let target_dir = get_target_dir().unwrap();
     let oxia_path = target_dir.join("oxia-bin");
-    let build_oxia = !oxia_path.exists();
+    let oxia_path_str = oxia_path.to_str().unwrap().to_string();
 
-    // Let's convert all paths into owned strings up-front: panic early
-    let oxia_path = oxia_path.to_str().unwrap().to_string();
-    let tools_src_dir = Path::new("go");
     let go_mod = tools_src_dir.join("go.mod").to_str().unwrap().to_string();
     let go_sum = tools_src_dir.join("go.sum").to_str().unwrap().to_string();
 
-    if build_oxia {
-        let start = Instant::now();
+    // Make Cargo re-run when vendored code or go.mod/go.sum change.
+    println!("cargo:rerun-if-changed={}", vendor_root.display());
+    println!("cargo:rerun-if-changed={go_mod}");
+    println!("cargo:rerun-if-changed={go_sum}");
+
+    // Compute a stable content hash of all relevant Go sources + go.mod/go.sum
+    let mut hasher = Sha256::new();
+
+    // Hash go.mod / go.sum
+    hasher.update(fs::read(&go_mod)?);
+    hasher.update(fs::read(&go_sum)?);
+
+    // Hash all .go files under the vendored oxia module
+    for entry in WalkDir::new(&vendor_root)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        let path = entry.path();
+        if path.is_file() && path.extension().is_some_and(|e| e == "go") {
+            hasher.update(fs::read(path)?);
+        }
+    }
+    let new_hash = format!("{:x}", hasher.finalize());
+
+    let hash_path = oxia_path.with_extension("sha256");
+    let old_hash = fs::read_to_string(&hash_path).ok();
+
+    let binary_missing = !oxia_path.exists();
+    let hash_changed = old_hash.as_deref() != Some(&new_hash);
+
+    if binary_missing || hash_changed {
         let status = Command::new("go")
             .current_dir(tools_src_dir)
             .env("GOPROXY", "off")
             .arg("build")
-            .arg("-v")
             .arg("-mod=vendor")
             .arg("-o")
-            .arg(&oxia_path)
+            .arg(&oxia_path_str)
             .arg(format!("./vendor/{OXIA_MOD}/cmd"))
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .status()
             .expect("failed to run `go build` for oxia CLI");
-        let install_time = start.elapsed();
-        println!("cargo:warning=oxia build finished in {install_time:.2?} seconds");
+
         assert!(status.success(), "oxia build failed");
+        fs::write(&hash_path, new_hash)?; // update hash after successful build
     }
-    println!("cargo:rerun-if-changed={go_mod}");
-    println!("cargo:rerun-if-changed={go_sum}");
-    println!("cargo:rustc-env=OXIA_BIN_PATH={oxia_path}");
+
+    // Keep exporting the path to the built binary for consumers
+    println!("cargo:rustc-env=OXIA_BIN_PATH={oxia_path_str}");
+    Ok(())
 }
 
 fn main() {
-    build_oxia_cli();
+    // Propagate IO errors as panics to fail the build clearly
+    build_oxia_cli().unwrap();
 }


### PR DESCRIPTION
The go cache doesn't work across builds because it the cache is based upon mtime.  Instead, use a content-based check. The binary and the sum file is preserved in the github build cache so hopefully we will save 80 or so seconds on most builds.  The go sources are vendored and rarely change.