### PR TITLE
clippy: suppress new warnings

### DIFF
--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -185,6 +185,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     #[cfg_attr(miri, ignore)]
+    #[allow(clippy::items_after_statements)]
     async fn test_with_retry() -> Result<()> {
         const RETRIES: usize = 3;
         const EXPECTED: usize = RETRIES + 2;

--- a/client/tests/cancellation_tests.rs
+++ b/client/tests/cancellation_tests.rs
@@ -220,6 +220,7 @@ async fn test_concurrent_ops_during_shutdown() -> anyhow::Result<()> {
 
 /// Test that dropping a notifications stream completes without hanging.
 #[test_log::test(tokio::test)]
+#[allow(clippy::items_after_statements)]
 async fn test_notifications_stream_drop_completes() -> anyhow::Result<()> {
     use futures::StreamExt;
 


### PR DESCRIPTION
these popped up with rust 1.96.0 and seem incorrect:

    Checking mauricebarnum-oxia-cmd v0.1.0 (/Users/pixi/src/mauricebarnum/oxia-rust/update-deps/cmd)
warning: adding items after statements is confusing, since items exist from the start of the scope
   --> client/src/util.rs:189:9
    |
189 |         const RETRIES: usize = 3;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#items_after_statements
    = note: `-D clippy::items-after-statements` implied by `-D clippy::pedantic`
    = help: to override `-D clippy::pedantic` add `#[allow(clippy::items_after_statements)]`

warning: adding items after statements is confusing, since items exist from the start of the scope
   --> client/src/util.rs:190:9
    |
190 |         const EXPECTED: usize = RETRIES + 2;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#items_after_statements

warning: `mauricebarnum-oxia-client` (lib test) generated 2 warnings
    Finished `dev` profile [optimized + debuginfo] target(s) in 6.03s

warning: adding items after statements is confusing, since items exist from the start of the scope
   --> client/tests/cancellation_tests.rs:224:5
    |
224 |     use futures::StreamExt;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#items_after_statements
    = note: `-D clippy::items-after-statements` implied by `-D clippy::pedantic`
    = help: to override `-D clippy::pedantic` add `#[allow(clippy::items_after_statements)]`
