### PR TITLE
claude fix audit findings

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -699,6 +699,11 @@ fn validate_dest(dest: &str) -> Result<()> {
     Ok(())
 }
 
+/// Maximum size for a single incoming gRPC response message.
+/// Protects against OOM from oversized server responses (the Go server
+/// allows up to 256 MB per frame).
+pub(crate) const MAX_GRPC_DECODING_SIZE: usize = 64 * 1024 * 1024;
+
 pub(crate) async fn create_grpc_client(
     dest: &str,
     channel_pool: &ChannelPool,
@@ -713,7 +718,7 @@ pub(crate) async fn create_grpc_client(
         url
     };
     let channel = channel_pool.get(&url).await?;
-    Ok(GrpcClient::new(channel))
+    Ok(GrpcClient::new(channel).max_decoding_message_size(MAX_GRPC_DECODING_SIZE))
 }
 
 const fn extract_leader_hint(e: &Error) -> Option<&LeaderHint> {

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -826,7 +826,9 @@ impl Client {
             )));
         }
 
-        get_response_as_result(rsp.gets.into_iter().next().unwrap())
+        get_response_as_result(rsp.gets.into_iter().next().ok_or_else(|| {
+            Error::Custom("expected one GetResponse in read response but got none".to_string())
+        })?)
     }
 
     async fn demux_stream(
@@ -972,7 +974,9 @@ impl Client {
             return Err(e);
         }
 
-        let p = rsp.puts.into_iter().next().unwrap();
+        let p = rsp.puts.into_iter().next().ok_or_else(|| {
+            Error::Custom("expected one PutResponse in write response but got none".to_string())
+        })?;
         Ok(PutResponse::from_proto(p))
     }
 

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -348,7 +348,7 @@ impl Client {
             .get_leader()
             .ok_or_else(|| Error::NoShardMapping(self.data.shard_id))?;
         let channel = self.data.channel_pool.get(&leader).await?;
-        Ok(GrpcClient::new(channel))
+        Ok(GrpcClient::new(channel).max_decoding_message_size(crate::MAX_GRPC_DECODING_SIZE))
     }
 
     /// Invalidate the cached channel for the current leader.


### PR DESCRIPTION
- **fix: replace unwrap() on response iterators with proper error propagation**
- **fix: set max_decoding_message_size on gRPC client to prevent OOM from oversized responses**
