### PR TITLE
Support ^C in the shell command

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -747,7 +747,7 @@ where
     util::with_timeout(timeout, util::with_retry(retry_config, retry_op)).await
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Client {
     shard_manager: Option<Arc<shard::Manager>>,
     config: Arc<config::Config>,

--- a/cmd/src/commands/completions.rs
+++ b/cmd/src/commands/completions.rs
@@ -30,7 +30,7 @@ pub struct CompletionsCommand {
 
 #[async_trait::async_trait]
 impl CommandRunnable for CompletionsCommand {
-    async fn run(self, _: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, _: crate::Context) -> anyhow::Result<()> {
         let mut cmd = Cli::command();
         let prog_name = cmd.get_name().to_string();
 

--- a/cmd/src/commands/delete.rs
+++ b/cmd/src/commands/delete.rs
@@ -34,7 +34,7 @@ pub struct DeleteCommand {
 
 #[async_trait::async_trait]
 impl CommandRunnable for DeleteCommand {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
         trace!(?self, ?ctx, "params");
         let opts = DeleteOptions::new().with(|opts| {
             if let Some(pk) = self.partition {

--- a/cmd/src/commands/delete_range.rs
+++ b/cmd/src/commands/delete_range.rs
@@ -36,7 +36,7 @@ pub struct DeleteRangeCommand {
 
 #[async_trait::async_trait]
 impl CommandRunnable for DeleteRangeCommand {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
         trace!(?self, ?ctx, "params");
         let opts = DeleteRangeOptions::new().with(|opts| {
             if let Some(pk) = self.partition {

--- a/cmd/src/commands/get.rs
+++ b/cmd/src/commands/get.rs
@@ -90,7 +90,7 @@ impl CommandRunnable for GetCommand {
 
         let result = ctx.client().await?.get_with_options(self.key, opts).await;
         trace!(?result, "result");
-        println!("(stub) {result:?}");
+        println!("{result:?}");
         super::to_result(result)
     }
 }

--- a/cmd/src/commands/get.rs
+++ b/cmd/src/commands/get.rs
@@ -70,7 +70,7 @@ pub struct GetCommand {
 
 #[async_trait::async_trait]
 impl CommandRunnable for GetCommand {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
         trace!(?self, ?ctx, "params");
         let opts = GetOptions::new().with(|opts| {
             opts.comparison_type(self.key_comp.into());

--- a/cmd/src/commands/list.rs
+++ b/cmd/src/commands/list.rs
@@ -40,7 +40,7 @@ pub struct ListCommand {
 
 #[async_trait::async_trait]
 impl CommandRunnable for ListCommand {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
         trace!(?self, ?ctx, "params");
         let opts = ListOptions::new().with(|opts| {
             if let Some(pk) = self.partition {

--- a/cmd/src/commands/mod.rs
+++ b/cmd/src/commands/mod.rs
@@ -37,7 +37,7 @@ pub use shell::ShellCommand;
 
 #[async_trait]
 pub trait CommandRunnable {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()>;
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()>;
 }
 
 #[derive(Subcommand)]
@@ -73,7 +73,7 @@ pub enum Commands {
 
 #[async_trait]
 impl CommandRunnable for Commands {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
         match self {
             Commands::Completions(cmd) => cmd.run(ctx).await,
             Commands::Delete(cmd) => cmd.run(ctx).await,

--- a/cmd/src/commands/notifications.rs
+++ b/cmd/src/commands/notifications.rs
@@ -24,7 +24,7 @@ pub struct NotificationsCommand {}
 
 #[async_trait::async_trait]
 impl CommandRunnable for NotificationsCommand {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
         trace!(?self, ?ctx, "params");
         let result = ctx.client().await?.create_notifications_stream();
         trace!(?result, "result");

--- a/cmd/src/commands/put.rs
+++ b/cmd/src/commands/put.rs
@@ -80,7 +80,7 @@ pub struct PutCommand {
 
 #[async_trait::async_trait]
 impl CommandRunnable for PutCommand {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
         trace!(?self, ?ctx, "params");
         let value = decode(self.encoding, self.value)?;
         let opts = PutOptions::new().with(|opts| {

--- a/cmd/src/commands/range_scan.rs
+++ b/cmd/src/commands/range_scan.rs
@@ -40,7 +40,7 @@ pub struct RangeScanCommand {
 
 #[async_trait::async_trait]
 impl CommandRunnable for RangeScanCommand {
-    async fn run(self, ctx: &mut crate::Context) -> anyhow::Result<()> {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
         trace!(?self, ?ctx, "params");
         let opts = RangeScanOptions::new().with(|opts| {
             if let Some(pk) = self.partition {

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -57,6 +57,6 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     cli.log.setup("off")?;
 
-    let mut ctx = Context::new(&cli)?;
-    cli.command.run(&mut ctx).await
+    let ctx = Context::new(&cli)?;
+    cli.command.run(ctx).await
 }


### PR DESCRIPTION
We need to rework the Context so that it can work with a spawned task:
instead of passing a mutable reference, pass an owned/cloneable value
with interior mutability.

In the ^C handling, be careful to handle the race condition between
receiving a ^C and the command completing successfully.
