### PR TITLE
ci: speed up Docker builds with caching and incremental compilation

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       build_mode:
-        description: "Build mode: auto, ci, ci-debug, or debug"
+        description: "Build mode: auto, ci, ci-debug, test-release, or debug"
         required: false
         default: "auto"
         type: string
@@ -25,7 +25,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Use sccache with local cache only (no GitHub Actions cache)
   SCCACHE_DIR: "/tmp/sccache"
   RUSTC_WRAPPER: "sccache"
   RUST_BACKTRACE: full
@@ -71,6 +70,10 @@ jobs:
             echo "CARGO_PROFILE=ci-debug" >> $GITHUB_ENV
             echo "RELEASE_FLAG=--profile ci-debug" >> $GITHUB_ENV
             echo "NEXTEST_FLAG=--cargo-profile ci-debug" >> $GITHUB_ENV
+          elif [ "$BUILD_MODE" = "test-release" ]; then
+            echo "CARGO_PROFILE=test-release" >> $GITHUB_ENV
+            echo "RELEASE_FLAG=--profile test-release" >> $GITHUB_ENV
+            echo "NEXTEST_FLAG=--cargo-profile test-release" >> $GITHUB_ENV
           elif [ "$EVENT" = "pull_request" ]; then
             # Auto mode: ci-debug for PRs
             echo "CARGO_PROFILE=ci-debug" >> $GITHUB_ENV
@@ -84,7 +87,6 @@ jobs:
           fi
           echo "Build mode: $BUILD_MODE, Event: $EVENT, Profile: $CARGO_PROFILE"
 
-      # TODO: move this to the build image
       - name: Compute rustc hash
         run: echo "RUSTC_HASH=$(rustc --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
@@ -126,8 +128,12 @@ jobs:
         run: cargo clippy $RELEASE_FLAG --no-deps --all-targets --frozen -- -D warnings
 
       - name: test
-        timeout-minutes: 10
+        timeout-minutes: 15  # release builds may be slower
         run: cargo nextest run $NEXTEST_FLAG --frozen --no-fail-fast --verbose
+
+      - name: doc-test
+        if: env.CARGO_PROFILE == 'test-release'
+        run: cargo test --doc $RELEASE_FLAG --frozen --verbose
 
       - name: miri-client
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,37 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     "cfg(accept_invalid_shard_ids)",
 ] }
 
+# The below is copied from build/cargo-config.toml.
+# DO  NOT EDIT
+
+# Cargo configuration installed into ${CARGO_HOME}/config.toml inside the
+# build image.  cargo-chef cook runs outside the workspace directory and
+# reads this file for profile settings; CI builds run inside the workspace
+# and read workspace Cargo.toml instead.  The two sources are merged by
+# Cargo with workspace Cargo.toml taking precedence.
+#
+# FINGERPRINT WARNING: For cargo-chef caching to survive into CI builds,
+# the effective compiler flags for each cooked profile must be identical in
+# both contexts.  Concretely:
+#   - [profile.ci-debug] here must exactly match [profile.ci-debug] in Cargo.toml.
+#   - [profile.ci] here must exactly match [profile.ci] in Cargo.toml.
+#   - [profile.test-release] here must exactly match [profile.test-release] in Cargo.toml.
+#   - [profile.release] here must exactly match [profile.release] in Cargo.toml
+#     (because [profile.ci] and [profile.test-release] inherit from it).
+# Update both files together whenever you change a profile.
+
+# Goal: Fast compiles, but fast enough runtime to not be frustrated.
 [profile.dev]
 opt-level = 1       # Basic optimizations so async code isn't glacial
 debug = "full"      # Maximum debug info for IDEs and GDB/LLDB
 incremental = true  # Essential for fast "edit-compile-test" cycles
 codegen-units = 256
 
+# Optimize dependencies even in debug mode
+[profile.dev.package."*"]
+opt-level = 3 # Your code stays debuggable; tokio/hyper/serde run at 100% speed
+
+# Must match workspace Cargo.toml
 [profile.release]
 opt-level = 3
 debug = true
@@ -42,32 +67,38 @@ incremental = false
 codegen-units = 1
 rpath = false
 
