### PR TITLE
security audit gemini

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ dependencies = [
  "fastrand",
  "futures",
  "getrandom 0.4.2",
+ "http",
  "itertools",
  "mauricebarnum-oxia-common",
  "nix",

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,27 +1,30 @@
 # Security Audit Report
 
 ## Executive Summary
+
 The security audit of the `oxia-rust` and vendored `oxia` Go codebase identified **5 prioritized findings** ranging from Medium to Informational severity. The overall risk is assessed as **Moderate**, primarily due to potential authentication bypass vectors in the Go server and dependency vulnerabilities. The Rust client is generally robust but exhibits patterns of over-reliance on panics (`unwrap`/`expect`) in background tasks which could impact availability.
 
-| Severity | Count |
-| :--- | :--- |
-| Critical | 0 |
-| High | 0 |
-| Medium | 2 |
-| Low | 2 |
-| Informational | 1 |
+| Severity      | Count |
+| :------------ | :---- |
+| Critical      | 0     |
+| High          | 0     |
+| Medium        | 2     |
+| Low           | 2     |
+| Informational | 1     |
 
 ---
 
 ## Dependency Scan Output
 
 ### Rust (`cargo audit`)
+
 ```text
     Scanning Cargo.lock for vulnerabilities (243 crate dependencies)
     Success: No vulnerabilities found
 ```
 
 ### Go (`govulncheck`)
+
 ```text
 Vulnerability #1: GO-2026-4918
     Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in
@@ -37,6 +40,7 @@ Vulnerability #1: GO-2026-4918
 ## Findings
 
 ### [MEDIUM] Authentication Bypass via Authority Spoofing
+
 - **File:** `ext/oxia/oxiad/dataserver/public_rpc_server.go:92-101`
 - **Category:** Broken Access Control
 - **Description:** The `validateAuthority` method relies on the `:authority` pseudo-header (retrieved via `oxiadcommonrpc.GetAuthority`) to authorize requests. This header can often be manipulated by clients or improperly handled by transparent proxies/load balancers, potentially allowing a client to bypass authority-based restrictions if they can match an entry in the `assignmentDispatcher`'s authority list.
@@ -44,6 +48,7 @@ Vulnerability #1: GO-2026-4918
 - **Remediation:** Do not rely solely on the `:authority` header for security decisions. Use mutual TLS (mTLS) with client certificate verification and OIDC tokens for all sensitive operations.
 
 ### [MEDIUM] Denial of Service via HTTP/2 Infinite Loop (Dependency)
+
 - **File:** `ext/oxia/cmd/go.mod`
 - **Category:** Dependency Vulnerability
 - **Description:** The project depends on `golang.org/x/net@v0.48.0`, which is vulnerable to `GO-2026-4918`. A malicious peer can trigger an infinite loop in the HTTP/2 transport by sending a malformed `SETTINGS_MAX_FRAME_SIZE` frame.
@@ -51,6 +56,7 @@ Vulnerability #1: GO-2026-4918
 - **Remediation:** Update `golang.org/x/net` to `v0.53.0` or later.
 
 ### [LOW] Availability Risk: Panic in Heartbeat Background Task
+
 - **File:** `client/src/shard.rs:483-484`
 - **Category:** Panics in production paths
 - **Description:** The `start_heartbeat` task uses `getrandom::fill(&mut seed).unwrap()`. If the system entropy source is temporarily unavailable or restricted (e.g., in a heavily restricted container or during system exhaustion), the background heartbeat task will panic, leading to session loss and potential client instability.
@@ -58,13 +64,16 @@ Vulnerability #1: GO-2026-4918
 - **Remediation:** Replace `unwrap()` with proper error handling that retries or logs a warning before gracefully degrading.
 
 ### [LOW] Insecure URL Construction for gRPC Clients
+
 - **File:** `client/src/lib.rs:658-669`
 - **Category:** Input Validation
 - **Description:** The client constructs gRPC connection URLs by directly concatenating `"http://"` with a `dest` string received from the shard assignment map. There is no validation or sanitization of the `dest` string before it is passed to the gRPC connector.
 - **Exploit scenario:** If the Oxia coordinator is compromised or a "Man-in-the-Middle" attacker can inject a malicious shard assignment, they could provide a `dest` string like `user:pass@malicious-host:6648`, potentially leading to credential leakage or connection to unauthorized endpoints.
 - **Remediation:** Validate that the `dest` string matches an expected host:port format and does not contain unexpected URI components (like userinfo or path fragments).
+- **FIXED**
 
 ### [INFORMATIONAL] Use of Non-Cryptographic Randomness for Logic
+
 - **File:** `ext/oxia/oxiad/coordinator/selector/leader/lowerest_leaders_selector.go`
 - **Category:** Insecure use of math/rand
 - **Description:** The coordinator uses `math/rand` for leader selection and other distribution logic. While not directly a security vulnerability if used only for load balancing, it makes the system's behavior predictable.
@@ -74,6 +83,7 @@ Vulnerability #1: GO-2026-4918
 ---
 
 ## Attack Surface Map
+
 - **Public gRPC API (`public_rpc_server.go`)**: Primary entry point for clients. Trust boundary for keys, values, and session management.
 - **Internal Coordination API (`internal_rpc_server.go`)**: Used for server-to-server communication (replication, heartbeats). Critical boundary for cluster integrity.
 - **CLI Arguments (`cmd/src/main.rs`)**: Trust boundary for configuration (service addresses, timeouts).
@@ -82,9 +92,11 @@ Vulnerability #1: GO-2026-4918
 ---
 
 ## Notes & Assumptions
+
 - **Vendored Code**: The audit included `ext/oxia/` as it is a critical part of the system's runtime behavior, even though it is technically a dependency.
 - **Unsafe Code**: Suspect `unsafe` blocks in examples (`a.rs`, `e.rs`) were excluded as they are not part of the core library production path.
 - **FFI**: No significant FFI boundaries were identified between Rust and Go; they communicate via gRPC (IPC).
 
 ---
-*Audit completed on May 12, 2026.*
+
+_Audit completed on May 12, 2026._

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -62,6 +62,7 @@ Vulnerability #1: GO-2026-4918
 - **Description:** The `start_heartbeat` task uses `getrandom::fill(&mut seed).unwrap()`. If the system entropy source is temporarily unavailable or restricted (e.g., in a heavily restricted container or during system exhaustion), the background heartbeat task will panic, leading to session loss and potential client instability.
 - **Exploit scenario:** Under extreme system resource exhaustion, the heartbeat thread panics, causing the client to lose its Oxia session and abort all ephemeral keys.
 - **Remediation:** Replace `unwrap()` with proper error handling that retries or logs a warning before gracefully degrading.
+- **FIXED**
 
 ### [LOW] Insecure URL Construction for gRPC Clients
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 mauricebarnum-oxia-common = { path = "../common" }
+http = "1"
 tokio = { version = "1.52.3", features = ["sync", "rt", "time"] }
 tokio-stream = "0.1.18"
 tonic = { version = "0.14.6", features = ["gzip", "channel", "zstd"] }

--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -242,6 +242,18 @@ pub enum ClientError {
 
     #[error("Unsupported key comparison {0}")]
     UnsupportedKeyComparator(KeyComparisonType),
+
+    #[error("Invalid destination format '{dest}': {reason}")]
+    InvalidDestinationFormat { dest: String, reason: String },
+
+    #[error("Destination must not contain userinfo")]
+    DestinationContainsUserinfo,
+
+    #[error("Destination must have an authority (host:port)")]
+    DestinationMissingAuthority,
+
+    #[error("Destination contains unexpected URI component: {component}")]
+    DestinationContainsUnexpectedComponent { component: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -655,10 +655,55 @@ impl LeaderHint {
 
 type GrpcClient = oxia_proto::OxiaClientClient<Channel>;
 
+fn validate_dest(dest: &str) -> Result<()> {
+    if dest.contains('#') {
+        let e = ClientError::DestinationContainsUnexpectedComponent {
+            component: "fragment".to_string(),
+        };
+        return Err(e.into());
+    }
+    // To properly validate, we need a scheme.
+    let url = format!("http://{dest}");
+    let uri = url
+        .parse::<http::Uri>()
+        .map_err(|e| ClientError::InvalidDestinationFormat {
+            dest: dest.to_string(),
+            reason: e.to_string(),
+        })?;
+
+    if let Some(auth) = uri.authority() {
+        if auth.as_str().contains('@') {
+            let e = ClientError::DestinationContainsUserinfo {};
+            return Err(e.into());
+        }
+    } else {
+        let e = ClientError::DestinationMissingAuthority {};
+        return Err(e.into());
+    }
+
+    if uri.path() != "" && uri.path() != "/" {
+        let e = ClientError::DestinationContainsUnexpectedComponent {
+            component: format!("path: '{}'", uri.path()),
+        };
+        return Err(e.into());
+    }
+
+    if uri.query().is_some() {
+        return Err(Error::Client(Arc::new(
+            ClientError::DestinationContainsUnexpectedComponent {
+                component: "query string".to_string(),
+            },
+        )));
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn create_grpc_client(
     dest: &str,
     channel_pool: &ChannelPool,
 ) -> Result<GrpcClient> {
+    validate_dest(dest)?;
     let url = {
         // TODO: http v https
         const SCHEME: &str = "http://";
@@ -1370,5 +1415,69 @@ impl Client {
             Arc::clone(&shard_manager),
             options,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_dest() {
+        assert!(validate_dest("localhost:6648").is_ok());
+        assert!(validate_dest("127.0.0.1:6648").is_ok());
+        assert!(validate_dest("[::1]:6648").is_ok());
+
+        // userinfo
+        let r = validate_dest("user:pass@localhost:6648");
+        assert!(matches!(
+            r,
+            Err(Error::Client(e)) if matches!(*e, ClientError::DestinationContainsUserinfo)
+        ));
+
+        let r = validate_dest("user@localhost:6648");
+        assert!(matches!(
+            r,
+            Err(Error::Client(e)) if matches!(*e, ClientError::DestinationContainsUserinfo)
+        ));
+
+        // path
+        let r = validate_dest("localhost:6648/path");
+        if let Err(Error::Client(e)) = r {
+            if let ClientError::DestinationContainsUnexpectedComponent { component } = e.as_ref() {
+                assert!(component.contains("path"));
+            } else {
+                panic!("Expected DestinationContainsUnexpectedComponent, got {e:?}");
+            }
+        } else {
+            panic!("Expected Error::Client, got {r:?}");
+        }
+
+        assert!(validate_dest("localhost:6648/").is_ok());
+
+        // query
+        let r = validate_dest("localhost:6648?query=1");
+        if let Err(Error::Client(e)) = r {
+            if let ClientError::DestinationContainsUnexpectedComponent { component } = e.as_ref() {
+                assert!(component.contains("query"));
+            } else {
+                panic!("Expected DestinationContainsUnexpectedComponent, got {e:?}");
+            }
+        } else {
+            panic!("Expected Error::Client, got {r:?}");
+        }
+
+        // Invalid formats
+        assert!(validate_dest(" ").is_err());
+        let r = validate_dest("localhost:6648#frag");
+        if let Err(Error::Client(e)) = r {
+            if let ClientError::DestinationContainsUnexpectedComponent { component } = e.as_ref() {
+                assert!(component.contains("fragment"));
+            } else {
+                panic!("Expected DestinationContainsUnexpectedComponent, got {e:?}");
+            }
+        } else {
+            panic!("Expected Error::Client, got {r:?}");
+        }
     }
 }

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -38,6 +38,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::Streaming;
 use tonic::metadata::MetadataValue;
 use tracing::debug;
+use tracing::error;
 use tracing::info;
 use tracing::trace;
 use tracing::warn;
@@ -479,11 +480,22 @@ impl Client {
 
         let client = self.clone();
 
-        let mut seed = [0u8; 32];
-        getrandom::fill(&mut seed).unwrap();
-        let mut rng = StdRng::from_seed(seed);
-
         tokio::spawn(async move {
+            let mut seed = [0u8; 32];
+            loop {
+                match getrandom::fill(&mut seed) {
+                    Ok(()) => break,
+                    Err(e) => {
+                        // If getrandom fails, we can't get a secure seed for jitter.
+                        // Stalling here (retrying) is safer than falling back to a predictable
+                        // seed which could allow an attacker to synchronize heartbeats.
+                        error!(?e, "getrandom failed in heartbeat task; retrying in 10s");
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                    }
+                }
+            }
+            let mut rng = StdRng::from_seed(seed);
+
             // We'll send heartbeats a random time +/- X% of one quarter of session timeout.
             // This will allow us to miss a few heartbeats without losing the session
             let distr = {
@@ -493,7 +505,12 @@ impl Client {
                 let min_ms = (target_ms * (1.0 - JITTER)).round() as u32;
                 #[allow(clippy::cast_sign_loss)]
                 let max_ms = (target_ms * (1.0 + JITTER)).round() as u32;
-                Uniform::new_inclusive(min_ms, max_ms).unwrap()
+                // If min_ms > max_ms (e.g. session_timeout is 0), fallback to a small fixed value
+                if min_ms <= max_ms {
+                    Uniform::new_inclusive(min_ms, max_ms).unwrap()
+                } else {
+                    Uniform::new_inclusive(10, 100).unwrap()
+                }
             };
             loop {
                 tokio::select! {


### PR DESCRIPTION
- validate gRPC url format
- avoid heartbeat panic on entropy exhaustion

both of these changes were suggested by a Gemini created security audit.  the proposed fixes where then tweaked into the final form.  for the url validation Gemini was going to use Error::Custom rather than enhance ClientError.  for the heartbeat panic, the initial idea was to fall back to a different seed rather than wait for entropy.
