### PR TITLE
fix off by one

### DIFF
--- a/client/src/notification.rs
+++ b/client/src/notification.rs
@@ -198,7 +198,11 @@ impl NotificationsStream {
             shards[idx].state = state;
             if let Poll::Ready(None) = poll_result {
                 shards.swap_remove(idx);
-                next = idx;
+                if idx == shards.len() {
+                    next = 0;
+                } else {
+                    next = idx;
+                }
             } else if poll_result.is_ready() {
                 return (poll_result, StreamState::Active { shards, next });
             }


### PR DESCRIPTION
after removing the current item from a vector, we need to wrap around to 0 if we just removed the last one.