### PR TITLE
claude leader hint

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -671,6 +671,23 @@ pub(crate) async fn create_grpc_client(
     Ok(GrpcClient::new(channel))
 }
 
+const fn extract_leader_hint(e: &Error) -> Option<&LeaderHint> {
+    if let Error::OxiaRpc(OxiaRpcError::NodeIsNotLeader { hint }) = e {
+        hint.as_ref()
+    } else {
+        None
+    }
+}
+
+fn remaining_timeout(
+    request_timeout: Option<Duration>,
+    start: Option<Instant>,
+) -> Option<Duration> {
+    request_timeout
+        .zip(start)
+        .map(|(timeout, started)| timeout.saturating_sub(started.elapsed()))
+}
+
 pub(crate) async fn execute_with_retry<F, Fut, R>(
     config: &Arc<config::Config>,
     shard_manager: Option<&Arc<shard::Manager>>,
@@ -709,10 +726,8 @@ where
         && let Err(ref e) = result
         && e.is_wrong_leader()
     {
-        let remaining = timeout
-            .zip(start)
-            .map(|(t, s)| t.saturating_sub(s.elapsed()));
-        return stale_shard_map_retry(config, sm, remaining, start, &op).await;
+        let hint = extract_leader_hint(e).cloned();
+        return stale_shard_map_retry(config, sm, start, hint, &op).await;
     }
 
     // Or... no retries are requested
@@ -721,9 +736,7 @@ where
     }
 
     // Account for the time we've used so far for the next round of retries
-    let timeout = timeout
-        .zip(start)
-        .map(|(t, s)| t.saturating_sub(s.elapsed()));
+    let timeout = remaining_timeout(timeout, start);
 
     let retry_op = move || op();
     util::with_timeout(timeout, util::with_retry(retry_config, retry_op)).await
@@ -731,13 +744,17 @@ where
 
 /// Retry loop for stale shard map (wrong leader) errors.
 ///
-/// Each iteration: capture epoch → trigger refresh → wait for update → retry op.
+/// When `initial_hint` is `Some`, the first iteration applies the hint immediately (fast path)
+/// instead of waiting for a discovery refresh.  Subsequent iterations use the hint extracted
+/// from the retry result, or fall back to the slow path when no hint is available.
+///
+/// Each slow-path iteration: capture epoch → trigger refresh → wait for update → retry op.
 /// Bounded by retry attempts (or 1 if no retry config) and the overall request timeout.
 async fn stale_shard_map_retry<F, Fut, R>(
     config: &Arc<config::Config>,
     shard_manager: &Arc<shard::Manager>,
-    remaining: Option<Duration>,
     start: Option<Instant>,
+    initial_hint: Option<LeaderHint>,
     op: F,
 ) -> Result<R>
 where
@@ -748,46 +765,46 @@ where
     let max_attempts = config.retry().map_or(1, |r| r.attempts);
     let request_timeout = config.request_timeout();
 
+    let mut hint = initial_hint;
+
     for _ in 0..max_attempts {
         // Check remaining time budget
-        let remaining = match request_timeout.zip(start) {
-            Some((t, s)) => {
-                let left = t.saturating_sub(s.elapsed());
-                if left.is_zero() {
-                    return Err(Error::RequestTimeout);
-                }
-                Some(left)
-            }
-            None => remaining,
-        };
+        let remaining = remaining_timeout(request_timeout, start);
+        if matches!(remaining, Some(left) if left.is_zero()) {
+            return Err(Error::RequestTimeout);
+        }
 
-        let epoch = shard_manager.epoch();
-        shard_manager.trigger_refresh();
+        if let Some(ref h) = hint {
+            // Fast path: leader hint known — apply immediately without waiting
+            // apply_leader_hint also calls trigger_refresh internally
+            shard_manager.apply_leader_hint(h);
+        } else {
+            // Slow path: wait for discovery refresh
+            let epoch = shard_manager.epoch();
+            shard_manager.trigger_refresh();
 
-        // Wait for the shard map to update, using remaining timeout or a reasonable default
-        let wait_timeout = remaining.unwrap_or(Duration::from_secs(30));
-        shard_manager.wait_for_update(epoch, wait_timeout).await?;
+            // Wait for the shard map to update, using remaining timeout or a reasonable default
+            let wait_timeout = remaining.unwrap_or(Duration::from_secs(30));
+            shard_manager.wait_for_update(epoch, wait_timeout).await?;
+        }
 
         // Retry the operation with remaining timeout
-        let remaining = match request_timeout.zip(start) {
-            Some((t, s)) => Some(t.saturating_sub(s.elapsed())),
-            None => remaining,
-        };
+        let remaining = remaining_timeout(request_timeout, start);
         let result = util::with_timeout(remaining, op()).await;
 
         #[allow(clippy::match_same_arms)]
         match &result {
             Ok(_) => return result,
             Err(Error::RequestTimeout) => return result,
-            Err(e) if e.is_wrong_leader() => (),
+            Err(e) if e.is_wrong_leader() => {
+                hint = extract_leader_hint(e).cloned();
+            }
             Err(_) => return result,
         }
     }
 
     // Final attempt after exhausting retry budget