-# CI build: exercises the optimiser at opt-level=3 without LTO, so that
-# cargo-chef pre-compiled dep artifacts have valid fingerprints. Fat LTO
-# forces the linker to reprocess all bitcode anyway, negating any caching.
-# Assertions are on to catch bugs the optimiser can expose.
-#
-# NOTE: [profile.ci] in build/cargo-config.toml must mirror these settings
-# exactly. cargo-chef cook runs outside the workspace and reads that file;
-# CI builds run inside the workspace and read this file. Fingerprints must
-# match or every CI build recompiles all dependencies.
-# PR CI builds: dev opt-levels for fast compile, line-tables-only for useful
-# stack traces without the cost of full debug info.
-# NOTE: [profile.ci-debug] in build/cargo-config.toml must mirror these settings
-# exactly — see the fingerprint warning in that file.
+# CI-debug: Fast CI for PR validation. Optimized for compilation speed.
+# Must match workspace Cargo.toml
 [profile.ci-debug]
 inherits = "dev"
-debug = "line-tables-only" # see build/cargo-config.toml — must match
-incremental = false        # see build/cargo-config.toml — must match
+debug = "line-tables-only" # Enough for backtraces, keeps compile fast
+incremental = true         # Enables sccache, matches dev
+codegen-units = 256        # Fast parallel compilation
 
 [profile.ci-debug.package."*"]
-opt-level = 3 # see build/cargo-config.toml — must match
+opt-level = 3
 
+# CI: Branch builds (main pushes). Slightly more optimized but still fast.
+# Must match workspace Cargo.toml
 [profile.ci]
 inherits = "release"
+debug = "line-tables-only"
+lto = false                # LTO kills compile time, not needed for tests
+incremental = true         # Enables sccache
+codegen-units = 256        # Fast parallel compilation
+opt-level = 2              # Good optimization, faster compile than 3
+debug-assertions = true    # Catch bugs in CI
+overflow-checks = true     # Catch arithmetic bugs
 strip = "none"
-debug = "line-tables-only" # see build/cargo-config.toml — must match
-lto = false                # see build/cargo-config.toml — must match
-codegen-units = 16         # see build/cargo-config.toml — must match
-debug-assertions = true    # see build/cargo-config.toml — must match
-overflow-checks = true     # see build/cargo-config.toml — must match
+
+# Test-release: Full optimizations plus assertions for catching release-only bugs.
+# Must match workspace Cargo.toml
+[profile.test-release]
+inherits = "release"
+debug = true            # Full debug info for accurate backtraces
+debug-assertions = true # Keep assertions enabled (critical for bug catching)
+overflow-checks = true  # Keep overflow checks
+lto = false             # LTO too slow for CI, optimizations not needed for tests
+codegen-units = 256     # Fast compilation
+incremental = true      # Enable sccache
+strip = "none"          # Keep symbols

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,7 @@
-# Global Scope ARGs
-ARG USER=runner
-ARG HOME=/home/${USER}
-ARG CARGO_HOME=${HOME}/.cargo
-ARG RUSTUP_HOME=${HOME}/.rustup
+# Global Scope ARGs (change these defaults if you ever switch user)
+ARG CARGO_HOME=/root/.cargo
+ARG RUSTUP_HOME=/root/.rustup
+ARG HOME=/root
 ARG RUST_VERSION=1.95.0
 ARG GO_VERSION=1.26.2
 
@@ -12,13 +11,10 @@ FROM golang:${GO_VERSION} AS go-official
 
 # ===== 2. Toolchain & Tool Preparer =====
 FROM rust-official AS toolchain-builder
-# Do NOT override RUSTUP_HOME/CARGO_HOME here; use image defaults (/usr/local)
-# to ensure the pre-installed stable toolchain is found by rustup.
-
+# Use image defaults (/usr/local) for CARGO_HOME/RUSTUP_HOME
 RUN rustup component add clippy && \
     rustup toolchain install --profile minimal --allow-downgrade nightly && \
     rustup component add --toolchain nightly miri rust-src && \
-    # Pre-build the miri sysroot in the default location
     cargo +nightly miri setup
 
 ARG CARGO_CHECK_EXTERNAL_TYPES_VERSION=nightly-2025-10-18
@@ -55,37 +51,34 @@ RUN for toml in */Cargo.toml; do \
 
 # ===== 4. OS Base =====
 FROM ubuntu:24.04 AS os-base
-ARG USER
-ARG HOME
 ARG CARGO_HOME
 ARG RUSTUP_HOME
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN apt-get update && apt-get install -y \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
     build-essential ca-certificates curl git gnupg jq libssl-dev \
     pkg-config protobuf-compiler python3 python3-pip unzip zstd \
     && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -ms /bin/bash ${USER} && \
