### PR TITLE
Rewrite simple async forwarders to non-async functions that return a future

### DIFF
--- a/client/benches/channel_pool.rs
+++ b/client/benches/channel_pool.rs
@@ -43,6 +43,7 @@ use std::time::Instant;
 use arc_swap::ArcSwap;
 #[cfg(feature = "bench-dashmap")]
 use dashmap::DashMap;
+use futures::FutureExt;
 use tokio::sync::RwLock;
 
 // ---------------------------------------------------------------------------
@@ -93,16 +94,19 @@ impl RwLockPool {
         }
     }
 
-    async fn get(&self, target: &str) -> Option<MockChannel> {
-        self.clients.read().await.get(target).cloned()
+    fn get(&self, target: &str) -> impl Future<Output = Option<MockChannel>> {
+        self.clients.read().map(|c| c.get(target).cloned())
     }
 
-    async fn remove(&self, target: &str) -> Option<MockChannel> {
-        self.clients.write().await.remove(target)
+    fn remove(&self, target: &str) -> impl Future<Output = Option<MockChannel>> {
+        self.clients.write().map(|mut c| c.remove(target))
     }
 
-    async fn insert(&self, target: &str, ch: MockChannel) {
-        self.clients.write().await.insert(target.to_string(), ch);
+    fn insert(&self, target: &str, ch: MockChannel) -> impl Future<Output = ()> {
+        let target = target.to_string();
+        async move {
+            self.clients.write().await.insert(target, ch);
+        }
     }
 }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -842,9 +842,9 @@ impl Client {
     }
 
     #[inline]
-    pub async fn reconnect(&mut self) -> Result<()> {
+    pub fn reconnect(&mut self) -> impl Future<Output = Result<()>> {
         self.shard_manager = None;
-        self.connect().await
+        self.connect()
     }
 
     /// Returns the current shard map epoch.
@@ -907,17 +907,17 @@ impl Client {
     }
 
     #[inline]
-    pub async fn get(&self, k: impl Into<String>) -> Result<Option<GetResponse>> {
-        self.get_with_options(k, GetOptions::default()).await
+    pub fn get(&self, k: impl Into<String>) -> impl Future<Output = Result<Option<GetResponse>>> {
+        self.get_with_options(k, GetOptions::default())
     }
 
     #[inline]
-    pub async fn get_with_options(
+    pub fn get_with_options(
         &self,
         key: impl Into<String>,
         options: GetOptions,
-    ) -> Result<Option<GetResponse>> {
-        self.get_internal(Arc::from(key.into()), options).await
+    ) -> impl Future<Output = Result<Option<GetResponse>>> {
+        self.get_internal(Arc::from(key.into()), options)
     }
 
     async fn get_internal(
@@ -1034,23 +1034,22 @@ impl Client {
     }
 
     #[inline]
-    pub async fn put(
+    pub fn put(
         &self,
         key: impl Into<String>,
         value: impl Into<Bytes>,
-    ) -> Result<PutResponse> {
-        self.put_with_options(key, value, PutOptions::new()).await
+    ) -> impl Future<Output = Result<PutResponse>> {
+        self.put_with_options(key, value, PutOptions::new())
     }
 
     #[inline]
-    pub async fn put_with_options(
+    pub fn put_with_options(
         &self,
         key: impl Into<String>,
         value: impl Into<Bytes>,
         options: PutOptions,
-    ) -> Result<PutResponse> {
+    ) -> impl Future<Output = Result<PutResponse>> {
         self.put_internal(Arc::from(key.into()), value.into(), options)
-            .await
     }
 
     async fn put_internal(
@@ -1072,18 +1071,17 @@ impl Client {
     }
 
     #[inline]
-    pub async fn delete(&self, key: impl Into<String>) -> Result<()> {
+    pub fn delete(&self, key: impl Into<String>) -> impl Future<Output = Result<()>> {
         self.delete_with_options(key, DeleteOptions::default())
-            .await
     }
 
     #[inline]
-    pub async fn delete_with_options(
+    pub fn delete_with_options(
         &self,
         key: impl Into<String>,
         options: DeleteOptions,
-    ) -> Result<()> {
-        self.delete_internal(Arc::from(key.into()), options).await
+    ) -> impl Future<Output = Result<()>> {
+        self.delete_internal(Arc::from(key.into()), options)
     }
 
     async fn delete_internal(&self, key: Arc<str>, options: DeleteOptions) -> Result<()> {
@@ -1099,32 +1097,30 @@ impl Client {
     }
 
     #[inline]
-    pub async fn delete_range(
+    pub fn delete_range(
         &self,
         start_inclusive: impl Into<String>,
         end_exclusive: impl Into<String>,
-    ) -> Result<()> {
+    ) -> impl Future<Output = Result<()>> {
         self.delete_range_with_options(
             start_inclusive,
             end_exclusive,
             DeleteRangeOptions::default(),
         )
-        .await
     }
 
     #[inline]
-    pub async fn delete_range_with_options(
+    pub fn delete_range_with_options(
         &self,
         start_inclusive: impl Into<String>,
         end_exclusive: impl Into<String>,
         options: DeleteRangeOptions,
-    ) -> Result<()> {
+    ) -> impl Future<Output = Result<()>> {
         self.delete_range_internal(
             Arc::from(start_inclusive.into()),
             Arc::from(end_exclusive.into()),
             options,
         )
-        .await
     }
 
     async fn delete_range_internal(
@@ -1193,28 +1189,26 @@ impl Client {
     }
 
     #[inline]
-    pub async fn list(
+    pub fn list(
         &self,
         start_inclusive: impl Into<String>,
         end_exclusive: impl Into<String>,
-    ) -> Result<ListResponse> {
+    ) -> impl Future<Output = Result<ListResponse>> {
         self.list_with_options(start_inclusive, end_exclusive, ListOptions::default())
-            .await
     }
 
     #[inline]
-    pub async fn list_with_options(
+    pub fn list_with_options(
         &self,
         start_inclusive: impl Into<String>,
         end_exclusive: impl Into<String>,
         options: ListOptions,
-    ) -> Result<ListResponse> {
+    ) -> impl Future<Output = Result<ListResponse>> {
         self.list_internal(
             Arc::from(start_inclusive.into()),
             Arc::from(end_exclusive.into()),
             options,
         )
-        .await
     }
 
     async fn list_internal(
@@ -1278,28 +1272,26 @@ impl Client {
     }
 
     #[inline]
-    pub async fn range_scan(
+    pub fn range_scan(
         &self,
         start_inclusive: impl Into<String>,
         end_exclusive: impl Into<String>,
-    ) -> Result<RangeScanResponse> {
+    ) -> impl Future<Output = Result<RangeScanResponse>> {
         self.range_scan_with_options(start_inclusive, end_exclusive, RangeScanOptions::default())
-            .await
     }
 
     #[inline]
-    pub async fn range_scan_with_options(
+    pub fn range_scan_with_options(
         &self,
         start_inclusive: impl Into<String>,
         end_exclusive: impl Into<String>,
         options: RangeScanOptions,
-    ) -> Result<RangeScanResponse> {
+    ) -> impl Future<Output = Result<RangeScanResponse>> {
         self.range_scan_internal(
             Arc::from(start_inclusive.into()),
             Arc::from(end_exclusive.into()),
             options,
         )
-        .await
     }
 
     async fn range_scan_internal(

--- a/client/src/pool.rs
+++ b/client/src/pool.rs
@@ -139,8 +139,8 @@ impl<Fact: ChannelFactory> ChannelPool<Fact> {
         }
     }
 
-    async fn create_channel(&self, target: &str) -> Result<Channel> {
-        self.factory.create(&self.config, target).await
+    fn create_channel(&self, target: &str) -> impl Future<Output = Result<Channel>> {
+        self.factory.create(&self.config, target)
     }
 
     async fn finalize_connection(

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
+use futures::FutureExt;
 use futures::stream::Stream;
 use futures::stream::StreamExt;
 use mauricebarnum_oxia_common::proto as oxia_proto;
@@ -971,16 +972,16 @@ impl Client {
     }
 
     /// Deletes a range of keys with the given options
-    pub(crate) async fn delete_range(
+    pub(crate) fn delete_range(
         &self,
         start_inclusive: &str,
         end_exclusive: &str,
         options: &DeleteRangeOptions,
-    ) -> Result<()> {
+    ) -> impl Future<Output = Result<()>> {
         let req = self.make_delete_range_req(options, start_inclusive, end_exclusive);
-        let rsp = self.process_write(req).await?;
-
-        check_delete_range_response(&rsp).map_or_else(|| Ok(()), Err)
+        self.process_write(req).map(|r| {
+            r.and_then(|rsp| check_delete_range_response(&rsp).map_or_else(|| Ok(()), Err))
+        })
     }
 
     /// Lists keys in the given range with options


### PR DESCRIPTION
Avoid the overhead of generating an async state machine when an async
function is either a trivial forwarder and/or has a simple preamble that can
be evaluated eagerly ad/or a simple postfix that be implemented with
FuturesExt;:map()