-    let remaining = request_timeout
-        .zip(start)
-        .map(|(t, s)| t.saturating_sub(s.elapsed()));
+    let remaining = remaining_timeout(request_timeout, start);
     util::with_timeout(remaining, op()).await
 }
 

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -50,6 +50,7 @@ use crate::GrpcClient;
 use crate::ListOptions;
 use crate::ListResponse;
 use crate::OxiaError;
+use crate::OxiaRpcError;
 use crate::PutOptions;
 use crate::PutResponse;
 use crate::RangeScanOptions;
@@ -261,6 +262,28 @@ fn format_leader_url(a: &oxia_proto::ShardAssignment) -> Arc<str> {
     Arc::from(format!("http://{}", a.leader))
 }
 
+fn format_leader_hint_url(hint: &crate::LeaderHint) -> Arc<str> {
+    Arc::from(format!("http://{}", hint.leader_address))
+}
+
+fn apply_leader_hint_to_directory(leaders: &LeaderDirectory, hint: &crate::LeaderHint) -> bool {
+    let new_url = format_leader_hint_url(hint);
+    let current = leaders.load();
+    if let Some(existing) = current.get(hint.shard)
+        && existing.as_ref() == new_url.as_ref()
+    {
+        return false;
+    }
+
+    let mut new_map = ShardIdMap::default();
+    for (id, url) in current.iter() {
+        new_map.insert(id, Arc::clone(url));
+    }
+    new_map.insert(hint.shard, new_url);
+    leaders.store(Arc::new(new_map));
+    true
+}
+
 #[derive(Debug)]
 struct ClientData {
     config: Arc<config::Config>,
@@ -331,6 +354,16 @@ impl Client {
         if let Some(leader) = self.get_leader() {
             self.data.channel_pool.remove(&leader).await;
         }
+    }
+
+    /// Apply a leader hint for this shard, updating the shared leader directory.
+    ///
+    /// No-ops if the hint is for a different shard.
+    fn apply_leader_hint(&self, hint: &crate::LeaderHint) {
+        if hint.shard != self.data.shard_id {
+            return;
+        }
+        apply_leader_hint_to_directory(&self.data.leaders, hint);
     }
 
     /// Execute an RPC with automatic channel invalidation on connection errors.
@@ -883,8 +916,20 @@ impl Client {
         };
 
         let read_result = self
-            .rpc(|mut grpc| async move { grpc.read(read_req).await })
+            .rpc(|mut grpc| {
+                let req = read_req.clone();
+                async move { grpc.read(req).await }
+            })
             .await;
+
+        let read_result = match read_result {
+            Err(Error::OxiaRpc(OxiaRpcError::NodeIsNotLeader { hint: Some(hint) })) => {
+                self.apply_leader_hint(&hint);
+                self.rpc(|mut grpc| async move { grpc.read(read_req).await })
+                    .await
+            }
+            other => other,
+        };
 
         Self::demux_stream(Arc::clone(&self.data), batch_req.keys, read_result).await
     }
@@ -1596,7 +1641,6 @@ impl ShardAssignmentTask {
 #[derive(Debug)]
 pub struct Manager {
     shards: Arc<ArcSwap<searchable::Shards>>,
-    #[allow(dead_code)]
     leaders: LeaderDirectory,
     cancel_token: CancellationToken,
     task_handle: JoinHandle<()>,
@@ -1684,6 +1728,15 @@ impl Manager {
     /// Rate-limited to prevent excessive refreshes.
     pub fn trigger_refresh(&self) {
         self.refresh_signal.notify_one();
+    }
+
+    /// Apply a leader hint, updating the shared leader directory immediately.
+    ///
+    /// Also triggers a background refresh so the authoritative map eventually catches up.
+    pub(crate) fn apply_leader_hint(&self, hint: &crate::LeaderHint) {
+        if apply_leader_hint_to_directory(&self.leaders, hint) {
+            self.trigger_refresh();
+        }
     }
 
     /// Waits for the shard map to be updated to an epoch greater than `after_epoch`.


### PR DESCRIPTION
    retry: use LeaderHint fast path when retrying wrong-leader errors

    When the server returns NodeIsNotLeader with a hint, apply the hint
    immediately to the LeaderDirectory instead of waiting for a full
    discovery refresh. This eliminates the round-trip to the discovery
    service on the hot retry path.  If the hint doesn't change the
    directory, do nothing.