-    mkdir -p /__w "${CARGO_HOME}" "${RUSTUP_HOME}" && \
-    chown -R ${USER}:${USER} /__w "${CARGO_HOME}" "${RUSTUP_HOME}"
+RUN mkdir -p /__w "${CARGO_HOME}" "${RUSTUP_HOME}"
 
 # ===== 5. Rust Cooker =====
 FROM os-base AS rust-cooker
-ARG USER
-ARG HOME
+ARG REPO_NAME=oxia-rust
 ARG CARGO_HOME
 ARG RUSTUP_HOME
-ARG REPO_NAME=oxia-rust
-USER ${USER}
+ARG HOME
+
 WORKDIR ${HOME}
 
-# MIGRATION: Copy from default image locations into runner's custom home
-COPY --from=toolchain-builder --chown=${USER}:${USER} /usr/local/cargo ${CARGO_HOME}
-COPY --from=toolchain-builder --chown=${USER}:${USER} /usr/local/rustup ${RUSTUP_HOME}
-COPY --from=chef --chown=${USER}:${USER} /usr/local/cargo/bin/cargo-chef ${CARGO_HOME}/bin/cargo-chef
+# Copy toolchains to our parameterised paths (root owned)
+COPY --from=toolchain-builder /usr/local/cargo ${CARGO_HOME}
+COPY --from=toolchain-builder /usr/local/rustup ${RUSTUP_HOME}
+COPY --from=chef /usr/local/cargo/bin/cargo-chef ${CARGO_HOME}/bin/cargo-chef
 
 ENV CARGO_HOME=${CARGO_HOME} \
     RUSTUP_HOME=${RUSTUP_HOME} \
@@ -94,44 +87,43 @@ ENV CARGO_HOME=${CARGO_HOME} \
 
 COPY build/cargo-config.toml ${CARGO_HOME}/config.toml
 
-COPY --from=planner --chown=${USER}:${USER} /recipe/recipe.json /tmp/recipe.json
+COPY --from=planner /recipe/recipe.json /tmp/recipe.json
+
 RUN GH_WORKSPACE="/__w/${REPO_NAME}/${REPO_NAME}" && \
     mkdir -p "${GH_WORKSPACE}" && \
     cp /tmp/recipe.json "${GH_WORKSPACE}/recipe.json" && \
     cd "${GH_WORKSPACE}" && \
-    CARGO_INCREMENTAL=0 cargo chef cook --profile ci-debug --all-targets --recipe-path recipe.json && \
-    CARGO_INCREMENTAL=0 cargo chef cook --profile ci --all-targets --recipe-path recipe.json && \
+    cargo chef cook --profile ci-debug --all-targets --recipe-path recipe.json && \
+    cargo chef cook --profile ci --all-targets --recipe-path recipe.json && \
+    cargo chef cook --profile test-release --all-targets --recipe-path recipe.json && \
+    cargo fetch --locked && \
     cargo +nightly fetch --locked
 
 # ===== 6. Go Builder =====
 FROM os-base AS go-builder
 COPY --from=go-official /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:$PATH
-RUN --mount=type=bind,dst=/src GOPROXY=off GOCACHE=/tmp/gocache \
-    go -C /src/ext/oxia/cmd build -mod=vendor -o /tmp/oxia && rm -rf "$GOCACHE"
+RUN --mount=type=bind,dst=/src \
+    --mount=type=cache,target=/tmp/gocache \
+    GOPROXY=off GOCACHE=/tmp/gocache \
+    go -C /src/ext/oxia/cmd build -mod=vendor -o /tmp/oxia
 
 # ===== 7. Final Assembly =====
 FROM os-base AS final
-ARG USER
-ARG HOME
 ARG CARGO_HOME
 ARG RUSTUP_HOME
+ARG HOME
 
-# Redefine ENV for runtime persistence
-ENV USER=${USER} \
-    HOME=${HOME} \
-    CARGO_HOME=${CARGO_HOME} \
+ENV CARGO_HOME=${CARGO_HOME} \
     RUSTUP_HOME=${RUSTUP_HOME} \
     CARGO_TARGET_DIR=${HOME}/deps/target \
-    CARGO_INCREMENTAL=0 \
     PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Ensure ownership and artifacts (including Miri sysroot) are transferred
-COPY --from=rust-cooker --chown=${USER}:${USER} ${CARGO_HOME} ${CARGO_HOME}
-COPY --from=rust-cooker --chown=${USER}:${USER} ${RUSTUP_HOME} ${RUSTUP_HOME}
-COPY --from=rust-cooker --chown=${USER}:${USER} ${HOME}/deps ${HOME}/deps
+# Copy all pre‑built pieces (root owned, no chown)
+COPY --from=rust-cooker ${CARGO_HOME} ${CARGO_HOME}
+COPY --from=rust-cooker ${RUSTUP_HOME} ${RUSTUP_HOME}
+COPY --from=rust-cooker ${HOME}/deps ${HOME}/deps
 COPY --from=go-official /usr/local/go /usr/local/go
 COPY --from=go-builder /tmp/oxia ${CARGO_HOME}/bin/oxia
 
-USER ${USER}
 WORKDIR ${HOME}

--- a/build/cargo-config.toml
+++ b/build/cargo-config.toml
@@ -9,8 +9,9 @@
 # both contexts.  Concretely:
 #   - [profile.ci-debug] here must exactly match [profile.ci-debug] in Cargo.toml.
 #   - [profile.ci] here must exactly match [profile.ci] in Cargo.toml.
+#   - [profile.test-release] here must exactly match [profile.test-release] in Cargo.toml.
 #   - [profile.release] here must exactly match [profile.release] in Cargo.toml
-#     (because [profile.ci] inherits from it).
+#     (because [profile.ci] and [profile.test-release] inherit from it).
 # Update both files together whenever you change a profile.
 
 # Goal: Fast compiles, but fast enough runtime to not be frustrated.
@@ -24,7 +25,7 @@ codegen-units = 256
 [profile.dev.package."*"]
 opt-level = 3 # Your code stays debuggable; tokio/hyper/serde run at 100% speed
 
-# Must match workspace Cargo.toml [profile.release] — see fingerprint warning above.
+# Must match workspace Cargo.toml
 [profile.release]
 opt-level = 3
 debug = true
@@ -38,21 +39,39 @@ incremental = false
 codegen-units = 1
 rpath = false
 
-# Must match workspace Cargo.toml [profile.ci-debug] — see fingerprint warning above.
+# CI-debug: Fast CI for PR validation. Optimized for compilation speed.
+# Must match workspace Cargo.toml
 [profile.ci-debug]
 inherits = "dev"
-debug = "line-tables-only" # see Cargo.toml — must match
-incremental = false        # see Cargo.toml — must match
+debug = "line-tables-only" # Enough for backtraces, keeps compile fast
+incremental = true         # Enables sccache, matches dev
+codegen-units = 256        # Fast parallel compilation
 
 [profile.ci-debug.package."*"]
-opt-level = 3 # see Cargo.toml — must match
+opt-level = 3
 
-# Must match workspace Cargo.toml [profile.ci] — see fingerprint warning above.
+# CI: Branch builds (main pushes). Slightly more optimized but still fast.
+# Must match workspace Cargo.toml
 [profile.ci]
 inherits = "release"
-debug = "line-tables-only" # see Cargo.toml — must match
-lto = false                # see Cargo.toml — must match
-codegen-units = 16         # see Cargo.toml — must match
-debug-assertions = true    # see Cargo.toml — must match
-overflow-checks = true     # see Cargo.toml — must match
+debug = "line-tables-only"
+lto = false                # LTO kills compile time, not needed for tests
+incremental = true         # Enables sccache
+codegen-units = 256        # Fast parallel compilation
+opt-level = 2              # Good optimization, faster compile than 3
+debug-assertions = true    # Catch bugs in CI
+overflow-checks = true     # Catch arithmetic bugs
 strip = "none"
+
+# Test-release: Full optimizations plus assertions for catching release-only bugs.
+# Must match workspace Cargo.toml
+[profile.test-release]
+inherits = "release"
+debug = true            # Full debug info for accurate backtraces
+debug-assertions = true # Keep assertions enabled (critical for bug catching)
+overflow-checks = true  # Keep overflow checks
+lto = false             # LTO too slow for CI, optimizations not needed for tests
+codegen-units = 256     # Fast compilation
+incremental = true      # Enable sccache
+strip = "none"          # Keep symbols
+


### PR DESCRIPTION
- Use Docker cache mounts for cargo registry and build artifacts
- Enable incremental builds in CI profiles for sccache compatibility
- Pre-build dependencies in the build image for all CI profiles
- Include pre-built dependencies in the build image
- Remove unnecessary COPY from Dockerfile
- Simplify build container by running as root
- Inline cargo-config.toml contents directly into Cargo.toml
- Update registry configuration in build image