### PR TITLE
codex otel instrumentation

### DIFF
--- a/.agent/rules/project_memory.md
+++ b/.agent/rules/project_memory.md
@@ -1,0 +1,85 @@
+# Oxia Rust Client - Project Memory
+
+This document serves as the project memory for agent collaboration on the experimental Rust Oxia client repository. It consolidates information from the project README, agent instructions, security audit, and local agent session history.
+
+## Project Overview & Current State
+- **Purpose**: An experimental, incomplete Rust client implementation for [Oxia](https://github.com/oxia-db/oxia) to explore Rust and the Oxia ecosystem.
+- **Crates Status**: Private, unpublished crates (`mauricebarnum-oxia-common`, `mauricebarnum-oxia-client`, `mauricebarnum-oxia-cmd`).
+- **Code Maturity**: In development, subject to rapid change, minimal testing.
+- **Git Workflow Constraints**:
+  - ALWAYS prefix branches with `claude-` (e.g., `claude-feature`). Checkout a branch before editing: `git checkout -b claude-task-name`. Never commit or push directly to `main` or `origin/main`.
+  - For isolation, test changes in `./claude-temp/` and propose diffs using `/diff` before writing to main files.
+  - Stash changes using `git stash push -m "pre-claude"` at the start of a session and `git stash push` during development. Do not commit or push without explicit confirmation.
+  - Annotate all commits created with AI assistance (e.g., including a line `Created with assistance from <AssistantName>` in the commit message body).
+  - NEVER modify `./ext/oxia/` as it contains the upstream Go Oxia server mirror.
+
+## Architecture Layout & Crate Structure
+The repository is structured as a Cargo workspace containing the following crates:
+
+1. **`common` (`mauricebarnum-oxia-common`)**:
+   - Low-level gRPC client bindings generated using the `tonic` and `prost` build framework (`tonic-prost-build`).
+   - Protobuf files are automatically read from the vendored Go server at `./ext/oxia/common/proto/client.proto`. Manual editing of protobufs or generated bindings is strictly forbidden.
+2. **`client` (`mauricebarnum-oxia-client`)**:
+   - Higher-level, ergonomic async client API wrapper.
+   - Handles sharding, dispatch logic, and connection pooling while minimizing exposure of internal `tonic` structures or the async runtime.
+   - Implements a concrete type `Client` rather than a trait interface (zero-cost abstraction) with generic `x` and `x_with_options` APIs.
+3. **`cmd` (`mauricebarnum-oxia-cmd`)**:
+   - The CLI client utility `oxia-cmd`.
+   - Supports: `get`, `put`, `delete`, `list` (keys), `range` (scan/delete), and `notifications` commands.
+4. **`oxia-bin-util`**:
+   - Build utility that compiles the vendored Go Oxia server source code to provide a test server binary located at `target/oxia/oxia`.
+
+### Core Architectural Patterns
+- **Concurrency & State Cache**:
+  - The hot path is lock-free. Use `ArcSwap::load` to retrieve active shard configuration and client connections.
+  - Use `RwLock::read` on the pool only for connection cache misses.
+  - General Rule: `ArcSwap` > `RwLock`. Use `tokio::sync` primitives. Do not hold locks across `.await` points.
+- **Async Interfaces**:
+  - Use `BoxFuture` desugaring for async traits (see `notification.rs`, `address.rs`) instead of the `async-trait` crate.
+- **Coding Style**:
+  - Strict linting is enforced via workspace Cargo.toml settings (pedantic, nursery, `clone_on_ref_ptr` warnings).
+  - Unmerged `use` statements (one import per line) are preferred. No merged imports like `use std::{foo, bar};`.
+  - When exposing new types in a public module, update `allowed_external_types` in `client/Cargo.toml`.
+
+## Security Model & Trust Boundaries
+A recent security audit identified key attack surfaces and vulnerability vectors:
+- **Public gRPC API (`public_rpc_server.go`)**: Primary trust boundary for client requests, keys, values, and session management.
+- **Internal Coordination API (`internal_rpc_server.go`)**: Critical boundary for replication, cluster health, and heartbeats.
+- **CLI Arguments (`cmd/src/main.rs`)**: Trust boundary for configuration addresses and timeout parameters.
+- **Service Discovery (`discovery.rs`)**: Boundary for processing untrusted network/node metadata received from the coordinator.
+
+### Security Vulnerabilities & Remediation Status
+1. **[MEDIUM] Authentication Bypass via Authority Spoofing** (`ext/oxia/oxiad/dataserver/public_rpc_server.go`):
+   - *Risk*: `validateAuthority` uses `:authority` header which is easily spoofed.
+   - *Remediation*: Require mTLS client verification or OIDC tokens for sensitive APIs.
+2. **[MEDIUM] Denial of Service via HTTP/2 Infinite Loop** (`ext/oxia/cmd/go.mod`):
+   - *Risk*: Dependency on `golang.org/x/net@v0.48.0` is vulnerable to `GO-2026-4918`.
+   - *Remediation*: Upgrade `golang.org/x/net` to `v0.53.0` or later.
+3. **[LOW] Panic in Heartbeat Background Task** (`client/src/shard.rs`):
+   - *Risk*: `getrandom::fill(&mut seed).unwrap()` panicking under entropy exhaustion.
+   - *Status*: **FIXED**. Proper error handling and fallback/retry logic implemented.
+4. **[LOW] Insecure URL Construction for gRPC Clients** (`client/src/lib.rs`):
+   - *Risk*: Directly concatenating `"http://"` with dynamic discovery address.
+   - *Status*: **FIXED**. Dest URL validation implemented.
+5. **[INFORMATIONAL] Non-Cryptographic Randomness for Coordinator Logic**:
+   - *Risk*: Coordinator uses predictable `math/rand` for leader selection and load balancing.
+
+## Outstanding Technical Constraints & Lessons Learned
+Based on workspace configurations and local agent memory:
+- **Oxia Cluster Readiness**:
+  - The `oxia-readiness` gRPC health service transitions to `SERVING` as soon as it receives its *first* shard assignment. However, leader election may still be ongoing.
+  - **Constraint**: A sleep of ~2s must be added after health probes settle before launching tests to ensure elections are completed.
+- **Process Management**:
+  - Always call `.wait()` on child processes after killing them (`child.kill().await`) to clean up zombie processes and release ports.
+- **Nextest Filtering**:
+  - Filter by test name using `test(foo::)`.
+  - Filter by test file/binary using `binary(foo)`.
+- **Clippy Type Cascades**:
+  - Changing return types (e.g., `io::Result<()>` to `()`) can cascade to callers, especially concerning drop implementations. Watch out for `let _ =` patterns in drop implementations.
+- **Shell Command Limitations**:
+  - Fish shell does not support bash-style heredocs `$(cat <<'EOF')`. When committing or writing files, use `printf '...' > file && git commit -F file` instead.
+- **Future Crates & CLI Enhancements (TODOs)**:
+  - Add client robustness for transient errors: do not fail assignment processing on shard connection failure; implement reconnection logic.
+  - Implement pretty formatting (JSON, raw, tabular) for `oxia-cmd`.
+  - Add `shell` command with tab completion, as well as `create`/`stop`/`list` control commands.
+  - Support secondary index write in the `put` command.

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -127,7 +127,7 @@ jobs:
           cargo fetch --locked   # fetch dependencies: last network dependency
 
       - name: build
-        run: cargo build $RELEASE_FLAG --frozen --all-targets
+        run: cargo build $RELEASE_FLAG --frozen --all-targets --features mauricebarnum-oxia-client/metrics
 
       - name: clippy
         run: cargo clippy $RELEASE_FLAG --no-deps --all-targets --frozen -- -D warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md – Project Guidance for AI Coding Assistants
+
+This guide outlines rules, architecture, testing frameworks, and style constraints for AI coding assistants working in this experimental Rust Oxia client repository. Follow strictly for safe and efficient collaboration.
+
+## Safety & Workflow Rules
+
+- **Branches**: ALWAYS work on a dedicated task branch. Check out a new branch before making edits: `git checkout -b <prefix>-<task-name>`. Never modify or push directly to `main` or `origin/main`.
+- **Isolation**: For major changes, draft code in a temporary directory (e.g., `./agent-temp/` or similar) first, review diffs, and confirm before writing to main repository files.
+- **Git Safety**: Stash changes when appropriate to avoid conflicts. No raw commits or pushes without checking compatibility and verifying changes. Do not run destructive git operations.
+- **Commit Annotations**: All commits created with assistance from an AI agent must include an annotation in the commit message body indicating AI assistance (e.g., `Created with assistance from <AssistantName>`).
+- **Read-Only Paths**: NEVER modify `./ext/oxia/` (vendored Oxia mirror).
+- **Work in Progress**: Always consider unmerged commits on the current branch. Run `git status` or check diffs relative to upstream tracking branches at the start of a session.
+
+## Project Overview
+
+Experimental Rust Oxia client with sharding, gRPC support, and notifications. 
+- Workspace crates: `common` (bindings), `client` (async API), `cmd` (CLI `oxia-cmd`), `oxia-bin-util` (server binary compiler).
+
+## Build & Test Commands
+
+| Task      | Command                                                    | Notes                       |
+| --------- | ---------------------------------------------------------- | --------------------------- |
+| Build     | `cargo build --all-targets`                                | All targets                 |
+| Tests     | `cargo nextest run`                                        | Full; or `--package client` |
+| Unit only | `cargo nextest run -E 'kind(lib)'`                         | Sandbox-safe; no sockets    |
+| ExtSyms   | `cargo nextest run -E 'binary(extsyms)'`                   | Public API types allowlist  |
+| Lint      | `cargo clippy --all-targets --all-features -- -D warnings` | Strict                      |
+| Format    | `cargo +nightly fmt --all` / `--check`                     | -                           |
+| Security  | `cargo deny check`                                         | Licenses                    |
+| Miri      | `+nightly cargo miri nextest run --package client`         | UB detection                |
+
+CI uses `--release --frozen`. Local commands can omit those flags.
+
+## Workspace Structure
+
+- `common`: gRPC protobuf bindings (`tonic-prost-build`).
+- `client`: Async client with sharding and dispatch.
+- `cmd`: CLI utility (`oxia-cmd`) implementing `get`, `put`, `delete`, `list`, `range`, `notifications`, and `shell`.
+- `oxia-bin-util`: Builds vendored Go Oxia server for testing. Output binary is at `target/oxia/oxia` after build.
+
+## Key Architecture
+
+- **API**: `Client` is a concrete struct, not a trait object, with `put(key, value)` and `put_with_options(...)`. Uses zero-cost abstractions.
+- **Sharding**: XXHASH3 routing; dynamic via `shard.rs`.
+- **Pooling**: `pool.rs` per-shard gRPC; `ArcSwap` caches.
+- **Notifications**: Streaming key changes.
+- **Protos**: Automatically generated from `./ext/oxia/common/proto`. No manual edits are allowed to generated files or protos.
+- **Tests**: Spawn local servers via `client/tests/common.rs`.
+
+## Security & Trust Boundaries
+
+- **Public gRPC API**: Primary entry point for clients (`public_rpc_server.go`). Trust boundary for keys, values, and session management.
+- **Internal Coordination API**: Server-to-server communication (`internal_rpc_server.go`). Critical for cluster integrity (replication, heartbeats).
+- **CLI Arguments**: Entry point for user-supplied configuration (`cmd/src/main.rs`). Boundary for service addresses and timeouts.
+- **Service Discovery**: The client receives node lists from the coordinator (`discovery.rs`). Boundary for potentially untrusted network metadata.
+- **CI/CD Workflows**: Reusable workflows (`rust-build.yml`). Trust boundary for input-driven command execution.
+
+## Concurrency & Synchronization (Hot Path: Lock-free)
+
+1. `ArcSwap::load` to look up active shards/clients.
+2. `RwLock::read` pool (only on misses).
+Guidelines: `ArcSwap` preferred over `RwLock`. Use `tokio::sync` primitives. Do not hold locks across `.await` points.
+
+- **Async Traits**: Use `BoxFuture` desugaring (see `notification.rs`, `address.rs`), not the `async-trait` crate.
+
+## Coding Style
+
+- **Clippy**: Strict workspace Cargo.toml settings must be followed.
+- **Imports**: Prefer unmerged `use` statements (one item per line). Do not merge imports (e.g. avoid `use std::{foo, bar};`).
+- **Docs**: Terse, idiomatic Rust API guidelines; prefer `const fn` when possible.
+- **GitHub**: Submit changes via Draft PRs; push with `--force-with-lease`; always verify clippy and tests locally before pushing. Ignore local `main`.
+
+## Dependencies
+
+- Include minimal features when adding or managing dependencies.
+- Do not add dependencies rejected by `cargo deny`.
+- When making a module `pub`, update `allowed_external_types` in `client/Cargo.toml` for any newly exposed external types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,21 +13,21 @@ This guide outlines rules, architecture, testing frameworks, and style constrain
 
 ## Project Overview
 
-Experimental Rust Oxia client with sharding, gRPC support, and notifications. 
+Experimental Rust Oxia client with sharding, gRPC support, and notifications.
+
 - Workspace crates: `common` (bindings), `client` (async API), `cmd` (CLI `oxia-cmd`), `oxia-bin-util` (server binary compiler).
 
 ## Build & Test Commands
 
-| Task      | Command                                                    | Notes                       |
-| --------- | ---------------------------------------------------------- | --------------------------- |
-| Build     | `cargo build --all-targets`                                | All targets                 |
-| Tests     | `cargo nextest run`                                        | Full; or `--package client` |
-| Unit only | `cargo nextest run -E 'kind(lib)'`                         | Sandbox-safe; no sockets    |
-| ExtSyms   | `cargo nextest run -E 'binary(extsyms)'`                   | Public API types allowlist  |
-| Lint      | `cargo clippy --all-targets --all-features -- -D warnings` | Strict                      |
-| Format    | `cargo +nightly fmt --all` / `--check`                     | -                           |
-| Security  | `cargo deny check`                                         | Licenses                    |
-| Miri      | `+nightly cargo miri nextest run --package client`         | UB detection                |
+| Task      | Command                                            | Notes                       |
+| --------- | -------------------------------------------------- | --------------------------- |
+| Build     | `cargo build --all-targets`                        | All targets                 |
+| Tests     | `cargo nextest run`                                | Full; or `--package client` |
+| Unit only | `cargo nextest run -E 'kind(lib)'`                 | Sandbox-safe; no sockets    |
+| Lint      | `just lint`                                        | Strict                      |
+| Format    | `just fmt`                                         | -                           |
+| Security  | `cargo deny check`                                 | Licenses                    |
+| Miri      | `cargo +nightly miri nextest run --package client` | UB detection                |
 
 CI uses `--release --frozen`. Local commands can omit those flags.
 
@@ -59,7 +59,7 @@ CI uses `--release --frozen`. Local commands can omit those flags.
 
 1. `ArcSwap::load` to look up active shards/clients.
 2. `RwLock::read` pool (only on misses).
-Guidelines: `ArcSwap` preferred over `RwLock`. Use `tokio::sync` primitives. Do not hold locks across `.await` points.
+   Guidelines: `ArcSwap` preferred over `RwLock`. Use `tokio::sync` primitives. Do not hold locks across `.await` points.
 
 - **Async Traits**: Use `BoxFuture` desugaring (see `notification.rs`, `address.rs`), not the `async-trait` crate.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,83 +1,23 @@
-# CLAUDE.md – Project Guidance for Claude Code
+# CLAUDE.md
 
-This CLAUDE.md guides Claude Code (`claude`) for this experimental Rust Oxia client repo. Follow strictly for safe, efficient collaboration. TITLE CLAUDE.md [file:43]
+Refer to the root `AGENTS.md` file for all project architectures, testing frameworks, and style constraints.
 
-## Safety & Workflow Rules (New)
+## Claude Code-Specific Safety & Workflow Rules
+- **Branches**: ALWAYS prefix branches with `claude-` (e.g., `git checkout -b claude-task-name`). Never commit or push directly to `main` or `origin/main`.
+- **Isolation**: Write to `./claude-temp/` first (create if needed: `mkdir claude-temp`). Propose diffs with `/diff`; confirm before main files.
+- **Git Safety**: 
+  - Pre-session: `git stash push -m "pre-claude"`
+  - Stash changes during session: `git stash push`
+  - Do not commit or push without using `/confirm` or getting explicit user approval.
+- **Tokens & Performance**: 
+  - Use `/rewind` (Esc Esc) for undos.
+  - Limit tools (`ENABLE_TOOL_SEARCH=auto:5%`).
+  - Summarize with `/compact`.
+  - Monitor `/cost`.
+- **Efficiency Prompts**:
+  - "Plan in `./claude-temp/`; diff before apply."
+  - "Verify with tests; /cost check."
 
-- **Branches**: ALWAYS prefix `claude-` (e.g., `claude-feature`). Check out new feature branch before edits: `git checkout -b claude-task-name`. Never touch `main`/`origin/main`. [file:43]
-- **Isolation**: Write to `./claude-temp/` first (create if needed: `mkdir claude-temp`). Propose diffs with `/diff`; confirm before main files. Read via `@file.rs` on-demand. [web:35]
-- **Git Safety**: Pre-session: `git stash push -m "pre-claude"`. Stash changes: `git stash push`. No commits/pushes without `/confirm`. Post: `git stash pop` selectively. Block destructives via hooks. [web:33]
-- **Tokens**: Use `/rewind` (Esc Esc) for undos. Limit tools (`ENABLE_TOOL_SEARCH=auto:5%`). Test incrementally; summarize with `/compact`. Monitor `/cost`. [web:10]
-- **Read-Only**: NEVER modify `./ext/oxia/` (vendored Oxia mirror). [file:43]
-- _Work in progress_: Always consider unmerged commits on the current branch
-  - Run `git log --oneline @{u}..` or `git status` at session start if relevant.
-  - Summarize unmerged changes before major tasks.
-
-## Project Overview
-
-Experimental Rust Oxia client: sharding, gRPC, notifications. Workspace: common (bindings), client (async API), cmd (CLI `oxia-cmd`), oxia-bin-util (server binary). [file:43]
-
-## Build & Test Commands
-
-| Task      | Command                                                    | Notes                       |
-| --------- | ---------------------------------------------------------- | --------------------------- |
-| Build     | `cargo build --all-targets`                                | All targets                 |
-| Tests     | `cargo nextest run`                                        | Full; or `--package client` |
-| Unit only | `cargo nextest run -E 'kind(lib)'`                         | Sandbox-safe; no sockets    |
-| ExtSyms   | `cargo nextest run -E 'binary(extsyms)'`                   | Public API types allowlist  |
-| Lint      | `cargo clippy --all-targets --all-features -- -D warnings` | Strict                      |
-| Format    | `cargo +nightly fmt --all` / `--check`                     | -                           |
-| Security  | `cargo deny check`                                         | Licenses                    |
-| Miri      | `+nightly cargo miri nextest run --package client`         | UB detection [file:43]      |
-
-CI uses `--release --frozen`. Local: omit.
-
-## Workspace Structure
-
-- `common`: gRPC protos (tonic-prost-build).
-- `client`: Async client (sharding, dispatch).
-- `cmd`: `oxia-cmd` CLI (get/put/delete/list/range/notifications/shell).
-- `oxia-bin-util`: Builds vendored Go Oxia server for tests. Binary at `target/oxia/oxia` after build. [file:43]
-
-## Key Architecture
-
-- **API**: `Client` struct; `put(key, value)` + `with_options()`. Zero-cost abstractions.
-- **Sharding**: XXHASH3 routing; dynamic via `shard.rs`.
-- **Pooling**: `pool.rs` per-shard gRPC; `ArcSwap` caches.
-- **Notifications**: Streaming key changes.
-- **Protos**: Auto from `./ext/oxia/common/proto`. No manual edits.
-- **Tests**: Spawn servers via `client/tests/common.rs`. [file:43]
-
-## Security & Trust Boundaries
-
-- **Public gRPC API**: Primary entry point for clients (`public_rpc_server.go`). Trust boundary for keys, values, and session management.
-- **Internal Coordination API**: Server-to-server communication (`internal_rpc_server.go`). Critical for cluster integrity (replication, heartbeats).
-- **CLI Arguments**: Entry point for user-supplied configuration (`cmd/src/main.rs`). Boundary for service addresses and timeouts.
-- **Service Discovery**: The client receives node lists from the coordinator (`discovery.rs`). Boundary for potentially untrusted network metadata.
-- **CI/CD Workflows**: Reusable workflows (`rust-build.yml`). Trust boundary for input-driven command execution.
-
-**Concurrency** (Hot Path: Lock-free):
-
-1. `ArcSwap::load` shards/clients.
-2. `RwLock::read` pool (misses).
-   Guidelines: ArcSwap > RwLock; tokio-sync; no locks pre-`.await`. [file:43]
-
-- **Async traits**: Use `BoxFuture` desugaring (see `notification.rs`, `address.rs`), not `async-trait` crate.
-
-## Coding Style
-
-- Clippy: Settings are in workspace Cargo.toml
-- **Imports**: Prefer unmerged `use` statements (one item per line). No `use std::{foo, bar};` merging.
-- Docs: Terse; Rust API guidelines; `const fn`.
-- GitHub: Draft PRs; `--force-with-lease`; tests/clippy pre-push. Ignore local `main`. [file:43]
-
-## Efficiency Prompts
-
-- "Plan in `./claude-temp/`; diff before apply."
-- "Verify with tests; /cost check."
-
-## Dependencies
-
-- Include minimal features when adding or managing dependencies
-- Do not add dependencies rejected by `cargo deny`
-- When making a module `pub`, update `allowed_external_types` in `client/Cargo.toml` for any newly exposed external types
+## Claude Code-Specific Overrides
+- When compacting history with `/compact`, always preserve the core task list.
+- Use subagents for complex research instead of inline exploration loops.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -627,6 +627,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -646,10 +657,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -1021,7 +1038,7 @@ dependencies = [
  "oxia-bin-util",
  "prost",
  "prost-types",
- "rand",
+ "rand 0.10.1",
  "socket2",
  "tempfile",
  "test-log",
@@ -1050,6 +1067,8 @@ dependencies = [
  "humantime",
  "mauricebarnum-oxia-client",
  "num_cpus",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
  "rustyline",
  "shlex 2.0.1",
  "thiserror 2.0.18",
@@ -1186,6 +1205,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-stdout"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8a298402aa5c260be90d10dc54b5a7d4e1025c354848f8e2c976d761351049"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.6",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "oxia-bin-util"
 version = "0.1.0"
 dependencies = [
@@ -1256,6 +1318,15 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1382,13 +1453,43 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1503,6 +1604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2364,6 +2466,26 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -488,7 +488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1017,6 +1017,7 @@ dependencies = [
  "itertools",
  "mauricebarnum-oxia-common",
  "nix",
+ "opentelemetry",
  "oxia-bin-util",
  "prost",
  "prost-types",
@@ -1024,7 +1025,7 @@ dependencies = [
  "socket2",
  "tempfile",
  "test-log",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1051,7 +1052,7 @@ dependencies = [
  "num_cpus",
  "rustyline",
  "shlex 2.0.1",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1136,7 +1137,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1169,6 +1170,20 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
 
 [[package]]
 name = "oxia-bin-util"
@@ -1430,7 +1445,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1590,7 +1605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1626,7 +1641,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1663,11 +1678,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2085,7 +2120,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "mauricebarnum-oxia-common",
  "nix",
  "opentelemetry",
+ "opentelemetry_sdk",
  "oxia-bin-util",
  "prost",
  "prost-types",

--- a/Justfile
+++ b/Justfile
@@ -3,8 +3,18 @@ default: build
 build:
     cargo build --all-targets --all-features
 
+build-all:
+    cargo build --all-targets
+    cargo build --all-targets --features metrics
+    cargo build --all-targets --features go-metrics-compat
+
 test:
     cargo nextest run
+
+test-all:
+    cargo nextest run
+    cargo nextest run --features mauricebarnum-oxia-client/metrics
+    cargo nextest run --features mauricebarnum-oxia-client/go-metrics-compat
 
 check:
     cargo check --all-targets --all-features

--- a/Justfile
+++ b/Justfile
@@ -14,4 +14,4 @@ lint: check
     cd client && cargo +nightly-2025-10-18 check-external-types
 
 fmt:
-    cargo fmt --all
+    cargo +nightly fmt --all

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Downsides:
 
 Switching to a trait interface should be doable with minimal changes to both the implementation and the callers. In the "this is an experiment" nature of the current code base, it made more sense to explore the generic decision space ("impl Into<T>"? "impl AsRef<T>"? concrete param? etc.). I'm considering putting in a test that will validate at compile time that the `Client` interface remains close to object safe. I haven't done it yet because I didn't want to deal with the maintenance overhead of the test, but the API is stable enough now that it shouldn't be a problem going forward. Maybe an LLM can generate it for me without making too much of a mess.
 
+## Metrics
+
+The client records semantic latency, size, and request count measurements as OpenTelemetry histogram instruments. Callers that provide their own `MeterProvider` must install SDK views for these instruments to receive `ExponentialHistogram` data points; otherwise the SDK default aggregation may be explicit buckets. The CLI metrics setup in [cmd/src/metrics.rs](cmd/src/metrics.rs) is the canonical example of configuring those views.
+
 # TODO
 
 1. Add robustness for transient errors

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -90,9 +90,9 @@ RUN GH_WORKSPACE="/__w/${REPO_NAME}/${REPO_NAME}" && \
     mkdir -p "${GH_WORKSPACE}" && \
     cp /tmp/recipe.json "${GH_WORKSPACE}/recipe.json" && \
     cd "${GH_WORKSPACE}" && \
-    cargo chef cook --profile ci-debug --all-targets --recipe-path recipe.json && \
-    cargo chef cook --profile ci --all-targets --recipe-path recipe.json && \
-    cargo chef cook --profile ci-test-release --all-targets --recipe-path recipe.json && \
+    cargo chef cook --profile ci-debug --all-targets --features mauricebarnum-oxia-client/metrics --recipe-path recipe.json && \
+    cargo chef cook --profile ci --all-targets --features mauricebarnum-oxia-client/metrics --recipe-path recipe.json && \
+    cargo chef cook --profile ci-test-release --all-targets --features mauricebarnum-oxia-client/metrics --recipe-path recipe.json && \
     cargo fetch --locked && \
     cargo +nightly fetch --locked
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -45,6 +45,10 @@ tempfile = "3.27.0"
 anyhow = "1.0.102"
 itertools = "0.14.0"
 nix = { version = "0.31", default-features = false, features = ["signal"] }
+opentelemetry_sdk = { version = "0.27.0", default-features = false, features = [
+    "metrics",
+    "spec_unstable_metrics_views",
+] }
 
 [[bench]]
 name = "shard_lookup"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,9 +27,12 @@ dashmap = { version = "6", optional = true }
 fastrand = "2.4.1"
 prost = "0.14.3"
 prost-types = "0.14.3"
+opentelemetry = { version = "0.27.0", features = ["metrics"], optional = true }
 
 [features]
 bench-dashmap = ["dep:dashmap"]
+go-metrics-compat = ["metrics"]
+metrics = ["dep:opentelemetry"]
 
 [dev-dependencies]
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros"] }
@@ -65,4 +68,5 @@ allowed_external_types = [
     "futures_core::stream::Stream",
     "bon::builder_state::IsSet",
     "bon::builder_state::IsUnset",
+    "opentelemetry::metrics::meter::MeterProvider",
 ]

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -20,6 +20,9 @@ use bon::Builder;
 use crate::discovery::IntoServiceDiscovery;
 use crate::discovery::ServiceDiscovery;
 
+#[cfg(feature = "metrics")]
+pub type MeterProviderHandle = Arc<dyn opentelemetry::metrics::MeterProvider + Send + Sync>;
+
 #[derive(Clone, Copy, Debug)]
 pub struct RetryConfig {
     pub(crate) attempts: usize,
@@ -38,7 +41,7 @@ impl RetryConfig {
     }
 }
 
-#[derive(Builder, Clone, Debug)]
+#[derive(Builder, Clone)]
 #[builder(finish_fn(name = do_build, vis = ""))]
 #[builder(on(String, into))]
 #[builder(state_mod(vis = "pub"))]
@@ -57,6 +60,8 @@ pub struct Config {
     retry: Option<RetryConfig>,
     #[builder(default = false)]
     retry_on_stale_shard_map: bool,
+    #[cfg(feature = "metrics")]
+    meter_provider: Option<MeterProviderHandle>,
 }
 
 impl Config {
@@ -98,6 +103,30 @@ impl Config {
     #[inline]
     pub const fn retry_on_stale_shard_map(&self) -> bool {
         self.retry_on_stale_shard_map
+    }
+
+    #[cfg(feature = "metrics")]
+    #[inline]
+    pub(crate) fn meter_provider(&self) -> Option<&MeterProviderHandle> {
+        self.meter_provider.as_ref()
+    }
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Config");
+        debug
+            .field("service_discovery", &"<service discovery>")
+            .field("namespace", &self.namespace)
+            .field("identity", &self.identity)
+            .field("session_timeout", &self.session_timeout)
+            .field("max_parallel_requests", &self.max_parallel_requests)
+            .field("request_timeout", &self.request_timeout)
+            .field("retry", &self.retry)
+            .field("retry_on_stale_shard_map", &self.retry_on_stale_shard_map);
+        #[cfg(feature = "metrics")]
+        debug.field("meter_provider", &self.meter_provider.is_some());
+        debug.finish()
     }
 }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -26,6 +26,7 @@ use futures::stream::StreamExt;
 use futures::stream::TryStreamExt;
 use mauricebarnum_oxia_common::proto as oxia_proto;
 use tonic::transport::Channel;
+use tracing::Instrument;
 
 use crate::notification::NotificationsStream;
 use crate::pool::ChannelPool;
@@ -35,6 +36,7 @@ pub mod batch_get;
 pub mod config;
 pub mod discovery;
 pub mod errors;
+mod metrics;
 mod notification;
 mod pool;
 mod shard;
@@ -862,14 +864,20 @@ where
 pub struct Client {
     shard_manager: Option<Arc<shard::Manager>>,
     config: Arc<config::Config>,
+    metrics: metrics::Metrics,
 }
 
 impl Client {
     #[inline]
-    pub const fn new(config: Arc<config::Config>) -> Self {
+    pub fn new(config: Arc<config::Config>) -> Self {
+        #[cfg(feature = "metrics")]
+        let metrics = metrics::Metrics::new(config.meter_provider());
+        #[cfg(not(feature = "metrics"))]
+        let metrics = metrics::Metrics::new(None);
         Self {
             shard_manager: None,
             config,
+            metrics,
         }
     }
 
@@ -884,11 +892,27 @@ impl Client {
     }
 
     pub async fn connect(&mut self) -> Result<()> {
-        if !self.is_connected() {
-            let sm = shard::Manager::new(&self.config).await?;
-            self.shard_manager = Some(Arc::new(sm));
+        let span = tracing::info_span!(
+            target: metrics::SCOPE_NAME,
+            "client.connect",
+            "db.system" = metrics::DB_SYSTEM,
+            "db.name" = self.config.namespace(),
+            "error.type" = tracing::field::Empty,
+        );
+        async {
+            let result = async {
+                if !self.is_connected() {
+                    let sm = shard::Manager::new(&self.config).await?;
+                    self.shard_manager = Some(Arc::new(sm));
+                }
+                Ok(())
+            }
+            .await;
+            metrics::record_error_type(&result);
+            result
         }
-        Ok(())
+        .instrument(span)
+        .await
     }
 
     #[inline]
@@ -970,56 +994,83 @@ impl Client {
         self.get_internal(Arc::from(key.into()), options)
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.get",
+        skip(self, key, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::Get.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn get_internal(
         &self,
         key: Arc<str>,
         options: GetOptions,
     ) -> Result<Option<GetResponse>> {
-        // Define the core operation with retry/timeout wrapper
-        let execute_get = |shard: shard::Client, key: Arc<str>, options: GetOptions| async move {
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
-                let key = Arc::clone(&key);
-                let options = options.clone();
-                async move { shard.get(&key, &options).await }
-            })
-            .await
-        };
+        let start = metrics::operation_start();
+        let result = async {
+            // Define the core operation with retry/timeout wrapper
+            let execute_get =
+                |shard: shard::Client, key: Arc<str>, options: GetOptions| async move {
+                    execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                        let shard = shard.clone();
+                        let key = Arc::clone(&key);
+                        let options = options.clone();
+                        async move { shard.get(&key, &options).await }
+                    })
+                    .await
+                };
 
-        // Single shard case: exact match with partition key OR exact match without secondary index
-        let use_single_shard = options.partition_key.is_some()
-            || (options.comparison_type == KeyComparisonType::Equal
-                && options.secondary_index_name.is_none());
+            // Single shard case: exact match with partition key OR exact match without secondary index
+            let use_single_shard = options.partition_key.is_some()
+                || (options.comparison_type == KeyComparisonType::Equal
+                    && options.secondary_index_name.is_none());
 
-        if use_single_shard {
-            let selector = options.partition_key.as_deref().unwrap_or(&key);
-            let shard = self.get_shard(selector)?;
-            return execute_get(shard, key, options).await;
-        }
+            if use_single_shard {
+                let selector = options.partition_key.as_deref().unwrap_or(&key);
+                let shard = self.get_shard(selector)?;
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                return execute_get(shard, key, options).await;
+            }
 
-        // Multi-shard case: query all shards and select the best response
-        let max_parallel = match self.config.max_parallel_requests() {
-            0 => usize::MAX,
-            n => n,
-        };
+            // Multi-shard case: query all shards and select the best response
+            let max_parallel = match self.config.max_parallel_requests() {
+                0 => usize::MAX,
+                n => n,
+            };
 
-        let best_response = futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
-            .map(|shard| execute_get(shard, Arc::clone(&key), options.clone()))
-            .buffer_unordered(max_parallel)
-            .try_fold(None, |best, response| async {
-                Ok(match response {
-                    Some(candidate) => Some(match best {
-                        None => candidate,
-                        Some(prev) => {
-                            util::select_response(Some(prev), candidate, options.comparison_type)
-                        }
-                    }),
-                    None => best,
+            futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
+                .map(|shard| execute_get(shard, Arc::clone(&key), options.clone()))
+                .buffer_unordered(max_parallel)
+                .try_fold(None, |best, response| async {
+                    Ok(match response {
+                        Some(candidate) => Some(match best {
+                            None => candidate,
+                            Some(prev) => {
+                                util::select_response(Some(prev), candidate, options.comparison_type)
+                            }
+                        }),
+                        None => best,
+                    })
                 })
-            })
-            .await?;
-
-        Ok(best_response)
+                .await
+        }
+        .await;
+        metrics::record_operation_result_with_size(
+            &self.metrics,
+            self.config.namespace(),
+            metrics::Operation::Get,
+            metrics::get_result_kind,
+            metrics::get_response_size,
+            start,
+            &result,
+        );
+        result
     }
 
     /// `batch_get` request multiple keys, minimizing requests to the backend
@@ -1032,55 +1083,74 @@ impl Client {
         &self,
         req: batch_get::Request,
     ) -> Result<impl futures::stream::Stream<Item = batch_get::ResponseItem> + use<>> {
-        use futures::future::Either::Left;
-        use futures::future::Either::Right;
+        let span = tracing::info_span!(
+            target: metrics::SCOPE_NAME,
+            "db.operation.batch_get",
+            "db.system" = metrics::DB_SYSTEM,
+            "db.name" = self.config.namespace(),
+            "db.operation" = metrics::Operation::BatchGet.as_str(),
+            "error.type" = tracing::field::Empty,
+        );
+        let _entered = span.enter();
 
-        let shard_manager = self.get_shard_manager()?;
-        let (batch_get_futures, failures) = batch_get::prepare_requests(req, &shard_manager);
+        metrics::record_operation_sync(
+            &self.metrics,
+            self.config.namespace(),
+            metrics::Operation::BatchGet,
+            metrics::result_kind,
+            || {
+                use futures::future::Either::Left;
+                use futures::future::Either::Right;
 
-        // Send the request to all of the shards in parallel.  This will block until the initial
-        // backend calls return either a stream or an error.  A remote error will be demuxed into
-        // per-key errors, see shard::Client::batch_get()
-        let batch_get_stream = if batch_get_futures.is_empty() {
-            None
-        } else {
-            Some(
-                futures::stream::iter(batch_get_futures)
-                    .buffer_unordered(self.config.max_parallel_requests())
-                    .flatten_unordered(None)
-                    .boxed(),
-            )
-        };
+                let shard_manager = self.get_shard_manager()?;
+                let (batch_get_futures, failures) =
+                    batch_get::prepare_requests(req, &shard_manager);
 
-        let failures_stream = if failures.is_empty() {
-            None
-        } else {
-            Some(futures::stream::iter(failures))
-        };
+                // Send the request to all of the shards in parallel.  This will block until the initial
+                // backend calls return either a stream or an error.  A remote error will be demuxed into
+                // per-key errors, see shard::Client::batch_get()
+                let batch_get_stream = if batch_get_futures.is_empty() {
+                    None
+                } else {
+                    Some(
+                        futures::stream::iter(batch_get_futures)
+                            .buffer_unordered(self.config.max_parallel_requests())
+                            .flatten_unordered(None)
+                            .boxed(),
+                    )
+                };
 
-        // Finally, return a stream that will collect results from each shard as they become
-        // available.  Per-shard ordering is defined by the Oxia server (as of this writing,
-        // they should be in the same order).  The ordering of responses between shards and the early failures
-        // already collected is unspecified.
-        //
-        // All of this syntatic mess lets us return precisely the stream we need without boxing it.
-        // The only overhead is reading it, which hopefully will be done just this once.
+                let failures_stream = if failures.is_empty() {
+                    None
+                } else {
+                    Some(futures::stream::iter(failures))
+                };
 
-        let final_stream = match (batch_get_stream, failures_stream) {
-            // Requests, no early failures
-            (Some(b), None) => Left(b),
+                // Finally, return a stream that will collect results from each shard as they become
+                // available.  Per-shard ordering is defined by the Oxia server (as of this writing,
+                // they should be in the same order).  The ordering of responses between shards and the early failures
+                // already collected is unspecified.
+                //
+                // All of this syntatic mess lets us return precisely the stream we need without boxing it.
+                // The only overhead is reading it, which hopefully will be done just this once.
 
-            // Requests and early failures
-            (Some(b), Some(f)) => Right(Left(Left(futures::stream::select(b, f)))),
+                let final_stream = match (batch_get_stream, failures_stream) {
+                    // Requests, no early failures
+                    (Some(b), None) => Left(b),
 
-            // All failures
-            (None, Some(f)) => Right(Left(Right(f))),
+                    // Requests and early failures
+                    (Some(b), Some(f)) => Right(Left(Left(futures::stream::select(b, f)))),
 
-            // Empty requests? Should be rare
-            (None, None) => Right(Right(futures::stream::empty())),
-        };
+                    // All failures
+                    (None, Some(f)) => Right(Left(Right(f))),
 
-        Ok(final_stream)
+                    // Empty requests? Should be rare
+                    (None, None) => Right(Right(futures::stream::empty())),
+                };
+
+                Ok(final_stream)
+            },
+        )
     }
 
     #[inline]
@@ -1102,22 +1172,51 @@ impl Client {
         self.put_internal(Arc::from(key.into()), value.into(), options)
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.put",
+        skip(self, key, value, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::Put.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn put_internal(
         &self,
         key: Arc<str>,
         value: Bytes,
         options: PutOptions,
     ) -> Result<PutResponse> {
-        let selector = options.partition_key.as_deref().unwrap_or(&key);
-        let shard = self.get_shard(selector)?;
-        execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-            let shard = shard.clone();
-            let key = Arc::clone(&key);
-            let value = value.clone();
-            let options = options.clone();
-            async move { shard.put(&key, value, &options).await }
-        })
-        .await
+        let value_size = value.len() as u64;
+        let start = metrics::operation_start();
+        let result = async {
+            let selector = options.partition_key.as_deref().unwrap_or(&key);
+            let shard = self.get_shard(selector)?;
+            tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                let shard = shard.clone();
+                let key = Arc::clone(&key);
+                let value = value.clone();
+                let options = options.clone();
+                async move { shard.put(&key, value, &options).await }
+            })
+            .await
+        }
+        .await;
+        metrics::record_operation_result_with_size(
+            &self.metrics,
+            self.config.namespace(),
+            metrics::Operation::Put,
+            metrics::result_kind,
+            |_| value_size,
+            start,
+            &result,
+        );
+        result
     }
 
     #[inline]
@@ -1134,16 +1233,43 @@ impl Client {
         self.delete_internal(Arc::from(key.into()), options)
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.delete",
+        skip(self, key, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::Delete.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn delete_internal(&self, key: Arc<str>, options: DeleteOptions) -> Result<()> {
-        let selector = options.partition_key.as_deref().unwrap_or(&key);
-        let shard = self.get_shard(selector)?;
-        execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-            let shard = shard.clone();
-            let key = Arc::clone(&key);
-            let options = options.clone();
-            async move { shard.delete(&key, &options).await }
-        })
-        .await
+        let start = metrics::operation_start();
+        let result = async {
+            let selector = options.partition_key.as_deref().unwrap_or(&key);
+            let shard = self.get_shard(selector)?;
+            tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                let shard = shard.clone();
+                let key = Arc::clone(&key);
+                let options = options.clone();
+                async move { shard.delete(&key, &options).await }
+            })
+            .await
+        }
+        .await;
+        metrics::record_operation_result(
+            &self.metrics,
+            self.config.namespace(),
+            metrics::Operation::Delete,
+            metrics::result_kind,
+            start,
+            &result,
+        );
+        result
     }
 
     #[inline]
@@ -1173,69 +1299,96 @@ impl Client {
         )
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.delete_range",
+        skip(self, start_inclusive, end_exclusive, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::DeleteRange.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn delete_range_internal(
         &self,
         start_inclusive: Arc<str>,
         end_exclusive: Arc<str>,
         options: DeleteRangeOptions,
     ) -> Result<()> {
-        let do_delete_range = |shard: shard::Client,
-                               start: Arc<str>,
-                               end: Arc<str>,
-                               options: DeleteRangeOptions| async move {
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
-                let start = Arc::clone(&start);
-                let end = Arc::clone(&end);
-                let options = options.clone();
-                async move { shard.delete_range(&start, &end, &options).await }
-            })
-            .await
-        };
-
-        if let Some(shard) = {
-            if let Some(pk) = options.partition_key.as_deref() {
-                Some(self.get_shard(pk)?)
-            } else if let Some(id) = options.shard {
-                Some(self.get_shard_by_id(id.into())?)
-            } else {
-                None
-            }
-        } {
-            return do_delete_range(shard, start_inclusive, end_exclusive, options).await;
-        }
-
-        let n = match self.config.max_parallel_requests() {
-            0 => usize::MAX,
-            n => n,
-        };
-
-        let mut result_stream =
-            futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
-                .map(|shard| {
-                    do_delete_range(
-                        shard,
-                        Arc::clone(&start_inclusive),
-                        Arc::clone(&end_exclusive),
-                        options.clone(),
-                    )
+        let start = metrics::operation_start();
+        let result = async {
+            let do_delete_range = |shard: shard::Client,
+                                   start: Arc<str>,
+                                   end: Arc<str>,
+                                   options: DeleteRangeOptions| async move {
+                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                    let shard = shard.clone();
+                    let start = Arc::clone(&start);
+                    let end = Arc::clone(&end);
+                    let options = options.clone();
+                    async move { shard.delete_range(&start, &end, &options).await }
                 })
-                .buffer_unordered(n);
+                .await
+            };
 
-        let mut errs = Vec::new();
-        while let Some(shard_result) = result_stream.next().await {
-            match shard_result {
-                Err(Error::ShardError(e)) => errs.push(e),
-                Err(_) => return shard_result,
-                Ok(()) => (),
+            if let Some(shard) = {
+                if let Some(pk) = options.partition_key.as_deref() {
+                    Some(self.get_shard(pk)?)
+                } else if let Some(id) = options.shard {
+                    Some(self.get_shard_by_id(id.into())?)
+                } else {
+                    None
+                }
+            } {
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                return do_delete_range(shard, start_inclusive, end_exclusive, options).await;
             }
-        }
 
-        if !errs.is_empty() {
-            return Err(Error::MultipleShardError(errs.into()));
-        }
+            let n = match self.config.max_parallel_requests() {
+                0 => usize::MAX,
+                n => n,
+            };
 
-        Ok(())
+            let mut result_stream =
+                futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
+                    .map(|shard| {
+                        do_delete_range(
+                            shard,
+                            Arc::clone(&start_inclusive),
+                            Arc::clone(&end_exclusive),
+                            options.clone(),
+                        )
+                    })
+                    .buffer_unordered(n);
+
+            let mut errs = Vec::new();
+            while let Some(shard_result) = result_stream.next().await {
+                match shard_result {
+                    Err(Error::ShardError(e)) => errs.push(e),
+                    Err(_) => return shard_result,
+                    Ok(()) => (),
+                }
+            }
+
+            if !errs.is_empty() {
+                return Err(Error::MultipleShardError(errs.into()));
+            }
+
+            Ok(())
+        }
+        .await;
+        metrics::record_operation_result(
+            &self.metrics,
+            self.config.namespace(),
+            metrics::Operation::DeleteRange,
+            metrics::result_kind,
+            start,
+            &result,
+        );
+        result
     }
 
     #[inline]
@@ -1261,64 +1414,91 @@ impl Client {
         )
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.list",
+        skip(self, start_inclusive, end_exclusive, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::List.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn list_internal(
         &self,
         start_inclusive: Arc<str>,
         end_exclusive: Arc<str>,
         options: ListOptions,
     ) -> Result<ListResponse> {
-        let do_list = |shard: shard::Client,
-                       start: Arc<str>,
-                       end: Arc<str>,
-                       options: ListOptions| async move {
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
-                let start = Arc::clone(&start);
-                let end = Arc::clone(&end);
-                let options = options.clone();
-                async move { shard.list(&start, &end, &options).await }
-            })
-            .await
-        };
-
-        if let Some(pk) = options.partition_key.as_deref() {
-            let shard = self.get_shard(pk)?;
-            return do_list(shard, start_inclusive, end_exclusive, options).await;
-        }
-
-        let n = match self.config.max_parallel_requests() {
-            0 => usize::MAX,
-            n => n,
-        };
-
-        let mut result_stream =
-            futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
-                .map(|shard| {
-                    do_list(
-                        shard,
-                        Arc::clone(&start_inclusive),
-                        Arc::clone(&end_exclusive),
-                        options.clone(),
-                    )
+        let start = metrics::operation_start();
+        let result = async {
+            let do_list = |shard: shard::Client,
+                           start: Arc<str>,
+                           end: Arc<str>,
+                           options: ListOptions| async move {
+                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                    let shard = shard.clone();
+                    let start = Arc::clone(&start);
+                    let end = Arc::clone(&end);
+                    let options = options.clone();
+                    async move { shard.list(&start, &end, &options).await }
                 })
-                .buffer_unordered(n);
+                .await
+            };
 
-        let mut response = ListResponse::default();
-        while let Some(shard_result) = result_stream.next().await {
-            if let Ok(shard_response) = shard_result {
-                response.merge(shard_response);
-            } else if options.partial_ok {
-                response.partial = true;
-            } else {
-                return shard_result;
+            if let Some(pk) = options.partition_key.as_deref() {
+                let shard = self.get_shard(pk)?;
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                return do_list(shard, start_inclusive, end_exclusive, options).await;
             }
-        }
 
-        if options.sort {
-            response.sort();
-        }
+            let n = match self.config.max_parallel_requests() {
+                0 => usize::MAX,
+                n => n,
+            };
 
-        Ok(response)
+            let mut result_stream =
+                futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
+                    .map(|shard| {
+                        do_list(
+                            shard,
+                            Arc::clone(&start_inclusive),
+                            Arc::clone(&end_exclusive),
+                            options.clone(),
+                        )
+                    })
+                    .buffer_unordered(n);
+
+            let mut response = ListResponse::default();
+            while let Some(shard_result) = result_stream.next().await {
+                if let Ok(shard_response) = shard_result {
+                    response.merge(shard_response);
+                } else if options.partial_ok {
+                    response.partial = true;
+                } else {
+                    return shard_result;
+                }
+            }
+
+            if options.sort {
+                response.sort();
+            }
+
+            Ok(response)
+        }
+        .await;
+        metrics::record_operation_result(
+            &self.metrics,
+            self.config.namespace(),
+            metrics::Operation::List,
+            metrics::result_kind,
+            start,
+            &result,
+        );
+        result
     }
 
     #[inline]
@@ -1344,64 +1524,92 @@ impl Client {
         )
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.range_scan",
+        skip(self, start_inclusive, end_exclusive, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::RangeScan.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn range_scan_internal(
         &self,
         start_inclusive: Arc<str>,
         end_exclusive: Arc<str>,
         options: RangeScanOptions,
     ) -> Result<RangeScanResponse> {
-        let do_range_scan = |shard: shard::Client,
-                             start: Arc<str>,
-                             end: Arc<str>,
-                             options: RangeScanOptions| async move {
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
-                let start = Arc::clone(&start);
-                let end = Arc::clone(&end);
-                let options = options.clone();
-                async move { shard.range_scan(&start, &end, &options).await }
-            })
-            .await
-        };
-
-        if let Some(pk) = options.partition_key.as_deref() {
-            let shard = self.get_shard(pk)?;
-            return do_range_scan(shard, start_inclusive, end_exclusive, options).await;
-        }
-
-        let n = match self.config.max_parallel_requests() {
-            0 => usize::MAX,
-            n => n,
-        };
-
-        let mut result_stream =
-            futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
-                .map(|shard| {
-                    do_range_scan(
-                        shard,
-                        Arc::clone(&start_inclusive),
-                        Arc::clone(&end_exclusive),
-                        options.clone(),
-                    )
+        let start = metrics::operation_start();
+        let result = async {
+            let do_range_scan = |shard: shard::Client,
+                                 start: Arc<str>,
+                                 end: Arc<str>,
+                                 options: RangeScanOptions| async move {
+                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                    let shard = shard.clone();
+                    let start = Arc::clone(&start);
+                    let end = Arc::clone(&end);
+                    let options = options.clone();
+                    async move { shard.range_scan(&start, &end, &options).await }
                 })
-                .buffer_unordered(n);
+                .await
+            };
 
-        let mut response = RangeScanResponse::default();
-        while let Some(shard_result) = result_stream.next().await {
-            if let Ok(shard_response) = shard_result {
-                response.merge(shard_response);
-            } else if options.partial_ok {
-                response.partial = true;
-            } else {
-                return shard_result;
+            if let Some(pk) = options.partition_key.as_deref() {
+                let shard = self.get_shard(pk)?;
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                return do_range_scan(shard, start_inclusive, end_exclusive, options).await;
             }
-        }
 
-        if options.sort {
-            response.sort();
-        }
+            let n = match self.config.max_parallel_requests() {
+                0 => usize::MAX,
+                n => n,
+            };
 
-        Ok(response)
+            let mut result_stream =
+                futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
+                    .map(|shard| {
+                        do_range_scan(
+                            shard,
+                            Arc::clone(&start_inclusive),
+                            Arc::clone(&end_exclusive),
+                            options.clone(),
+                        )
+                    })
+                    .buffer_unordered(n);
+
+            let mut response = RangeScanResponse::default();
+            while let Some(shard_result) = result_stream.next().await {
+                if let Ok(shard_response) = shard_result {
+                    response.merge(shard_response);
+                } else if options.partial_ok {
+                    response.partial = true;
+                } else {
+                    return shard_result;
+                }
+            }
+
+            if options.sort {
+                response.sort();
+            }
+
+            Ok(response)
+        }
+        .await;
+        metrics::record_operation_result_with_size(
+            &self.metrics,
+            self.config.namespace(),
+            metrics::Operation::RangeScan,
+            metrics::result_kind,
+            metrics::range_scan_response_size,
+            start,
+            &result,
+        );
+        result
     }
 
     /// Create a notifications stream with default options.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -892,6 +892,10 @@ impl Client {
     }
 
     pub async fn connect(&mut self) -> Result<()> {
+        if self.is_connected() {
+            return Ok(());
+        }
+
         let span = tracing::info_span!(
             target: metrics::SCOPE_NAME,
             "client.connect",
@@ -900,14 +904,9 @@ impl Client {
             "error.type" = tracing::field::Empty,
         );
         async {
-            let result = async {
-                if !self.is_connected() {
-                    let sm = shard::Manager::new(&self.config).await?;
-                    self.shard_manager = Some(Arc::new(sm));
-                }
-                Ok(())
-            }
-            .await;
+            let result = shard::Manager::new(&self.config).await.map(|sm| {
+                self.shard_manager = Some(Arc::new(sm));
+            });
             metrics::record_error_type(&result);
             result
         }

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -39,9 +39,9 @@ pub(crate) type OperationStart = Instant;
 pub(crate) type OperationStart = ();
 
 #[cfg(any(all(feature = "metrics", not(feature = "go-metrics-compat")), test))]
-pub(crate) const LATENCY_BUCKETS_MILLIS: &[f64] = &[
-    0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1_000.0, 2_000.0, 5_000.0,
-    10_000.0, 20_000.0, 50_000.0,
+pub(crate) const LATENCY_BUCKETS_SECONDS: &[f64] = &[
+    0.0001, 0.0002, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0,
+    10.0, 20.0, 50.0,
 ];
 #[cfg(any(feature = "metrics", test))]
 pub(crate) const SIZE_BUCKETS_BYTES: &[f64] = &[
@@ -336,7 +336,7 @@ mod imp {
     use super::COUNT_BUCKETS;
     use super::DB_SYSTEM;
     #[cfg(not(feature = "go-metrics-compat"))]
-    use super::LATENCY_BUCKETS_MILLIS;
+    use super::LATENCY_BUCKETS_SECONDS;
     use super::Operation;
     use super::ResultKind;
     use super::SCOPE_NAME;
@@ -427,8 +427,8 @@ mod imp {
                 #[cfg(not(feature = "go-metrics-compat"))]
                 op_duration: meter
                     .f64_histogram(names::OP_DURATION)
-                    .with_unit("ms")
-                    .with_boundaries(LATENCY_BUCKETS_MILLIS.to_vec())
+                    .with_unit("s")
+                    .with_boundaries(LATENCY_BUCKETS_SECONDS.to_vec())
                     .build(),
                 #[cfg(feature = "go-metrics-compat")]
                 op_duration: Timer::new(&meter, names::OP_DURATION_SUM, names::OP_DURATION_COUNT),
@@ -440,8 +440,8 @@ mod imp {
                 #[cfg(not(feature = "go-metrics-compat"))]
                 batch_total_duration: meter
                     .f64_histogram(names::BATCH_TOTAL)
-                    .with_unit("ms")
-                    .with_boundaries(LATENCY_BUCKETS_MILLIS.to_vec())
+                    .with_unit("s")
+                    .with_boundaries(LATENCY_BUCKETS_SECONDS.to_vec())
                     .build(),
                 #[cfg(feature = "go-metrics-compat")]
                 batch_total_duration: Timer::new(
@@ -452,8 +452,8 @@ mod imp {
                 #[cfg(not(feature = "go-metrics-compat"))]
                 batch_exec_duration: meter
                     .f64_histogram(names::BATCH_EXEC)
-                    .with_unit("ms")
-                    .with_boundaries(LATENCY_BUCKETS_MILLIS.to_vec())
+                    .with_unit("s")
+                    .with_boundaries(LATENCY_BUCKETS_SECONDS.to_vec())
                     .build(),
                 #[cfg(feature = "go-metrics-compat")]
                 batch_exec_duration: Timer::new(
@@ -526,7 +526,7 @@ mod imp {
 
     #[cfg(not(feature = "go-metrics-compat"))]
     fn record_timer(timer: &Histogram<f64>, duration: std::time::Duration, attrs: &[KeyValue]) {
-        timer.record(duration.as_secs_f64() * 1_000.0, attrs);
+        timer.record(duration.as_secs_f64(), attrs);
     }
 
     #[cfg(feature = "go-metrics-compat")]
@@ -556,12 +556,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn go_histogram_boundaries_match_reference() {
+    fn semantic_histogram_boundaries_match_reference() {
         assert_eq!(
-            LATENCY_BUCKETS_MILLIS,
+            LATENCY_BUCKETS_SECONDS,
             &[
-                0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1_000.0,
-                2_000.0, 5_000.0, 10_000.0, 20_000.0, 50_000.0,
+                0.0001, 0.0002, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0,
+                2.0, 5.0, 10.0, 20.0, 50.0,
             ]
         );
         assert_eq!(

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -38,51 +38,25 @@ pub(crate) type OperationStart = Instant;
 #[cfg(not(feature = "metrics"))]
 pub(crate) type OperationStart = ();
 
-#[cfg(any(all(feature = "metrics", not(feature = "go-metrics-compat")), test))]
-pub(crate) const LATENCY_BUCKETS_SECONDS: &[f64] = &[
-    0.0001, 0.0002, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0,
-    10.0, 20.0, 50.0,
+#[cfg(all(test, feature = "metrics"))]
+pub(crate) const HISTOGRAM_NAMES: &[&str] = &[
+    names::OP_DURATION,
+    names::OP_SIZE,
+    names::BATCH_TOTAL,
+    names::BATCH_EXEC,
+    names::BATCH_SIZE,
+    names::BATCH_REQUEST_COUNT,
 ];
+
 #[cfg(any(feature = "metrics", test))]
-pub(crate) const SIZE_BUCKETS_BYTES: &[f64] = &[
-    0x10 as f64,
-    0x20 as f64,
-    0x40 as f64,
-    0x80 as f64,
-    0x100 as f64,
-    0x200 as f64,
-    0x400 as f64,
-    0x800 as f64,
-    0x1000 as f64,
-    0x2000 as f64,
-    0x4000 as f64,
-    0x8000 as f64,
-    0x10000 as f64,
-    0x20000 as f64,
-    0x40000 as f64,
-    0x80000 as f64,
-    0x10_0000 as f64,
-    0x20_0000 as f64,
-    0x40_0000 as f64,
-    0x80_0000 as f64,
-];
-#[cfg(any(feature = "metrics", test))]
-pub(crate) const COUNT_BUCKETS: &[f64] = &[
-    1.0,
-    5.0,
-    10.0,
-    20.0,
-    50.0,
-    100.0,
-    200.0,
-    500.0,
-    1_000.0,
-    10_000.0,
-    20_000.0,
-    50_000.0,
-    100_000.0,
-    1_000_000.0,
-];
+pub(crate) mod names {
+    pub(crate) const OP_DURATION: &str = "db.client.operation.duration";
+    pub(crate) const OP_SIZE: &str = "db.client.operation.size";
+    pub(crate) const BATCH_TOTAL: &str = "db.client.batch.duration";
+    pub(crate) const BATCH_EXEC: &str = "db.client.batch.exec_duration";
+    pub(crate) const BATCH_SIZE: &str = "db.client.batch.size";
+    pub(crate) const BATCH_REQUEST_COUNT: &str = "db.client.batch.request_count";
+}
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Operation {
@@ -333,55 +307,36 @@ mod imp {
     use opentelemetry::metrics::Counter;
     use opentelemetry::metrics::Histogram;
 
-    use super::COUNT_BUCKETS;
     use super::DB_SYSTEM;
-    #[cfg(not(feature = "go-metrics-compat"))]
-    use super::LATENCY_BUCKETS_SECONDS;
     use super::Operation;
     use super::ResultKind;
     use super::SCOPE_NAME;
-    use super::SIZE_BUCKETS_BYTES;
-
-    #[cfg(not(feature = "go-metrics-compat"))]
-    mod names {
-        pub(super) const OP_DURATION: &str = "db.client.operation.duration";
-        pub(super) const OP_SIZE: &str = "db.client.operation.size";
-        pub(super) const BATCH_TOTAL: &str = "db.client.batch.duration";
-        pub(super) const BATCH_EXEC: &str = "db.client.batch.exec_duration";
-        pub(super) const BATCH_SIZE: &str = "db.client.batch.size";
-        pub(super) const BATCH_REQUEST_COUNT: &str = "db.client.batch.request_count";
-    }
+    use super::names;
 
     #[cfg(feature = "go-metrics-compat")]
-    mod names {
+    mod compat_names {
         pub(super) const OP_DURATION_SUM: &str = "oxia_client_op_sum";
         pub(super) const OP_DURATION_COUNT: &str = "oxia_client_op_count";
-        pub(super) const OP_SIZE: &str = "oxia_client_op_value";
         pub(super) const BATCH_TOTAL_SUM: &str = "oxia_client_batch_total_sum";
         pub(super) const BATCH_TOTAL_COUNT: &str = "oxia_client_batch_total_count";
         pub(super) const BATCH_EXEC_SUM: &str = "oxia_client_batch_exec_sum";
         pub(super) const BATCH_EXEC_COUNT: &str = "oxia_client_batch_exec_count";
-        pub(super) const BATCH_SIZE: &str = "oxia_client_batch_value";
-        pub(super) const BATCH_REQUEST_COUNT: &str = "oxia_client_batch_request";
     }
 
     pub(crate) type MeterProviderHandle = crate::config::MeterProviderHandle;
 
     #[derive(Clone)]
     pub(crate) struct Metrics {
-        #[cfg(not(feature = "go-metrics-compat"))]
         op_duration: Histogram<f64>,
         #[cfg(feature = "go-metrics-compat")]
-        op_duration: Timer,
+        compat_op_duration: Timer,
         op_size: Histogram<u64>,
-        #[cfg(not(feature = "go-metrics-compat"))]
         batch_total_duration: Histogram<f64>,
         #[cfg(feature = "go-metrics-compat")]
-        batch_total_duration: Timer,
-        #[cfg(not(feature = "go-metrics-compat"))]
+        compat_batch_total_duration: Timer,
         batch_exec_duration: Histogram<f64>,
         #[cfg(feature = "go-metrics-compat")]
-        batch_exec_duration: Timer,
+        compat_batch_exec_duration: Timer,
         batch_size: Histogram<u64>,
         batch_request_count: Histogram<u64>,
     }
@@ -424,52 +379,44 @@ mod imp {
             let meter = provider.meter(SCOPE_NAME);
 
             Self {
-                #[cfg(not(feature = "go-metrics-compat"))]
                 op_duration: meter
                     .f64_histogram(names::OP_DURATION)
                     .with_unit("s")
-                    .with_boundaries(LATENCY_BUCKETS_SECONDS.to_vec())
                     .build(),
                 #[cfg(feature = "go-metrics-compat")]
-                op_duration: Timer::new(&meter, names::OP_DURATION_SUM, names::OP_DURATION_COUNT),
-                op_size: meter
-                    .u64_histogram(names::OP_SIZE)
-                    .with_unit("By")
-                    .with_boundaries(SIZE_BUCKETS_BYTES.to_vec())
-                    .build(),
-                #[cfg(not(feature = "go-metrics-compat"))]
+                compat_op_duration: Timer::new(
+                    &meter,
+                    compat_names::OP_DURATION_SUM,
+                    compat_names::OP_DURATION_COUNT,
+                ),
+                op_size: meter.u64_histogram(names::OP_SIZE).with_unit("By").build(),
                 batch_total_duration: meter
                     .f64_histogram(names::BATCH_TOTAL)
                     .with_unit("s")
-                    .with_boundaries(LATENCY_BUCKETS_SECONDS.to_vec())
                     .build(),
                 #[cfg(feature = "go-metrics-compat")]
-                batch_total_duration: Timer::new(
+                compat_batch_total_duration: Timer::new(
                     &meter,
-                    names::BATCH_TOTAL_SUM,
-                    names::BATCH_TOTAL_COUNT,
+                    compat_names::BATCH_TOTAL_SUM,
+                    compat_names::BATCH_TOTAL_COUNT,
                 ),
-                #[cfg(not(feature = "go-metrics-compat"))]
                 batch_exec_duration: meter
                     .f64_histogram(names::BATCH_EXEC)
                     .with_unit("s")
-                    .with_boundaries(LATENCY_BUCKETS_SECONDS.to_vec())
                     .build(),
                 #[cfg(feature = "go-metrics-compat")]
-                batch_exec_duration: Timer::new(
+                compat_batch_exec_duration: Timer::new(
                     &meter,
-                    names::BATCH_EXEC_SUM,
-                    names::BATCH_EXEC_COUNT,
+                    compat_names::BATCH_EXEC_SUM,
+                    compat_names::BATCH_EXEC_COUNT,
                 ),
                 batch_size: meter
                     .u64_histogram(names::BATCH_SIZE)
                     .with_unit("By")
-                    .with_boundaries(SIZE_BUCKETS_BYTES.to_vec())
                     .build(),
                 batch_request_count: meter
                     .u64_histogram(names::BATCH_REQUEST_COUNT)
                     .with_unit("1")
-                    .with_boundaries(COUNT_BUCKETS.to_vec())
                     .build(),
             }
         }
@@ -483,6 +430,8 @@ mod imp {
         ) {
             let attrs = attrs(namespace, operation, result);
             record_timer(&self.op_duration, duration, &attrs);
+            #[cfg(feature = "go-metrics-compat")]
+            self.compat_op_duration.record(duration, &attrs);
         }
 
         pub(crate) fn record_operation_size(
@@ -510,6 +459,13 @@ mod imp {
             let attrs = attrs(namespace, operation, result);
             record_timer(&self.batch_total_duration, total_duration, &attrs);
             record_timer(&self.batch_exec_duration, exec_duration, &attrs);
+            #[cfg(feature = "go-metrics-compat")]
+            {
+                self.compat_batch_total_duration
+                    .record(total_duration, &attrs);
+                self.compat_batch_exec_duration
+                    .record(exec_duration, &attrs);
+            }
             self.batch_size.record(value_size, &attrs);
             self.batch_request_count.record(request_count, &attrs);
         }
@@ -524,14 +480,8 @@ mod imp {
         ]
     }
 
-    #[cfg(not(feature = "go-metrics-compat"))]
     fn record_timer(timer: &Histogram<f64>, duration: std::time::Duration, attrs: &[KeyValue]) {
         timer.record(duration.as_secs_f64(), attrs);
-    }
-
-    #[cfg(feature = "go-metrics-compat")]
-    fn record_timer(timer: &Timer, duration: std::time::Duration, attrs: &[KeyValue]) {
-        timer.record(duration, attrs);
     }
 }
 
@@ -556,63 +506,271 @@ mod tests {
     use super::*;
 
     #[test]
-    fn semantic_histogram_boundaries_match_reference() {
-        assert_eq!(
-            LATENCY_BUCKETS_SECONDS,
-            &[
-                0.0001, 0.0002, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0,
-                2.0, 5.0, 10.0, 20.0, 50.0,
-            ]
-        );
-        assert_eq!(
-            SIZE_BUCKETS_BYTES,
-            &[
-                16.0,
-                32.0,
-                64.0,
-                128.0,
-                256.0,
-                512.0,
-                1_024.0,
-                2_048.0,
-                4_096.0,
-                8_192.0,
-                16_384.0,
-                32_768.0,
-                65_536.0,
-                131_072.0,
-                262_144.0,
-                524_288.0,
-                1_048_576.0,
-                2_097_152.0,
-                4_194_304.0,
-                8_388_608.0,
-            ]
-        );
-        assert_eq!(
-            COUNT_BUCKETS,
-            &[
-                1.0,
-                5.0,
-                10.0,
-                20.0,
-                50.0,
-                100.0,
-                200.0,
-                500.0,
-                1_000.0,
-                10_000.0,
-                20_000.0,
-                50_000.0,
-                100_000.0,
-                1_000_000.0,
-            ]
-        );
-    }
-
-    #[test]
     fn key_not_found_get_is_success_for_metrics() {
         let result = Err(Error::Oxia(OxiaError::KeyNotFound));
         assert_eq!(get_result_kind(&result), ResultKind::Success);
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod sdk_tests {
+    use std::sync::Arc;
+    use std::sync::Weak;
+    use std::time::Duration;
+
+    use opentelemetry_sdk::Resource;
+    use opentelemetry_sdk::metrics::Aggregation;
+    use opentelemetry_sdk::metrics::Instrument;
+    use opentelemetry_sdk::metrics::InstrumentKind;
+    use opentelemetry_sdk::metrics::ManualReader;
+    use opentelemetry_sdk::metrics::MetricResult;
+    use opentelemetry_sdk::metrics::Pipeline;
+    use opentelemetry_sdk::metrics::SdkMeterProvider;
+    use opentelemetry_sdk::metrics::Stream;
+    use opentelemetry_sdk::metrics::Temporality;
+    use opentelemetry_sdk::metrics::data;
+    use opentelemetry_sdk::metrics::data::ResourceMetrics;
+    use opentelemetry_sdk::metrics::reader::MetricReader;
+
+    use super::*;
+
+    const EXPONENTIAL_HISTOGRAM_MAX_SIZE: u32 = 160;
+    const EXPONENTIAL_HISTOGRAM_MAX_SCALE: i8 = 20;
+
+    #[test]
+    fn semantic_metrics_use_exponential_histograms() {
+        let (reader, _provider, metrics) = setup_metrics();
+
+        metrics.record_operation(
+            "default",
+            Operation::Get,
+            ResultKind::Success,
+            Duration::from_millis(250),
+        );
+        metrics.record_operation_size("default", Operation::Get, ResultKind::Success, 42);
+        metrics.record_batch(
+            "default",
+            Operation::Put,
+            ResultKind::Success,
+            Duration::from_secs(2),
+            Duration::from_millis(500),
+            128,
+            3,
+        );
+        metrics.record_operation_size("default", Operation::Get, ResultKind::Success, 0);
+
+        let rm = collect(&reader);
+
+        assert_exponential_f64(&rm, names::OP_DURATION, "s", 1, 0.25, true);
+        assert_exponential_u64(&rm, names::OP_SIZE, "By", 2, 42, true, true);
+        assert_exponential_f64(&rm, names::BATCH_TOTAL, "s", 1, 2.0, true);
+        assert_exponential_f64(&rm, names::BATCH_EXEC, "s", 1, 0.5, true);
+        assert_exponential_u64(&rm, names::BATCH_SIZE, "By", 1, 128, true, false);
+        assert_exponential_u64(&rm, names::BATCH_REQUEST_COUNT, "1", 1, 3, true, false);
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    #[test]
+    fn go_metrics_compat_adds_only_latency_sum_count_metrics() {
+        let (reader, _provider, metrics) = setup_metrics();
+
+        metrics.record_operation(
+            "default",
+            Operation::Get,
+            ResultKind::Success,
+            Duration::from_millis(250),
+        );
+        metrics.record_operation_size("default", Operation::Get, ResultKind::Success, 42);
+        metrics.record_batch(
+            "default",
+            Operation::Put,
+            ResultKind::Success,
+            Duration::from_secs(2),
+            Duration::from_millis(500),
+            128,
+            3,
+        );
+
+        let rm = collect(&reader);
+
+        assert_exponential_f64(&rm, names::OP_DURATION, "s", 1, 0.25, true);
+        assert_sum_f64(&rm, "oxia_client_op_sum", "ms", 250.0);
+        assert_sum_u64(&rm, "oxia_client_op_count", "1", 1);
+        assert_sum_f64(&rm, "oxia_client_batch_total_sum", "ms", 2_000.0);
+        assert_sum_u64(&rm, "oxia_client_batch_total_count", "1", 1);
+        assert_sum_f64(&rm, "oxia_client_batch_exec_sum", "ms", 500.0);
+        assert_sum_u64(&rm, "oxia_client_batch_exec_count", "1", 1);
+        assert_metric_absent(&rm, "oxia_client_op_value");
+        assert_metric_absent(&rm, "oxia_client_batch_value");
+        assert_metric_absent(&rm, "oxia_client_batch_request");
+    }
+
+    fn setup_metrics() -> (
+        SharedManualReader,
+        crate::config::MeterProviderHandle,
+        Metrics,
+    ) {
+        let reader = SharedManualReader::new(
+            ManualReader::builder()
+                .with_temporality(Temporality::Cumulative)
+                .build(),
+        );
+        let provider = SdkMeterProvider::builder()
+            .with_reader(reader.clone())
+            .with_view(exponential_histogram_view)
+            .build();
+        let provider_handle: crate::config::MeterProviderHandle = Arc::new(provider);
+        let metrics = Metrics::new(Some(&provider_handle));
+        (reader, provider_handle, metrics)
+    }
+
+    fn exponential_histogram_view(instrument: &Instrument) -> Option<Stream> {
+        (instrument.kind == Some(InstrumentKind::Histogram)
+            && HISTOGRAM_NAMES.contains(&instrument.name.as_ref()))
+        .then(|| {
+            Stream::new()
+                .name(instrument.name.clone())
+                .description(instrument.description.clone())
+                .unit(instrument.unit.clone())
+                .aggregation(Aggregation::Base2ExponentialHistogram {
+                    max_size: EXPONENTIAL_HISTOGRAM_MAX_SIZE,
+                    max_scale: EXPONENTIAL_HISTOGRAM_MAX_SCALE,
+                    record_min_max: false,
+                })
+        })
+    }
+
+    fn collect(reader: &SharedManualReader) -> ResourceMetrics {
+        let mut rm = ResourceMetrics {
+            resource: Resource::empty(),
+            scope_metrics: Vec::new(),
+        };
+        reader
+            .collect(&mut rm)
+            .expect("metrics collection succeeds");
+        rm
+    }
+
+    fn assert_exponential_f64(
+        rm: &ResourceMetrics,
+        name: &str,
+        unit: &str,
+        count: usize,
+        sum: f64,
+        has_positive_bucket: bool,
+    ) {
+        let histogram = metric_data::<data::ExponentialHistogram<f64>>(rm, name, unit);
+        assert_eq!(Temporality::Cumulative, histogram.temporality);
+        assert_eq!(1, histogram.data_points.len());
+        let point = &histogram.data_points[0];
+        assert_eq!(count, point.count);
+        assert!((point.sum - sum).abs() < f64::EPSILON);
+        assert_eq!(None, point.min);
+        assert_eq!(None, point.max);
+        assert_eq!(0, point.zero_count);
+        assert_eq!(
+            has_positive_bucket,
+            point.positive_bucket.counts.iter().any(|count| *count > 0)
+        );
+    }
+
+    fn assert_exponential_u64(
+        rm: &ResourceMetrics,
+        name: &str,
+        unit: &str,
+        count: usize,
+        sum: u64,
+        has_positive_bucket: bool,
+        has_zero: bool,
+    ) {
+        let histogram = metric_data::<data::ExponentialHistogram<u64>>(rm, name, unit);
+        assert_eq!(Temporality::Cumulative, histogram.temporality);
+        assert_eq!(1, histogram.data_points.len());
+        let point = &histogram.data_points[0];
+        assert_eq!(count, point.count);
+        assert_eq!(sum, point.sum);
+        assert_eq!(None, point.min);
+        assert_eq!(None, point.max);
+        assert_eq!(u64::from(has_zero), point.zero_count);
+        assert_eq!(
+            has_positive_bucket,
+            point.positive_bucket.counts.iter().any(|count| *count > 0)
+        );
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn assert_sum_f64(rm: &ResourceMetrics, name: &str, unit: &str, value: f64) {
+        let sum = metric_data::<data::Sum<f64>>(rm, name, unit);
+        assert_eq!(1, sum.data_points.len());
+        assert!((sum.data_points[0].value - value).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn assert_sum_u64(rm: &ResourceMetrics, name: &str, unit: &str, value: u64) {
+        let sum = metric_data::<data::Sum<u64>>(rm, name, unit);
+        assert_eq!(1, sum.data_points.len());
+        assert_eq!(value, sum.data_points[0].value);
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn assert_metric_absent(rm: &ResourceMetrics, name: &str) {
+        assert!(
+            metric(rm, name).is_none(),
+            "metric {name} should not be exported"
+        );
+    }
+
+    fn metric_data<'a, T>(rm: &'a ResourceMetrics, name: &str, unit: &str) -> &'a T
+    where
+        T: data::Aggregation,
+    {
+        let metric = metric(rm, name).unwrap_or_else(|| panic!("metric {name} is exported"));
+        assert_eq!(unit, metric.unit);
+        metric
+            .data
+            .as_any()
+            .downcast_ref::<T>()
+            .unwrap_or_else(|| panic!("metric {name} has expected data type"))
+    }
+
+    fn metric<'a>(
+        rm: &'a ResourceMetrics,
+        name: &str,
+    ) -> Option<&'a opentelemetry_sdk::metrics::data::Metric> {
+        rm.scope_metrics
+            .iter()
+            .flat_map(|scope| scope.metrics.iter())
+            .find(|metric| metric.name == name)
+    }
+
+    #[derive(Clone, Debug)]
+    struct SharedManualReader(Arc<ManualReader>);
+
+    impl SharedManualReader {
+        fn new(reader: ManualReader) -> Self {
+            Self(Arc::new(reader))
+        }
+    }
+
+    impl MetricReader for SharedManualReader {
+        fn register_pipeline(&self, pipeline: Weak<Pipeline>) {
+            self.0.register_pipeline(pipeline);
+        }
+
+        fn collect(&self, rm: &mut ResourceMetrics) -> MetricResult<()> {
+            self.0.collect(rm)
+        }
+
+        fn force_flush(&self) -> MetricResult<()> {
+            self.0.force_flush()
+        }
+
+        fn shutdown(&self) -> MetricResult<()> {
+            self.0.shutdown()
+        }
+
+        fn temporality(&self, kind: InstrumentKind) -> Temporality {
+            self.0.temporality(kind)
+        }
     }
 }

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -1,0 +1,618 @@
+// Copyright 2025-2026 Maurice S. Barnum
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::redundant_pub_crate)]
+
+#[cfg(feature = "metrics")]
+use std::time::Instant;
+
+use crate::Error;
+use crate::GetResponse;
+use crate::RangeScanResponse;
+use crate::errors::OxiaError;
+
+pub(crate) const SCOPE_NAME: &str = "mauricebarnum_oxia_client";
+pub(crate) const DB_SYSTEM: &str = "oxia";
+
+#[cfg(feature = "metrics")]
+pub(crate) type BatchStart = Instant;
+#[cfg(not(feature = "metrics"))]
+pub(crate) type BatchStart = ();
+#[cfg(feature = "metrics")]
+pub(crate) type BatchExecDuration = std::time::Duration;
+#[cfg(not(feature = "metrics"))]
+pub(crate) type BatchExecDuration = ();
+#[cfg(feature = "metrics")]
+pub(crate) type OperationStart = Instant;
+#[cfg(not(feature = "metrics"))]
+pub(crate) type OperationStart = ();
+
+#[cfg(any(all(feature = "metrics", not(feature = "go-metrics-compat")), test))]
+pub(crate) const LATENCY_BUCKETS_MILLIS: &[f64] = &[
+    0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1_000.0, 2_000.0, 5_000.0,
+    10_000.0, 20_000.0, 50_000.0,
+];
+#[cfg(any(feature = "metrics", test))]
+pub(crate) const SIZE_BUCKETS_BYTES: &[f64] = &[
+    0x10 as f64,
+    0x20 as f64,
+    0x40 as f64,
+    0x80 as f64,
+    0x100 as f64,
+    0x200 as f64,
+    0x400 as f64,
+    0x800 as f64,
+    0x1000 as f64,
+    0x2000 as f64,
+    0x4000 as f64,
+    0x8000 as f64,
+    0x10000 as f64,
+    0x20000 as f64,
+    0x40000 as f64,
+    0x80000 as f64,
+    0x10_0000 as f64,
+    0x20_0000 as f64,
+    0x40_0000 as f64,
+    0x80_0000 as f64,
+];
+#[cfg(any(feature = "metrics", test))]
+pub(crate) const COUNT_BUCKETS: &[f64] = &[
+    1.0,
+    5.0,
+    10.0,
+    20.0,
+    50.0,
+    100.0,
+    200.0,
+    500.0,
+    1_000.0,
+    10_000.0,
+    20_000.0,
+    50_000.0,
+    100_000.0,
+    1_000_000.0,
+];
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Operation {
+    Get,
+    Put,
+    Delete,
+    DeleteRange,
+    List,
+    RangeScan,
+    BatchGet,
+}
+
+impl Operation {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Get => "get",
+            Self::Put => "put",
+            Self::Delete => "delete",
+            Self::DeleteRange => "delete_range",
+            Self::List => "list",
+            Self::RangeScan => "range_scan",
+            Self::BatchGet => "batch_get",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResultKind {
+    Success,
+    Failure,
+}
+
+impl ResultKind {
+    #[cfg(feature = "metrics")]
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failure => "failure",
+        }
+    }
+}
+
+pub(crate) const fn result_kind<T>(result: &crate::Result<T>) -> ResultKind {
+    match result {
+        Ok(_) => ResultKind::Success,
+        Err(_) => ResultKind::Failure,
+    }
+}
+
+pub(crate) const fn get_result_kind(result: &crate::Result<Option<GetResponse>>) -> ResultKind {
+    match result {
+        Ok(_) | Err(Error::Oxia(OxiaError::KeyNotFound)) => ResultKind::Success,
+        Err(_) => ResultKind::Failure,
+    }
+}
+
+pub(crate) fn get_response_size(result: &crate::Result<Option<GetResponse>>) -> u64 {
+    result
+        .as_ref()
+        .ok()
+        .and_then(Option::as_ref)
+        .and_then(|response| response.value.as_ref())
+        .map_or(0, |value| value.len() as u64)
+}
+
+pub(crate) fn range_scan_response_size(result: &crate::Result<RangeScanResponse>) -> u64 {
+    result.as_ref().map_or(0, |response| {
+        response
+            .records
+            .iter()
+            .map(|record| record.value.as_ref().map_or(0, bytes::Bytes::len) as u64)
+            .sum()
+    })
+}
+
+pub(crate) fn record_error_type<T>(result: &crate::Result<T>) {
+    if let Err(error) = result {
+        tracing::Span::current().record("error.type", error.to_string());
+    }
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn record_operation_sync<T, C, O>(
+    metrics: &Metrics,
+    namespace: &str,
+    operation: Operation,
+    classify: C,
+    op: O,
+) -> crate::Result<T>
+where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+    O: FnOnce() -> crate::Result<T>,
+{
+    let start = Instant::now();
+    let result = op();
+    metrics.record_operation(namespace, operation, classify(&result), start.elapsed());
+    record_error_type(&result);
+    result
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) fn record_operation_sync<T, C, O>(
+    _metrics: &Metrics,
+    _namespace: &str,
+    _operation: Operation,
+    _classify: C,
+    op: O,
+) -> crate::Result<T>
+where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+    O: FnOnce() -> crate::Result<T>,
+{
+    let result = op();
+    record_error_type(&result);
+    result
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn operation_start() -> OperationStart {
+    Instant::now()
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) const fn operation_start() {}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn record_operation_result<T, C>(
+    metrics: &Metrics,
+    namespace: &str,
+    operation: Operation,
+    classify: C,
+    start: OperationStart,
+    result: &crate::Result<T>,
+) where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+{
+    metrics.record_operation(namespace, operation, classify(result), start.elapsed());
+    record_error_type(result);
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) fn record_operation_result<T, C>(
+    _metrics: &Metrics,
+    _namespace: &str,
+    _operation: Operation,
+    _classify: C,
+    _start: OperationStart,
+    result: &crate::Result<T>,
+) where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+{
+    record_error_type(result);
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn record_operation_result_with_size<T, C, S>(
+    metrics: &Metrics,
+    namespace: &str,
+    operation: Operation,
+    classify: C,
+    size: S,
+    start: OperationStart,
+    result: &crate::Result<T>,
+) where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+    S: FnOnce(&crate::Result<T>) -> u64,
+{
+    let result_kind = classify(result);
+    metrics.record_operation(namespace, operation, result_kind, start.elapsed());
+    metrics.record_operation_size(namespace, operation, result_kind, size(result));
+    record_error_type(result);
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) fn record_operation_result_with_size<T, C, S>(
+    _metrics: &Metrics,
+    _namespace: &str,
+    _operation: Operation,
+    _classify: C,
+    _size: S,
+    _start: OperationStart,
+    result: &crate::Result<T>,
+) where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+    S: FnOnce(&crate::Result<T>) -> u64,
+{
+    record_error_type(result);
+}
+
+#[cfg(feature = "metrics")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_batch(
+    metrics: &Metrics,
+    namespace: &str,
+    operation: Operation,
+    result: ResultKind,
+    total_start: BatchStart,
+    exec_duration: BatchExecDuration,
+    value_size: u64,
+    request_count: u64,
+) {
+    metrics.record_batch(
+        namespace,
+        operation,
+        result,
+        total_start.elapsed(),
+        exec_duration,
+        value_size,
+        request_count,
+    );
+}
+
+#[cfg(not(feature = "metrics"))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_batch(
+    _metrics: &Metrics,
+    _namespace: &str,
+    _operation: Operation,
+    _result: ResultKind,
+    _total_start: BatchStart,
+    _exec_duration: BatchExecDuration,
+    _value_size: u64,
+    _request_count: u64,
+) {
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn batch_start() -> Instant {
+    Instant::now()
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn batch_exec_duration(start: Instant) -> std::time::Duration {
+    start.elapsed()
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) const fn batch_start() {}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) const fn batch_exec_duration(_: ()) {}
+
+#[cfg(feature = "metrics")]
+mod imp {
+    use opentelemetry::KeyValue;
+    use opentelemetry::global;
+    #[cfg(feature = "go-metrics-compat")]
+    use opentelemetry::metrics::Counter;
+    use opentelemetry::metrics::Histogram;
+
+    use super::COUNT_BUCKETS;
+    use super::DB_SYSTEM;
+    #[cfg(not(feature = "go-metrics-compat"))]
+    use super::LATENCY_BUCKETS_MILLIS;
+    use super::Operation;
+    use super::ResultKind;
+    use super::SCOPE_NAME;
+    use super::SIZE_BUCKETS_BYTES;
+
+    #[cfg(not(feature = "go-metrics-compat"))]
+    mod names {
+        pub(super) const OP_DURATION: &str = "db.client.operation.duration";
+        pub(super) const OP_SIZE: &str = "db.client.operation.size";
+        pub(super) const BATCH_TOTAL: &str = "db.client.batch.duration";
+        pub(super) const BATCH_EXEC: &str = "db.client.batch.exec_duration";
+        pub(super) const BATCH_SIZE: &str = "db.client.batch.size";
+        pub(super) const BATCH_REQUEST_COUNT: &str = "db.client.batch.request_count";
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    mod names {
+        pub(super) const OP_DURATION_SUM: &str = "oxia_client_op_sum";
+        pub(super) const OP_DURATION_COUNT: &str = "oxia_client_op_count";
+        pub(super) const OP_SIZE: &str = "oxia_client_op_value";
+        pub(super) const BATCH_TOTAL_SUM: &str = "oxia_client_batch_total_sum";
+        pub(super) const BATCH_TOTAL_COUNT: &str = "oxia_client_batch_total_count";
+        pub(super) const BATCH_EXEC_SUM: &str = "oxia_client_batch_exec_sum";
+        pub(super) const BATCH_EXEC_COUNT: &str = "oxia_client_batch_exec_count";
+        pub(super) const BATCH_SIZE: &str = "oxia_client_batch_value";
+        pub(super) const BATCH_REQUEST_COUNT: &str = "oxia_client_batch_request";
+    }
+
+    pub(crate) type MeterProviderHandle = crate::config::MeterProviderHandle;
+
+    #[derive(Clone)]
+    pub(crate) struct Metrics {
+        #[cfg(not(feature = "go-metrics-compat"))]
+        op_duration: Histogram<f64>,
+        #[cfg(feature = "go-metrics-compat")]
+        op_duration: Timer,
+        op_size: Histogram<u64>,
+        #[cfg(not(feature = "go-metrics-compat"))]
+        batch_total_duration: Histogram<f64>,
+        #[cfg(feature = "go-metrics-compat")]
+        batch_total_duration: Timer,
+        #[cfg(not(feature = "go-metrics-compat"))]
+        batch_exec_duration: Histogram<f64>,
+        #[cfg(feature = "go-metrics-compat")]
+        batch_exec_duration: Timer,
+        batch_size: Histogram<u64>,
+        batch_request_count: Histogram<u64>,
+    }
+
+    impl std::fmt::Debug for Metrics {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Metrics").finish_non_exhaustive()
+        }
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    #[derive(Clone, Debug)]
+    struct Timer {
+        sum: Counter<f64>,
+        count: Counter<u64>,
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    impl Timer {
+        fn new(
+            meter: &opentelemetry::metrics::Meter,
+            sum: &'static str,
+            count: &'static str,
+        ) -> Self {
+            Self {
+                sum: meter.f64_counter(sum).with_unit("ms").build(),
+                count: meter.u64_counter(count).with_unit("1").build(),
+            }
+        }
+
+        fn record(&self, duration: std::time::Duration, attrs: &[KeyValue]) {
+            self.sum.add(duration.as_secs_f64() * 1_000.0, attrs);
+            self.count.add(1, attrs);
+        }
+    }
+
+    impl Metrics {
+        pub(crate) fn new(provider: Option<&MeterProviderHandle>) -> Self {
+            let provider = provider.cloned().unwrap_or_else(global::meter_provider);
+            let meter = provider.meter(SCOPE_NAME);
+
+            Self {
+                #[cfg(not(feature = "go-metrics-compat"))]
+                op_duration: meter
+                    .f64_histogram(names::OP_DURATION)
+                    .with_unit("ms")
+                    .with_boundaries(LATENCY_BUCKETS_MILLIS.to_vec())
+                    .build(),
+                #[cfg(feature = "go-metrics-compat")]
+                op_duration: Timer::new(&meter, names::OP_DURATION_SUM, names::OP_DURATION_COUNT),
+                op_size: meter
+                    .u64_histogram(names::OP_SIZE)
+                    .with_unit("By")
+                    .with_boundaries(SIZE_BUCKETS_BYTES.to_vec())
+                    .build(),
+                #[cfg(not(feature = "go-metrics-compat"))]
+                batch_total_duration: meter
+                    .f64_histogram(names::BATCH_TOTAL)
+                    .with_unit("ms")
+                    .with_boundaries(LATENCY_BUCKETS_MILLIS.to_vec())
+                    .build(),
+                #[cfg(feature = "go-metrics-compat")]
+                batch_total_duration: Timer::new(
+                    &meter,
+                    names::BATCH_TOTAL_SUM,
+                    names::BATCH_TOTAL_COUNT,
+                ),
+                #[cfg(not(feature = "go-metrics-compat"))]
+                batch_exec_duration: meter
+                    .f64_histogram(names::BATCH_EXEC)
+                    .with_unit("ms")
+                    .with_boundaries(LATENCY_BUCKETS_MILLIS.to_vec())
+                    .build(),
+                #[cfg(feature = "go-metrics-compat")]
+                batch_exec_duration: Timer::new(
+                    &meter,
+                    names::BATCH_EXEC_SUM,
+                    names::BATCH_EXEC_COUNT,
+                ),
+                batch_size: meter
+                    .u64_histogram(names::BATCH_SIZE)
+                    .with_unit("By")
+                    .with_boundaries(SIZE_BUCKETS_BYTES.to_vec())
+                    .build(),
+                batch_request_count: meter
+                    .u64_histogram(names::BATCH_REQUEST_COUNT)
+                    .with_unit("1")
+                    .with_boundaries(COUNT_BUCKETS.to_vec())
+                    .build(),
+            }
+        }
+
+        pub(crate) fn record_operation(
+            &self,
+            namespace: &str,
+            operation: Operation,
+            result: ResultKind,
+            duration: std::time::Duration,
+        ) {
+            let attrs = attrs(namespace, operation, result);
+            record_timer(&self.op_duration, duration, &attrs);
+        }
+
+        pub(crate) fn record_operation_size(
+            &self,
+            namespace: &str,
+            operation: Operation,
+            result: ResultKind,
+            size: u64,
+        ) {
+            self.op_size
+                .record(size, &attrs(namespace, operation, result));
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        pub(crate) fn record_batch(
+            &self,
+            namespace: &str,
+            operation: Operation,
+            result: ResultKind,
+            total_duration: std::time::Duration,
+            exec_duration: std::time::Duration,
+            value_size: u64,
+            request_count: u64,
+        ) {
+            let attrs = attrs(namespace, operation, result);
+            record_timer(&self.batch_total_duration, total_duration, &attrs);
+            record_timer(&self.batch_exec_duration, exec_duration, &attrs);
+            self.batch_size.record(value_size, &attrs);
+            self.batch_request_count.record(request_count, &attrs);
+        }
+    }
+
+    fn attrs(namespace: &str, operation: Operation, result: ResultKind) -> [KeyValue; 4] {
+        [
+            KeyValue::new("db.system", DB_SYSTEM),
+            KeyValue::new("db.name", namespace.to_string()),
+            KeyValue::new("db.operation", operation.as_str()),
+            KeyValue::new("result", result.as_str()),
+        ]
+    }
+
+    #[cfg(not(feature = "go-metrics-compat"))]
+    fn record_timer(timer: &Histogram<f64>, duration: std::time::Duration, attrs: &[KeyValue]) {
+        timer.record(duration.as_secs_f64() * 1_000.0, attrs);
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn record_timer(timer: &Timer, duration: std::time::Duration, attrs: &[KeyValue]) {
+        timer.record(duration, attrs);
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+mod imp {
+    pub(crate) type MeterProviderHandle = ();
+
+    #[derive(Clone, Debug)]
+    pub(crate) struct Metrics;
+
+    impl Metrics {
+        pub(crate) const fn new(_provider: Option<&MeterProviderHandle>) -> Self {
+            Self
+        }
+    }
+}
+
+pub(crate) use imp::Metrics;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn go_histogram_boundaries_match_reference() {
+        assert_eq!(
+            LATENCY_BUCKETS_MILLIS,
+            &[
+                0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1_000.0,
+                2_000.0, 5_000.0, 10_000.0, 20_000.0, 50_000.0,
+            ]
+        );
+        assert_eq!(
+            SIZE_BUCKETS_BYTES,
+            &[
+                16.0,
+                32.0,
+                64.0,
+                128.0,
+                256.0,
+                512.0,
+                1_024.0,
+                2_048.0,
+                4_096.0,
+                8_192.0,
+                16_384.0,
+                32_768.0,
+                65_536.0,
+                131_072.0,
+                262_144.0,
+                524_288.0,
+                1_048_576.0,
+                2_097_152.0,
+                4_194_304.0,
+                8_388_608.0,
+            ]
+        );
+        assert_eq!(
+            COUNT_BUCKETS,
+            &[
+                1.0,
+                5.0,
+                10.0,
+                20.0,
+                50.0,
+                100.0,
+                200.0,
+                500.0,
+                1_000.0,
+                10_000.0,
+                20_000.0,
+                50_000.0,
+                100_000.0,
+                1_000_000.0,
+            ]
+        );
+    }
+
+    #[test]
+    fn key_not_found_get_is_success_for_metrics() {
+        let result = Err(Error::Oxia(OxiaError::KeyNotFound));
+        assert_eq!(get_result_kind(&result), ResultKind::Success);
+    }
+}

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -62,6 +62,7 @@ use crate::SecondaryIndex;
 use crate::batch_get;
 use crate::config;
 use crate::create_grpc_client;
+use crate::metrics;
 use crate::pool::ChannelPool;
 
 #[repr(transparent)]
@@ -289,6 +290,7 @@ fn apply_leader_hint_to_directory(leaders: &LeaderDirectory, hint: &crate::Leade
 #[derive(Debug)]
 struct ClientData {
     config: Arc<config::Config>,
+    metrics: metrics::Metrics,
     channel_pool: ChannelPool,
     shard_id: ShardId,
     /// Shared reference to leader directory - enables dynamic leader lookup.
@@ -302,7 +304,7 @@ struct ClientData {
 }
 
 impl ClientData {
-    const fn new(
+    fn new(
         config: Arc<config::Config>,
         channel_pool: ChannelPool,
         shard_id: ShardId,
@@ -310,8 +312,13 @@ impl ClientData {
         meta: tonic::metadata::MetadataMap,
         cancel_token: CancellationToken,
     ) -> Self {
+        #[cfg(feature = "metrics")]
+        let metrics = metrics::Metrics::new(config.meter_provider());
+        #[cfg(not(feature = "metrics"))]
+        let metrics = metrics::Metrics::new(None);
         Self {
             config,
+            metrics,
             channel_pool,
             shard_id,
             leaders,
@@ -742,11 +749,13 @@ impl Client {
         write_req: oxia_proto::WriteRequest,
     ) -> Result<oxia_proto::WriteResponse> {
         let data = &self.data;
+        let total_start = metrics::batch_start();
 
         let write_req = oxia_proto::WriteRequest {
             shard: Some(data.shard_id.0),
             ..write_req
         };
+        let (value_size, request_count) = write_metrics(&write_req);
 
         // Create a channel for the write stream with a buffer of 1 (only sending one request)
         let (tx, rx) = tokio::sync::mpsc::channel(1);
@@ -763,33 +772,49 @@ impl Client {
         let req = self.create_request(write_stream);
 
         // Get response stream with better error handling
-        let mut resp_stream = self
+        let exec_start = metrics::batch_start();
+        let rpc_result = self
             .rpc(|mut grpc| async move { grpc.write_stream(req).await })
-            .await?
-            .into_inner();
+            .await;
+        let exec_duration = metrics::batch_exec_duration(exec_start);
+        let result = async {
+            let mut resp_stream = rpc_result?.into_inner();
 
-        // Get first response
-        let write_response = match resp_stream.next().await {
-            Some(Ok(response)) => response,
-            Some(Err(err)) => return Err(err.into()),
-            None => {
-                return Err(Error::Custom(
-                    "Server returned no write response".to_string(),
-                ));
+            // Get first response
+            let write_response = match resp_stream.next().await {
+                Some(Ok(response)) => response,
+                Some(Err(err)) => return Err(err.into()),
+                None => {
+                    return Err(Error::Custom(
+                        "Server returned no write response".to_string(),
+                    ));
+                }
+            };
+
+            // Close the stream by dropping the sender
+            drop(tx);
+
+            // Verify we received only one response
+            if let Some(response) = resp_stream.next().await {
+                return Err(Error::Custom(format!(
+                    "Expected exactly one response, but got additional response: {response:?}"
+                )));
             }
-        };
 
-        // Close the stream by dropping the sender
-        drop(tx);
-
-        // Verify we received only one response
-        if let Some(response) = resp_stream.next().await {
-            return Err(Error::Custom(format!(
-                "Expected exactly one response, but got additional response: {response:?}"
-            )));
+            Ok(write_response)
         }
-
-        Ok(write_response)
+        .await;
+        metrics::record_batch(
+            &data.metrics,
+            data.config.namespace(),
+            metrics::Operation::Put,
+            metrics::result_kind(&result),
+            total_start,
+            exec_duration,
+            value_size,
+            request_count,
+        );
+        result
     }
 
     /// Retrieves a key with the given options
@@ -831,10 +856,13 @@ impl Client {
         })?)
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn demux_stream(
         context: Arc<ClientData>,
         keys: Vec<Arc<str>>,
         read_response: Result<tonic::Response<Streaming<oxia_proto::ReadResponse>>>,
+        total_start: metrics::BatchStart,
+        exec_duration: metrics::BatchExecDuration,
     ) -> impl Stream<Item = batch_get::ResponseItem> {
         enum State {
             Demuxing {
@@ -849,24 +877,69 @@ impl Client {
         }
 
         let keys_iter = keys.into_iter();
-        let state = match read_response {
+        let (result_kind, value_size, request_count, state) = match read_response {
             Ok(s) => match s.into_inner().next().await {
-                Some(Ok(rr)) => State::Demuxing {
-                    context,
-                    keys_iter,
-                    gets_iter: rr.gets.into_iter(),
-                },
-                Some(Err(status)) => State::Failing {
-                    keys_iter,
-                    err: status.into(),
-                },
-                None => State::Failing {
-                    keys_iter,
-                    err: no_response_error(context.get_leader().as_deref(), context.shard_id),
-                },
+                Some(Ok(rr)) => {
+                    let (value_size, request_count) = read_metrics(&rr);
+                    (
+                        metrics::ResultKind::Success,
+                        value_size,
+                        request_count,
+                        State::Demuxing {
+                            context: Arc::clone(&context),
+                            keys_iter,
+                            gets_iter: rr.gets.into_iter(),
+                        },
+                    )
+                }
+                Some(Err(status)) => {
+                    let request_count = keys_iter.len() as u64;
+                    (
+                        metrics::ResultKind::Failure,
+                        0,
+                        request_count,
+                        State::Failing {
+                            keys_iter,
+                            err: status.into(),
+                        },
+                    )
+                }
+                None => {
+                    let request_count = keys_iter.len() as u64;
+                    (
+                        metrics::ResultKind::Failure,
+                        0,
+                        request_count,
+                        State::Failing {
+                            keys_iter,
+                            err: no_response_error(
+                                context.get_leader().as_deref(),
+                                context.shard_id,
+                            ),
+                        },
+                    )
+                }
             },
-            Err(err) => State::Failing { keys_iter, err },
+            Err(err) => {
+                let request_count = keys_iter.len() as u64;
+                (
+                    metrics::ResultKind::Failure,
+                    0,
+                    request_count,
+                    State::Failing { keys_iter, err },
+                )
+            }
         };
+        metrics::record_batch(
+            &context.metrics,
+            context.config.namespace(),
+            metrics::Operation::Get,
+            result_kind,
+            total_start,
+            exec_duration,
+            value_size,
+            request_count,
+        );
 
         futures::stream::unfold(state, move |mut state| async move {
             loop {
@@ -919,6 +992,7 @@ impl Client {
         &self,
         batch_req: batch_get::Request,
     ) -> impl Stream<Item = batch_get::ResponseItem> + use<> {
+        let total_start = metrics::batch_start();
         let opts = match batch_req.opts {
             Some(o) => o.into(),
             None => GetOptions::default(),
@@ -935,23 +1009,43 @@ impl Client {
             gets,
         };
 
+        let exec_start = metrics::batch_start();
         let read_result = self
             .rpc(|mut grpc| {
                 let req = read_req.clone();
                 async move { grpc.read(req).await }
             })
             .await;
+        let exec_duration = metrics::batch_exec_duration(exec_start);
 
         let read_result = match read_result {
             Err(Error::OxiaRpc(OxiaRpcError::NodeIsNotLeader { hint: Some(hint) })) => {
                 self.apply_leader_hint(&hint);
-                self.rpc(|mut grpc| async move { grpc.read(read_req).await })
-                    .await
+                let exec_start = metrics::batch_start();
+                let retry_result = self
+                    .rpc(|mut grpc| async move { grpc.read(read_req).await })
+                    .await;
+                let retry_exec_duration = metrics::batch_exec_duration(exec_start);
+                return Self::demux_stream(
+                    Arc::clone(&self.data),
+                    batch_req.keys,
+                    retry_result,
+                    total_start,
+                    retry_exec_duration,
+                )
+                .await;
             }
             other => other,
         };
 
-        Self::demux_stream(Arc::clone(&self.data), batch_req.keys, read_result).await
+        Self::demux_stream(
+            Arc::clone(&self.data),
+            batch_req.keys,
+            read_result,
+            total_start,
+            exec_duration,
+        )
+        .await
     }
 
     /// Puts a value with the given options
@@ -1102,6 +1196,23 @@ impl Client {
             .await?;
         Ok(NotificationsStream::from_proto(rsp.into_inner()))
     }
+}
+
+fn write_metrics(request: &oxia_proto::WriteRequest) -> (u64, u64) {
+    let value_size = request.puts.iter().map(|put| put.value.len() as u64).sum();
+    let request_count =
+        (request.puts.len() + request.deletes.len() + request.delete_ranges.len()) as u64;
+    (value_size, request_count)
+}
+
+fn read_metrics(response: &oxia_proto::ReadResponse) -> (u64, u64) {
+    let value_size = response
+        .gets
+        .iter()
+        .map(|get| get.value.as_ref().map_or(0, bytes::Bytes::len) as u64)
+        .sum();
+    let request_count = response.gets.len() as u64;
+    (value_size, request_count)
 }
 
 /// Trait for a shardfmapping strategy.

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -18,8 +18,10 @@ clap_complete = "4.6.5"
 futures = "0.3.32"
 hex = "0.4.3"
 humantime = "2.3.0"
-mauricebarnum-oxia-client = { path = "../client" }
+mauricebarnum-oxia-client = { path = "../client", features = ["metrics"] }
 num_cpus = "1.17.0"
+opentelemetry-stdout = { version = "0.27.0", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.27.0", default-features = false, features = ["metrics"] }
 rustyline = "18.0.0"
 shlex = "2.0.1"
 thiserror = "2.0.18"

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -21,7 +21,10 @@ humantime = "2.3.0"
 mauricebarnum-oxia-client = { path = "../client", features = ["metrics"] }
 num_cpus = "1.17.0"
 opentelemetry-stdout = { version = "0.27.0", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.27.0", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.27.0", default-features = false, features = [
+    "metrics",
+    "spec_unstable_metrics_views",
+] }
 rustyline = "18.0.0"
 shlex = "2.0.1"
 thiserror = "2.0.18"

--- a/cmd/src/context.rs
+++ b/cmd/src/context.rs
@@ -31,13 +31,14 @@ pub struct Context {
 }
 
 impl Context {
-    pub(super) fn new(cli: &crate::Cli) -> Self {
+    pub(super) fn new(cli: &crate::Cli, metrics: Option<&crate::metrics::MetricsOutput>) -> Self {
         let config = config::Config::builder()
             .service_addr(cli.service_address.clone())
             .max_parallel_requests(cli.max_parallel_requests)
             .session_timeout(cli.session_timeout)
             .request_timeout(cli.request_timeout)
             .retry_on_stale_shard_map(cli.retry_on_stale_shard_map)
+            .maybe_meter_provider(metrics.map(crate::metrics::MetricsOutput::meter_provider))
             .build();
 
         let client = Client::new(config);

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -27,6 +27,9 @@ use context::Context;
 mod log;
 use log::LogArgs;
 
+mod metrics;
+use metrics::MetricsOutput;
+
 mod utils;
 
 #[derive(Parser)]
@@ -52,6 +55,9 @@ pub struct Cli {
 
     #[arg(long, default_value_t = false)]
     retry_on_stale_shard_map: bool,
+
+    #[arg(long, default_value_t = false)]
+    metrics: bool,
 }
 
 #[tokio::main]
@@ -59,6 +65,16 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     cli.log.setup("off")?;
 
-    let ctx = Context::new(&cli);
-    cli.command.run(ctx).await
+    let metrics = cli.metrics.then(MetricsOutput::new);
+    let ctx = Context::new(&cli, metrics.as_ref());
+    let result = cli.command.run(ctx).await;
+
+    if let Some(m) = metrics {
+        m.export()
+            .await
+            .inspect_err(|e| eprintln!("failed to export metrics: {e:#}"))
+            .ok();
+    }
+
+    result
 }

--- a/cmd/src/metrics.rs
+++ b/cmd/src/metrics.rs
@@ -1,0 +1,106 @@
+// Copyright 2026 Maurice S. Barnum
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::sync::Weak;
+
+use anyhow::Context as _;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::InstrumentKind;
+use opentelemetry_sdk::metrics::ManualReader;
+use opentelemetry_sdk::metrics::MetricResult;
+use opentelemetry_sdk::metrics::Pipeline;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::Temporality;
+use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+use opentelemetry_sdk::metrics::reader::MetricReader;
+
+#[derive(Debug)]
+pub struct MetricsOutput {
+    provider: SdkMeterProvider,
+    reader: SharedManualReader,
+    exporter: opentelemetry_stdout::MetricExporter,
+}
+
+impl MetricsOutput {
+    pub fn new() -> Self {
+        let exporter = opentelemetry_stdout::MetricExporter::default();
+        let reader = SharedManualReader::new(
+            ManualReader::builder()
+                .with_temporality(exporter.temporality())
+                .build(),
+        );
+        let provider = SdkMeterProvider::builder()
+            .with_reader(reader.clone())
+            .build();
+        Self {
+            provider,
+            reader,
+            exporter,
+        }
+    }
+
+    pub fn meter_provider(&self) -> crate::client_lib::config::MeterProviderHandle {
+        Arc::new(self.provider.clone())
+    }
+
+    pub async fn export(self) -> anyhow::Result<()> {
+        let mut metrics = ResourceMetrics {
+            resource: Resource::empty(),
+            scope_metrics: Vec::new(),
+        };
+        self.reader
+            .collect(&mut metrics)
+            .context("failed to collect metrics")?;
+        self.exporter
+            .export(&mut metrics)
+            .await
+            .context("failed to export metrics to stdout")?;
+        self.provider
+            .shutdown()
+            .context("failed to shut down metrics provider")
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SharedManualReader(Arc<ManualReader>);
+
+impl SharedManualReader {
+    fn new(reader: ManualReader) -> Self {
+        Self(Arc::new(reader))
+    }
+}
+
+impl MetricReader for SharedManualReader {
+    fn register_pipeline(&self, pipeline: Weak<Pipeline>) {
+        self.0.register_pipeline(pipeline);
+    }
+
+    fn collect(&self, rm: &mut ResourceMetrics) -> MetricResult<()> {
+        self.0.collect(rm)
+    }
+
+    fn force_flush(&self) -> MetricResult<()> {
+        self.0.force_flush()
+    }
+
+    fn shutdown(&self) -> MetricResult<()> {
+        self.0.shutdown()
+    }
+
+    fn temporality(&self, kind: InstrumentKind) -> Temporality {
+        self.0.temporality(kind)
+    }
+}

--- a/cmd/src/metrics.rs
+++ b/cmd/src/metrics.rs
@@ -17,15 +17,30 @@ use std::sync::Weak;
 
 use anyhow::Context as _;
 use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::Aggregation;
+use opentelemetry_sdk::metrics::Instrument;
 use opentelemetry_sdk::metrics::InstrumentKind;
 use opentelemetry_sdk::metrics::ManualReader;
 use opentelemetry_sdk::metrics::MetricResult;
 use opentelemetry_sdk::metrics::Pipeline;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::Stream;
 use opentelemetry_sdk::metrics::Temporality;
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
 use opentelemetry_sdk::metrics::reader::MetricReader;
+
+const EXPONENTIAL_HISTOGRAM_MAX_SIZE: u32 = 160;
+const EXPONENTIAL_HISTOGRAM_MAX_SCALE: i8 = 20;
+
+const HISTOGRAM_NAMES: &[&str] = &[
+    "db.client.operation.duration",
+    "db.client.operation.size",
+    "db.client.batch.duration",
+    "db.client.batch.exec_duration",
+    "db.client.batch.size",
+    "db.client.batch.request_count",
+];
 
 #[derive(Debug)]
 pub struct MetricsOutput {
@@ -44,6 +59,7 @@ impl MetricsOutput {
         );
         let provider = SdkMeterProvider::builder()
             .with_reader(reader.clone())
+            .with_view(exponential_histogram_view)
             .build();
         Self {
             provider,
@@ -73,6 +89,27 @@ impl MetricsOutput {
             .context("failed to shut down metrics provider")
     }
 }
+
+fn exponential_histogram_view(instrument: &Instrument) -> Option<Stream> {
+    (instrument.kind == Some(InstrumentKind::Histogram)
+        && HISTOGRAM_NAMES.contains(&instrument.name.as_ref()))
+    .then(|| {
+        Stream::new()
+            .name(instrument.name.clone())
+            .description(instrument.description.clone())
+            .unit(instrument.unit.clone())
+            .aggregation(Aggregation::Base2ExponentialHistogram {
+                max_size: EXPONENTIAL_HISTOGRAM_MAX_SIZE,
+                max_scale: EXPONENTIAL_HISTOGRAM_MAX_SCALE,
+                record_min_max: false,
+            })
+    })
+}
+
+// SharedManualReader is a wrapper to address ownership issues with the
+// MeterProvider builder, that takes ownership of a MetricReader. But we
+// need to keep a reference for collecting the metrics at program shutdown,
+// hence this Arc wrapper.
 
 #[derive(Clone, Debug)]
 struct SharedManualReader(Arc<ManualReader>);

--- a/otel-instrumentation-design.md
+++ b/otel-instrumentation-design.md
@@ -1,0 +1,422 @@
+# OpenTelemetry Instrumentation Design: Rust Oxia Client
+
+This document provides a detailed design and implementation specification for adding OpenTelemetry (OTel) instrumentation (spans, metrics, and structured logs) to the Rust Oxia client library (`client` crate).
+
+---
+
+# Part A: Design Narrative (For Human Review)
+
+## 1. Executive Summary
+
+- **Proposed:** This design defines a standard, idiomatic telemetry layer for the Rust Oxia client library (`client` crate), aligned with OpenTelemetry Semantic Conventions version `v1.41.0`.
+- **Proposed:** Telemetry will include:
+  - **Traces (Spans):** High-level client operation boundaries (e.g., `get`, `put`, `delete`, etc.), client connection, background task events (discovery refreshes, heartbeat loops), and lower-level gRPC RPC calls.
+  - **Metrics:** Client operation latencies, batching latencies, value/payload sizes, and request counts, ensuring behavioral and namespacing consistency with the Go reference library (`ext/oxia`).
+  - **Logs:** Structured log correlation linking existing logging calls to active spans.
+- **Proposed:** The following are out of scope:
+  - Configuring exporters, tracing subscribers, or SDK pipelines within the library. The client library will only depend on telemetry APIs/facades.
+  - System-level resource monitoring (CPU, memory), which is the responsibility of the server or the consumer application.
+
+---
+
+## 2. Repository Findings
+
+### 2.1 Rust Crate Inventory
+
+- **Observed:** **Public API Surface** (`client/src/lib.rs`):
+  - `Client::new(config: Arc<config::Config>) -> Self` (line 869)
+  - `Client::connect(&mut self) -> Result<()>` (line 886)
+  - `Client::reconnect(&mut self) -> impl Future<Output = Result<()>>` (line 895)
+  - `Client::get(&self, k: impl Into<String>) -> impl Future<Output = Result<Option<GetResponse>>>` (line 960)
+  - `Client::get_with_options(&self, key: impl Into<String>, options: GetOptions) -> impl Future<Output = Result<Option<GetResponse>>>` (line 965)
+  - `Client::batch_get(&self, req: batch_get::Request) -> Result<impl Stream<Item = batch_get::ResponseItem>>` (line 1031)
+  - `Client::put(&self, key: impl Into<String>, value: impl Into<Bytes>) -> impl Future<Output = Result<PutResponse>>` (line 1087)
+  - `Client::put_with_options(&self, key: impl Into<String>, value: impl Into<Bytes>, options: PutOptions) -> impl Future<Output = Result<PutResponse>>` (line 1096)
+  - `Client::delete(&self, key: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1124)
+  - `Client::delete_with_options(&self, key: impl Into<String>, options: DeleteOptions) -> impl Future<Output = Result<()>>` (line 1128)
+  - `Client::delete_range(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1150)
+  - `Client::delete_range_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: DeleteRangeOptions) -> impl Future<Output = Result<()>>` (line 1163)
+  - `Client::list(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<ListResponse>>` (line 1242)
+  - `Client::list_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: ListOptions) -> impl Future<Output = Result<ListResponse>>` (line 1251)
+  - `Client::range_scan(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<RangeScanResponse>>` (line 1325)
+  - `Client::range_scan_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: RangeScanOptions) -> impl Future<Output = Result<RangeScanResponse>>` (line 1334)
+  - `Client::create_notifications_stream(&self) -> Result<NotificationsStream>` (line 1408)
+  - `Client::create_notifications_stream_with_options(&self, options: NotificationsOptions) -> Result<NotificationsStream>` (line 1413)
+- **Observed:** **Async Entry Points:**
+  - `Client::connect` (file `client/src/lib.rs`, line 886)
+  - `Client::get_internal` (file `client/src/lib.rs`, line 973)
+  - `Client::put_internal` (file `client/src/lib.rs`, line 1105)
+  - `Client::delete_internal` (file `client/src/lib.rs`, line 1137)
+  - `Client::delete_range_internal` (file `client/src/lib.rs`, line 1176)
+  - `Client::list_internal` (file `client/src/lib.rs`, line 1264)
+  - `Client::range_scan_internal` (file `client/src/lib.rs`, line 1347)
+  - `shard::Client::get` (file `client/src/shard.rs`, line 796)
+  - `shard::Client::put` (file `client/src/shard.rs`, line 958)
+  - `shard::Client::delete` (file `client/src/shard.rs`, line 984)
+  - `shard::Client::delete_range` (file `client/src/shard.rs`, line 996)
+  - `shard::Client::list` (file `client/src/shard.rs`, line 1009)
+  - `shard::Client::range_scan` (file `client/src/shard.rs`, line 1059)
+  - `shard::Client::get_notifications` (file `client/src/shard.rs`, line 1091)
+  - `shard::Client::create_session` (file `client/src/shard.rs`, line 579)
+- **Observed:** **Background Tasks:**
+  - Shard assignment syncing loop `ShardAssignmentTask::run` (file `client/src/shard.rs`, line 1642)
+  - Session heartbeat loop task spawned in `Client::start_heartbeat` (file `client/src/shard.rs`, line 483)
+  - Notification stream change listener task spawned in `NotificationsStream::new` (file `client/src/notification.rs`, line 163)
+- **Observed:** **Retry Loops:**
+  - Transient/timeout retries in `execute_with_retry` (file `client/src/lib.rs`, line 741)
+  - Wrong-leader routing retries in `stale_shard_map_retry` (file `client/src/lib.rs`, line 803)
+  - Shard assignment stream reconnection loop in `ShardAssignmentTask::get_stream` (file `client/src/shard.rs`, line 1611)
+- **Observed:** **Network Operations:**
+  - Connecting gRPC channel in `ChannelPool::get` (file `client/src/pool.rs`, line 177)
+  - Tonic gRPC calls:
+    - `get_shard_assignments` (file `client/src/shard.rs`, line 1596)
+    - `create_session` (file `client/src/shard.rs`, line 587)
+    - `keep_alive` (file `client/src/shard.rs`, line 524)
+    - `write_stream` (file `client/src/shard.rs`, line 767)
+    - `read` (file `client/src/shard.rs`, line 799)
+    - `list` (file `client/src/shard.rs`, line 1020)
+    - `range_scan` (file `client/src/shard.rs`, line 1071)
+    - `get_notifications` (file `client/src/shard.rs`, line 1101)
+    - `list_nodes` (file `client/src/discovery.rs`, line 109)
+- **Observed:** **Streaming Operations:**
+  - Shard assignment updates stream `Streaming<oxia_proto::ShardAssignments>` (file `client/src/shard.rs`, line 1559)
+  - Notifications stream `Streaming<oxia_proto::NotificationBatch>` (file `client/src/shard.rs`, line 1445)
+  - `batch_get` result stream demuxing `demux_stream` (file `client/src/shard.rs`, line 834)
+- **Observed:** **Batching Operations:**
+  - Multi-key read batching in `Client::batch_get` (file `client/src/lib.rs`, line 1031)
+- **Observed:** **Error Types** (`client/src/errors.rs`):
+  - `Error` (line 320), `OxiaError` (line 31), `OxiaRpcError` (line 61), `ClientError` (line 233), `ServerError` (line 278), `ShardError` (line 304).
+- **Observed:** **Concurrency Boundaries:**
+  - `ArcSwap` for lock-free state swaps (file `client/src/pool.rs`, line 69; file `client/src/shard.rs`, line 1665, 1666)
+  - `Mutex` for synchronizing channel creations (file `client/src/pool.rs`, line 70)
+  - `OnceCell` for lazy session creation (file `client/src/shard.rs`, line 332, 598)
+  - `watch::Sender` / `watch::Receiver` for notifying updates (file `client/src/shard.rs`, line 1669, 1808)
+  - `tokio::sync::Notify` for refresh signals (file `client/src/shard.rs`, line 1670, 1819)
+- **Observed:** **Task Spawning Boundaries:**
+  - Spawning heartbeat loops (file `client/src/shard.rs`, line 483)
+  - Spawning assignment sync loops (file `client/src/shard.rs`, line 1821)
+  - Spawning configuration watcher tasks (file `client/src/notification.rs`, line 163)
+- **Observed:** **Cancellation Semantics:**
+  - Background loops are monitored by `CancellationToken` (file `client/src/shard.rs`, line 298, 1667; file `client/src/notification.rs`, line 150) and handles are aborted on drop.
+- **Observed:** **Existing Telemetry Hooks:**
+  - Crate depends on `tracing` (file `client/Cargo.toml`, line 15) and logs extensively via `info!`, `warn!`, `debug!`, `error!`, and `trace!`.
+
+### 2.2 Go Reference Instrumentation Inventory
+
+- **Observed:** **Metrics** (`ext/oxia/oxia/internal/metrics/metrics.go`):
+  - `oxia_client_op` (Timer: sum counter and count counter): records call latency.
+  - `oxia_client_op_value` (Histogram, unit: `"By"`): records KV size for `put` and `get`.
+  - `oxia_client_batch_total` (Timer: sum counter and count counter): records time from request queueing to response.
+  - `oxia_client_batch_exec` (Timer: sum counter and count counter): records time elapsed during batch execution.
+  - `oxia_client_batch_value` (Histogram, unit: `"By"`): records total bytes processed in a batch.
+  - `oxia_client_batch_request` (Histogram): records count of requests inside a batch.
+  - Attributes registered per metric: `"type"` (operation name, e.g., `"get"`, `"put"`) and `"result"` (`"success"` or `"failure"`).
+- **Observed:** **Traces (Spans):**
+  - The Go client has no tracing instrumentation. `go.opentelemetry.io/otel/trace` is only listed as an `// indirect` dependency in `ext/oxia/oxia/go.mod` (line 40).
+- **Observed:** **Structured Log Events:**
+  - Go client uses structured logging (`log/slog`) for system state:
+    - retry warnings (file `ext/oxia/oxia/async_client_impl.go`, line 433, 531)
+    - notification events (file `ext/oxia/oxia/cache.go`, line 156)
+    - batch rerouting notices (file `ext/oxia/oxia/internal/batch/read_batch.go`, line 96; file `ext/oxia/oxia/internal/batch/write_batch.go`, line 117)
+    - connection warning/errors (file `ext/oxia/oxia/internal/executor.go`, line 153)
+
+### 2.3 Cross-Language Mapping and Differences
+
+- **Observed:** **Go-to-Rust Equivalency mapping:**
+  - `DecoratePut` / `DecorateGet` / `DecorateDelete` -> Map directly to wrapping `Client::put_internal`, `Client::get_internal`, `Client::delete_internal` and `Client::batch_get` operations in `client/src/lib.rs`.
+  - `WriteCallback` / `ReadCallback` -> Maps to wrappers around `shard::Client::process_write` and `shard::Client::get`/`batch_get` (file `client/src/shard.rs`).
+- **Observed:** **Rust operations with no Go equivalent:**
+  - `Client::connect` (file `client/src/lib.rs`, line 886) - Go client performs lazy connection at executor level.
+  - `Client::reconnect` (file `client/src/lib.rs`, line 895).
+  - `stale_shard_map_retry` (file `client/src/lib.rs`, line 803) - explicit stale-map wait loop in Rust client.
+- **Observed:** **Go instrumentation with no Rust equivalent:**
+  - Go's custom `Timer` metric type (split into a sum Float64Counter and a count Int64Counter under the same name).
+  - Go's unstructured/slog logger. Rust utilizes `tracing` exclusively.
+
+---
+
+## 3. Goals, Constraints, and Assumptions
+
+### 3.1 Telemetry Framework Choice
+
+- **Proposed:** The library will use the **`tracing` crate** (already present in `client/Cargo.toml#L15`) as its tracing and logging facade, and the **`opentelemetry` API crate** (with the `metric` feature) as its metrics facade.
+- **Justification:**
+  1. The `tracing` crate is the de facto standard in Rust. Using it ensures all spans and logs integrate out-of-the-box with downstream subscriber ecosystems (such as `tracing-opentelemetry`).
+  2. Direct instrumentation using the `opentelemetry` tracing API inside a Rust library requires handling a heavy API layer, which is less idiomatic and more difficult to format and correlate than Rust's native `tracing::Span` structures.
+  3. Spans can be bridged downstream using the standard `tracing-opentelemetry` subscriber.
+- **Proposed:** The library will interact only with the _facade/API layers_ (`tracing` and `opentelemetry::metric`). It will not instantiate or configure exporters, tracer providers, or meter providers internally, but it _will_ support user-supplied `MeterProvider` configurations.
+- **Assumption:** If no OTel SDK or `tracing` subscriber is registered by the parent application, all instrumentation calls compile down to no-ops with negligible runtime overhead.
+- **Proposed:** To ensure zero overhead when telemetry is disabled, the OTel metrics logic will be conditionally compiled behind a feature flag (see Section 8).
+
+---
+
+## 4. Instrumentation Boundaries
+
+### 4.1 Boundary Scope
+
+- **Proposed:** **Instrumented operations:**
+  - `Client::connect` and `Client::reconnect` (to track cluster connectivity).
+  - Main KV API entry points (`get`, `put`, `delete`, `delete_range`, `list`, `range_scan`, `batch_get`).
+  - Coordinator discovery requests (`discovery::CoordinatorServiceDiscovery::addresses`).
+  - Heartbeat loop cycles (to monitor session health).
+  - Background shard assignment sync loop runs.
+- **Proposed:** **Explicitly non-instrumented operations:**
+  - Lower-level internal utilities (`util::with_timeout`, `util::with_retry`) to avoid duplicate spans. Span details will instead be captured as attributes or retry events on the parent operation span.
+
+### 4.2 Architectural Design Decisions
+
+- **Decision 1: Spans representation**
+  - **Selected Approach:** Maintain spans using `tracing::Span` and rely on downstream `tracing-opentelemetry` for OTel exporting.
+  - **Rejected Alternative:** Directly use the `opentelemetry::trace::Tracer` API in-crate.
+  - **Reason for Rejection:** Direct OTel trace API makes logs harder to correlate and diverges from the existing `tracing` macros already used in the codebase.
+- **Decision 2: Latency metrics implementation**
+  - **Selected Approach:** Use OTel `Histogram` for operation latencies.
+  - **Rejected Alternative:** Translate Go's dual-counter Timer approach literally (making a count counter and a latency sum counter).
+  - **Reason for Rejection:** A dual-counter Timer is not idiomatic in modern OpenTelemetry and is rejected by the OTel API in favor of histograms, which natively provide percentiles, counts, and sums.
+
+---
+
+## 5. Tracing and Logging Design
+
+### 5.1 Naming and Scope
+
+- **Proposed:** The tracer/telemetry scope name will be `"mauricebarnum_oxia_client"`.
+- **Proposed:** Spans will map to operations:
+  - `"client.connect"` (SpanKind::Client)
+  - `"db.operation.get"` (SpanKind::Client)
+  - `"db.operation.put"` (SpanKind::Client)
+  - `"db.operation.delete"` (SpanKind::Client)
+  - `"db.operation.delete_range"` (SpanKind::Client)
+  - `"db.operation.list"` (SpanKind::Client)
+  - `"db.operation.range_scan"` (SpanKind::Client)
+  - `"db.operation.batch_get"` (SpanKind::Client)
+  - `"shard.heartbeat"` (SpanKind::Internal)
+  - `"shard.assignment_sync"` (SpanKind::Internal)
+
+### 5.2 Attributes (OpenTelemetry Semantic Conventions v1.41.0)
+
+- **Proposed:** All spans representing database operations must carry:
+  - `db.system`: `"oxia"` (static string)
+  - `db.name`: Namespace name from configuration (e.g., `"default"`)
+  - `db.operation`: Operation identifier (`"get"`, `"put"`, `"delete"`, etc.)
+  - `db.oxia.shard_id`: The ID of the shard targeted by the routing key
+  - `server.address`: Leader endpoint host (if resolved)
+  - `server.port`: Leader endpoint port
+  - `error.type`: The error string code on failure (e.g., `"KeyNotFound"`, `"TransportError"`)
+
+### 5.3 Error and Status Rules
+
+- **Proposed:** If an operation returns an `Err(Error::Oxia(OxiaError::KeyNotFound))` on a `get` operation, the span status remains `Ok` (this is a standard lookup result, not a system failure).
+- **Proposed:** For all other `Err` results, the span status must be set to `Error`, and the error description must be recorded in the `exception.message` event.
+- **Proposed:** Panics must be caught using `std::panic::AssertUnwindSafe` to set the span status to `Error` before resuming panic propagation.
+
+### 5.4 Sampling and Logging Integration
+
+- **Proposed:** Attributes requiring allocations (like formatting the server address) must be lazily computed only if the span is active (`Span::is_disabled` checks).
+- **Proposed:** Existing logs will automatically inherit `trace_id` and `span_id` context when executed within the scope of active tracing spans.
+
+---
+
+## 6. Metrics Design
+
+### 6.1 Metrics Specifications
+
+- **Proposed:** The client will register the following metrics:
+  
+  - `"oxia.client.op.size"` (Histogram, unit: `"By"`): Measures payload sizes of `put` values and `get` returned values.
+  - `"oxia.client.batch.total_duration"` (Histogram, unit: `"s"`): Measures total duration of batched requests (queueing + execution).
+  - `"oxia.client.batch.exec_duration"` (Histogram, unit: `"s"`): Measures actual network execution duration of batches.
+  - `"oxia.client.batch.size"` (Histogram, unit: `"By"`): Measures total payload size in a batch.
+  - `"oxia.client.batch.request_count"` (Histogram, unit: `"1"`): Measures count of operations packed in a batch.
+
+### 6.2 Attributes and Bounded Cardinality
+
+- **Proposed:** All metrics will utilize the following dimensions:
+  - `db.system`: Bounded (Value: `"oxia"`)
+  - `db.name` (Namespace): Bounded (Value from config)
+  - `db.operation`: Bounded (Values: `"get"`, `"put"`, `"delete"`, etc.)
+  - `db.oxia.shard_id`: Bounded (Values: integers [0 - maximum sharding limit])
+  - `result`: Bounded (Values: `"success"`, `"failure"`)
+- **Proposed:** **Cardinality Risk Flag:** No dynamic, user-provided data (such as keys, values, or raw error messages containing user parameters) may be used as metric dimensions. Recording arbitrary keys as dimensions is strictly prohibited due to infinite cardinality risks.
+
+---
+
+## 7. Context Propagation and Concurrency Design
+
+### 7.1 Context over Boundaries
+
+- **Proposed:** Context enters the client via the implicit thread-local/async `tracing::Span::current()`.
+- **Proposed:** Since `client` operations are async and span boundaries, we must recommend:
+  - **Bridge via `tracing-opentelemetry`**: This handles propagating trace headers over spawned task boundaries (like the heartbeat and discovery tasks) using `tracing` parent span attachment.
+- **Proposed:** For background tasks (`ShardAssignmentTask` and heartbeats), we will construct detached root spans `"shard.assignment_sync"` and `"shard.heartbeat"`.
+- **Proposed:** If a caller cancels an operation future, the corresponding span will record a `"cancelled"` event and close immediately.
+
+---
+
+## 8. Public API and Internal Structure Impact
+
+### 8.1 Feature Gating Decision
+
+- **Proposed:** Recommend **Option B: Feature-gated, opt-in**. Telemetry instrumentation logic (specifically the direct `opentelemetry` metrics API dependency and context-propagation functions) will compile only when downstream crates enable the `telemetry` feature flag.
+- **Rejected Alternative A (Always compiled):** Forces all users to download and compile `opentelemetry` API crates, increasing compile time and dependency trees for minimal-size environments.
+- **Rejected Alternative C (Opt-out):** Violates Rust best practices by enabling a large transitive dependency tree by default.
+
+### 8.2 Dependency and API Impact
+
+- **Proposed:** Add `opentelemetry` (API crate) as an optional dependency under `[dependencies]` in `client/Cargo.toml`.
+- **Proposed:** Add `telemetry` feature to `client/Cargo.toml` enabling the optional dependency.
+- **Proposed:** Expose `meter_provider` setter field on `Config` and `ConfigBuilder` under the `telemetry` feature flag. This allows downstream consumers to explicitly inject custom OTel `MeterProvider` implementations (mapped as `Arc<dyn opentelemetry::metric::MeterProvider + Send + Sync>`). If not set, metrics fallback to `opentelemetry::global::meter_provider()`.
+- **Proposed:** MSRV impact is negligible, as `opentelemetry` supports modern stable Rust compilers matching the workspace's version.
+
+---
+
+## 9. Semantic Conventions and Cross-Language Consistency
+
+- **Proposed:** Align strictly with OTel Semantic Conventions version `v1.41.0` (database client namespace).
+- **Proposed:** Go uses custom counter names `oxia_client_op`. We will export standard semantic convention metric names (`db.client.operation.duration`) by default, but allow custom mappings if required for legacy dashboard compatibility.
+- **Proposed:** **Handling Technology-Agnostic Naming:** To support setups where Oxia serves as an internal coordinator/metadata engine inside a larger database system (similar to etcd/zookeeper configurations):
+  - **Database system isolation:** Differentiating nested telemetry calls (e.g. outer database system client vs inner coordinator/metadata database client) is done purely via attributes. The inner Oxia calls will carry `db.system = "oxia"`, whereas the outer system client calls will carry `db.system = "my_custom_db"`.
+  - **Unified dashboard querying:** Using the standard semantic convention name `db.client.operation.duration` across both clients enables operators to aggregate database latency metrics globally or slice them by `db.system` to analyze the exact overhead contribution of the coordination layer.
+
+---
+
+## 10. Performance and Risk Analysis
+
+- **Proposed:** **Operation Path Classification:**
+  - **Hot path:** `Client::get`, `Client::put`, `Client::delete`, `Client::batch_get`.
+    - _Mitigation:_ Ensure attributes are constructed using static slices or pre-allocated elements. Do not format strings (e.g. `format!("shard-{}", id)`) on these paths.
+  - **Warm path:** `Client::delete_range`, `Client::list`, `Client::range_scan`, `Client::connect`, heartbeats.
+  - **Cold path:** Background task startups, stale map retries.
+
+---
+
+## 11. Rollout and Migration Plan
+
+- **Proposed:** **Phased Approach:**
+  - **Phase 1:** Add optional `telemetry` Cargo feature, introduce the `client/src/telemetry.rs` module, and configure the ZST metrics interface.
+  - **Phase 2:** Instrument tracing spans using `tracing` macros across the KV operations in `lib.rs` and `shard.rs`.
+  - **Phase 3:** Instrument metrics recorders inside the write batch and read batch streams. Expose the `meter_provider` setter on `Config` when the `telemetry` feature flag is active.
+  - **Phase 4:** Instrument background loops (heartbeat and assignment task).
+
+---
+
+## 12. Testing and Validation Strategy
+
+- **Proposed:** Introduce unit tests under `client/tests/` using `otel-test` or `tracing-subscriber` mock layer to verify:
+  - Metric recordings match expected values (counts, sums) on success and failure.
+  - Spans have correct attributes and parent/child relationship.
+  - Custom injected `MeterProvider` receives the expected measurements.
+  - When `telemetry` feature is disabled, tests verify compilation succeeds and no metrics are registered.
+
+---
+
+## 13. Open Questions
+
+- **Reviewer Input Required:**
+  1. Do downstream dashboards expect exact Go-compatible metric names (`oxia_client_op`) or should we migrate to standard OTel `v1.41.0` names (`db.client.operation.duration`)?
+
+---
+
+# Part B: Implementation Handoff Spec
+
+## B.1 Required Decisions
+
+- [x] Utilize the `tracing` crate facade with a target dependency on `tracing-opentelemetry` compatibility; do not take a direct dependency on `opentelemetry-sdk` in the library.
+- [x] Use Option B (Feature-gated, opt-in) via the `telemetry` Cargo feature.
+- [x] Use OTel `Histogram` for operation latencies instead of Go's counter-based timer approach.
+- [x] Prohibit dynamic user keys or values in metric attributes.
+- [x] Expose `meter_provider` setter on the `Config` builder when the `telemetry` feature flag is active.
+
+## B.2 Assumptions
+
+- **MSRV:** Target client's current edition (2021).
+- **Target OTel Version:** `v1.41.0` Semantic Conventions.
+- **Runtime:** Assumes `tokio` multi-threaded executor downstream.
+
+## B.3 Per-Operation Instrumentation Spec
+
+### Summary Mapping Table
+
+| Rust API Entry Point   | Span Name                     | Type (Span Kind)   | Metrics Emitted                                                           | Performance Classification |
+| ---------------------- | ----------------------------- | ------------------ | ------------------------------------------------------------------------- | -------------------------- |
+| `Client::connect`      | `"client.connect"`            | `SpanKind::Client` | —                                                                         | Warm path                  |
+| `Client::get`          | `"db.operation.get"`          | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Hot path                   |
+| `Client::put`          | `"db.operation.put"`          | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Hot path                   |
+| `Client::delete`       | `"db.operation.delete"`       | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Hot path                   |
+| `Client::delete_range` | `"db.operation.delete_range"` | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Warm path                  |
+| `Client::list`         | `"db.operation.list"`         | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Warm path                  |
+| `Client::range_scan`   | `"db.operation.range_scan"`   | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Warm path                  |
+| `Client::batch_get`    | `"db.operation.batch_get"`    | `SpanKind::Client` | `"oxia.client.batch.total_duration"`, `"oxia.client.batch.exec_duration"` | Hot path                   |
+
+---
+
+### Detailed Operation Specifications
+
+##### Operation: `Client::connect`
+
+- **Purpose:** Tracks connection and setup of the client's shard manager.
+- **Span Name:** `"client.connect"`
+- **Span Kind:** `SpanKind::Client`
+- **Parent Context Behavior:** Attaches to implicit parent context.
+- **Attributes:**
+  - `db.system`: `"oxia"`
+  - `db.name`: Namespace name (e.g. `"default"`)
+- **Error / Status Behavior:** Sets status to `Error` if connection to coordinator fails.
+- **Performance Notes:** Warm path, allocates client metadata during connection.
+
+##### Operation: `Client::get`
+
+- **Purpose:** Fetches value for a key.
+- **Span Name:** `"db.operation.get"`
+- **Span Kind:** `SpanKind::Client`
+- **Parent Context Behavior:** Attaches to implicit parent context.
+- **Attributes:**
+  - `db.system`: `"oxia"`
+  - `db.name`: Namespace name
+  - `db.operation`: `"get"`
+  - `db.oxia.shard_id`: Targeted shard ID
+  - `error.type`: Set on failure.
+- **Error / Status Behavior:** `KeyNotFound` is marked `Ok`. Other failures set status to `Error`.
+- **Performance Notes:** Hot path. Minimize dynamic allocations in attributes.
+
+##### Operation: `Client::put`
+
+- **Purpose:** Puts a key-value record.
+- **Span Name:** `"db.operation.put"`
+- **Span Kind:** `SpanKind::Client`
+- **Parent Context Behavior:** Attaches to implicit parent context.
+- **Attributes:**
+  - `db.system`: `"oxia"`
+  - `db.name`: Namespace name
+  - `db.operation`: `"put"`
+  - `db.oxia.shard_id`: Targeted shard ID
+  - `error.type`: Set on failure.
+- **Error / Status Behavior:** Fails with `Error` status on version mismatches or network failures.
+- **Performance Notes:** Hot path. Do not clone payload bytes for attribute logging.
+
+---
+
+## B.4 Metric Inventory
+
+| Metric Name                          | Instrument Type | Unit   | Attributes                                       | Attribute Cardinality | Semantic Convention Version | Lifecycle (init location)   | Cardinality Warnings |
+| ------------------------------------ | --------------- | ------ | ------------------------------------------------ | --------------------- | --------------------------- | --------------------------- | -------------------- |
+| `"oxia.client.op.duration"`          | Histogram       | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
+| `"oxia.client.op.size"`              | Histogram       | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
+| `"oxia.client.batch.total_duration"` | Histogram       | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
+| `"oxia.client.batch.exec_duration"`  | Histogram       | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
+| `"oxia.client.batch.size"`           | Histogram       | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
+| `"oxia.client.batch.request_count"`  | Histogram       | `"1"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
+
+---
+
+## B.5 Module and File Plan
+
+- **[NEW] `client/src/telemetry.rs`**: Contains all metrics wrappers, declarations, and feature-conditional definitions. When `telemetry` feature is off, compile as a zero-overhead ZST.
+- **[MODIFY] `client/Cargo.toml`**:
+  - Add optional dependency `opentelemetry = { version = "0.27.0", features = ["metric"] }` (or matching latest stable version).
+  - Add feature `telemetry = ["dep:opentelemetry"]`.
+- **[MODIFY] `client/src/lib.rs`**:
+  - Integrate operations tracing using `tracing::info_span!` macros inside `put_internal`, `get_internal`, `delete_internal`, etc.
+  - Record execution metrics inside completion handlers.
+- **[MODIFY] `client/src/config.rs`**:
+  - Expose `meter_provider` field under `#[cfg(feature = "telemetry")]` using `Option<Arc<dyn opentelemetry::metric::MeterProvider + Send + Sync>>` with a setter in the `ConfigBuilder`.

--- a/otel-instrumentation-design.md
+++ b/otel-instrumentation-design.md
@@ -7,68 +7,66 @@ This document provides a detailed design and implementation specification for ad
 # Part A: Design Narrative (For Human Review)
 
 ## 1. Executive Summary
-
-- **Proposed:** This design defines a standard, idiomatic telemetry layer for the Rust Oxia client library (`client` crate), aligned with OpenTelemetry Semantic Conventions version `v1.41.0`.
-- **Proposed:** Telemetry will include:
-  - **Traces (Spans):** High-level client operation boundaries (e.g., `get`, `put`, `delete`, etc.), client connection, background task events (discovery refreshes, heartbeat loops), and lower-level gRPC RPC calls.
-  - **Metrics:** Client operation latencies, batching latencies, value/payload sizes, and request counts, ensuring behavioral and namespacing consistency with the Go reference library (`ext/oxia`).
-  - **Logs:** Structured log correlation linking existing logging calls to active spans.
-- **Proposed:** The following are out of scope:
-  - Configuring exporters, tracing subscribers, or SDK pipelines within the library. The client library will only depend on telemetry APIs/facades.
-  - System-level resource monitoring (CPU, memory), which is the responsibility of the server or the consumer application.
+* **Proposed:** This design defines a standard, idiomatic telemetry layer for the Rust Oxia client library (`client` crate), aligned with OpenTelemetry Semantic Conventions version `v1.41.0`.
+* **Proposed:** Telemetry will include:
+  * **Traces (Spans):** High-level client operation boundaries (e.g., `get`, `put`, `delete`, etc.), client connection, background task events (discovery refreshes, heartbeat loops), and lower-level gRPC RPC calls.
+  * **Metrics:** Client operation latencies, batching latencies, value/payload sizes, and request counts, ensuring behavioral and namespacing consistency with the Go reference library (`ext/oxia`).
+  * **Logs:** Structured log correlation linking existing logging calls to active spans.
+* **Proposed:** The following are out of scope:
+  * Configuring exporters, tracing subscribers, or SDK pipelines within the library. The client library will only depend on telemetry APIs/facades.
+  * System-level resource monitoring (CPU, memory), which is the responsibility of the server or the consumer application.
 
 ---
 
 ## 2. Repository Findings
 
 ### 2.1 Rust Crate Inventory
-
-- **Observed:** **Public API Surface** (`client/src/lib.rs`):
-  - `Client::new(config: Arc<config::Config>) -> Self` (line 869)
-  - `Client::connect(&mut self) -> Result<()>` (line 886)
-  - `Client::reconnect(&mut self) -> impl Future<Output = Result<()>>` (line 895)
-  - `Client::get(&self, k: impl Into<String>) -> impl Future<Output = Result<Option<GetResponse>>>` (line 960)
-  - `Client::get_with_options(&self, key: impl Into<String>, options: GetOptions) -> impl Future<Output = Result<Option<GetResponse>>>` (line 965)
-  - `Client::batch_get(&self, req: batch_get::Request) -> Result<impl Stream<Item = batch_get::ResponseItem>>` (line 1031)
-  - `Client::put(&self, key: impl Into<String>, value: impl Into<Bytes>) -> impl Future<Output = Result<PutResponse>>` (line 1087)
-  - `Client::put_with_options(&self, key: impl Into<String>, value: impl Into<Bytes>, options: PutOptions) -> impl Future<Output = Result<PutResponse>>` (line 1096)
-  - `Client::delete(&self, key: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1124)
-  - `Client::delete_with_options(&self, key: impl Into<String>, options: DeleteOptions) -> impl Future<Output = Result<()>>` (line 1128)
-  - `Client::delete_range(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1150)
-  - `Client::delete_range_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: DeleteRangeOptions) -> impl Future<Output = Result<()>>` (line 1163)
-  - `Client::list(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<ListResponse>>` (line 1242)
-  - `Client::list_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: ListOptions) -> impl Future<Output = Result<ListResponse>>` (line 1251)
-  - `Client::range_scan(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<RangeScanResponse>>` (line 1325)
-  - `Client::range_scan_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: RangeScanOptions) -> impl Future<Output = Result<RangeScanResponse>>` (line 1334)
-  - `Client::create_notifications_stream(&self) -> Result<NotificationsStream>` (line 1408)
-  - `Client::create_notifications_stream_with_options(&self, options: NotificationsOptions) -> Result<NotificationsStream>` (line 1413)
-- **Observed:** **Async Entry Points:**
-  - `Client::connect` (file `client/src/lib.rs`, line 886)
-  - `Client::get_internal` (file `client/src/lib.rs`, line 973)
-  - `Client::put_internal` (file `client/src/lib.rs`, line 1105)
-  - `Client::delete_internal` (file `client/src/lib.rs`, line 1137)
-  - `Client::delete_range_internal` (file `client/src/lib.rs`, line 1176)
-  - `Client::list_internal` (file `client/src/lib.rs`, line 1264)
-  - `Client::range_scan_internal` (file `client/src/lib.rs`, line 1347)
-  - `shard::Client::get` (file `client/src/shard.rs`, line 796)
-  - `shard::Client::put` (file `client/src/shard.rs`, line 958)
-  - `shard::Client::delete` (file `client/src/shard.rs`, line 984)
-  - `shard::Client::delete_range` (file `client/src/shard.rs`, line 996)
-  - `shard::Client::list` (file `client/src/shard.rs`, line 1009)
-  - `shard::Client::range_scan` (file `client/src/shard.rs`, line 1059)
-  - `shard::Client::get_notifications` (file `client/src/shard.rs`, line 1091)
-  - `shard::Client::create_session` (file `client/src/shard.rs`, line 579)
-- **Observed:** **Background Tasks:**
-  - Shard assignment syncing loop `ShardAssignmentTask::run` (file `client/src/shard.rs`, line 1642)
-  - Session heartbeat loop task spawned in `Client::start_heartbeat` (file `client/src/shard.rs`, line 483)
-  - Notification stream change listener task spawned in `NotificationsStream::new` (file `client/src/notification.rs`, line 163)
-- **Observed:** **Retry Loops:**
-  - Transient/timeout retries in `execute_with_retry` (file `client/src/lib.rs`, line 741)
-  - Wrong-leader routing retries in `stale_shard_map_retry` (file `client/src/lib.rs`, line 803)
-  - Shard assignment stream reconnection loop in `ShardAssignmentTask::get_stream` (file `client/src/shard.rs`, line 1611)
-- **Observed:** **Network Operations:**
-  - Connecting gRPC channel in `ChannelPool::get` (file `client/src/pool.rs`, line 177)
-  - Tonic gRPC calls:
+* **Observed:** **Public API Surface** (`client/src/lib.rs`):
+  * `Client::new(config: Arc<config::Config>) -> Self` (line 869)
+  * `Client::connect(&mut self) -> Result<()>` (line 886)
+  * `Client::reconnect(&mut self) -> impl Future<Output = Result<()>>` (line 895)
+  * `Client::get(&self, k: impl Into<String>) -> impl Future<Output = Result<Option<GetResponse>>>` (line 960)
+  * `Client::get_with_options(&self, key: impl Into<String>, options: GetOptions) -> impl Future<Output = Result<Option<GetResponse>>>` (line 965)
+  * `Client::batch_get(&self, req: batch_get::Request) -> Result<impl Stream<Item = batch_get::ResponseItem>>` (line 1031)
+  * `Client::put(&self, key: impl Into<String>, value: impl Into<Bytes>) -> impl Future<Output = Result<PutResponse>>` (line 1087)
+  * `Client::put_with_options(&self, key: impl Into<String>, value: impl Into<Bytes>, options: PutOptions) -> impl Future<Output = Result<PutResponse>>` (line 1096)
+  * `Client::delete(&self, key: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1124)
+  * `Client::delete_with_options(&self, key: impl Into<String>, options: DeleteOptions) -> impl Future<Output = Result<()>>` (line 1128)
+  * `Client::delete_range(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1150)
+  * `Client::delete_range_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: DeleteRangeOptions) -> impl Future<Output = Result<()>>` (line 1163)
+  * `Client::list(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<ListResponse>>` (line 1242)
+  * `Client::list_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: ListOptions) -> impl Future<Output = Result<ListResponse>>` (line 1251)
+  * `Client::range_scan(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<RangeScanResponse>>` (line 1325)
+  * `Client::range_scan_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: RangeScanOptions) -> impl Future<Output = Result<RangeScanResponse>>` (line 1334)
+  * `Client::create_notifications_stream(&self) -> Result<NotificationsStream>` (line 1408)
+  * `Client::create_notifications_stream_with_options(&self, options: NotificationsOptions) -> Result<NotificationsStream>` (line 1413)
+* **Observed:** **Async Entry Points:**
+  * `Client::connect` (file `client/src/lib.rs`, line 886)
+  * `Client::get_internal` (file `client/src/lib.rs`, line 973)
+  * `Client::put_internal` (file `client/src/lib.rs`, line 1105)
+  * `Client::delete_internal` (file `client/src/lib.rs`, line 1137)
+  * `Client::delete_range_internal` (file `client/src/lib.rs`, line 1176)
+  * `Client::list_internal` (file `client/src/lib.rs`, line 1264)
+  * `Client::range_scan_internal` (file `client/src/lib.rs`, line 1347)
+  * `shard::Client::get` (file `client/src/shard.rs`, line 796)
+  * `shard::Client::put` (file `client/src/shard.rs`, line 958)
+  * `shard::Client::delete` (file `client/src/shard.rs`, line 984)
+  * `shard::Client::delete_range` (file `client/src/shard.rs`, line 996)
+  * `shard::Client::list` (file `client/src/shard.rs`, line 1009)
+  * `shard::Client::range_scan` (file `client/src/shard.rs`, line 1059)
+  * `shard::Client::get_notifications` (file `client/src/shard.rs`, line 1091)
+  * `shard::Client::create_session` (file `client/src/shard.rs`, line 579)
+* **Observed:** **Background Tasks:**
+  * Shard assignment syncing loop `ShardAssignmentTask::run` (file `client/src/shard.rs`, line 1642)
+  * Session heartbeat loop task spawned in `Client::start_heartbeat` (file `client/src/shard.rs`, line 483)
+  * Notification stream change listener task spawned in `NotificationsStream::new` (file `client/src/notification.rs`, line 163)
+* **Observed:** **Retry Loops:**
+  * Transient/timeout retries in `execute_with_retry` (file `client/src/lib.rs`, line 741)
+  * Wrong-leader routing retries in `stale_shard_map_retry` (file `client/src/lib.rs`, line 803)
+  * Shard assignment stream reconnection loop in `ShardAssignmentTask::get_stream` (file `client/src/shard.rs`, line 1611)
+* **Observed:** **Network Operations:**
+  * Connecting gRPC channel in `ChannelPool::get` (file `client/src/pool.rs`, line 177)
+  * Tonic gRPC calls:
     - `get_shard_assignments` (file `client/src/shard.rs`, line 1596)
     - `create_session` (file `client/src/shard.rs`, line 587)
     - `keep_alive` (file `client/src/shard.rs`, line 524)
@@ -78,257 +76,313 @@ This document provides a detailed design and implementation specification for ad
     - `range_scan` (file `client/src/shard.rs`, line 1071)
     - `get_notifications` (file `client/src/shard.rs`, line 1101)
     - `list_nodes` (file `client/src/discovery.rs`, line 109)
-- **Observed:** **Streaming Operations:**
-  - Shard assignment updates stream `Streaming<oxia_proto::ShardAssignments>` (file `client/src/shard.rs`, line 1559)
-  - Notifications stream `Streaming<oxia_proto::NotificationBatch>` (file `client/src/shard.rs`, line 1445)
-  - `batch_get` result stream demuxing `demux_stream` (file `client/src/shard.rs`, line 834)
-- **Observed:** **Batching Operations:**
-  - Multi-key read batching in `Client::batch_get` (file `client/src/lib.rs`, line 1031)
-- **Observed:** **Error Types** (`client/src/errors.rs`):
-  - `Error` (line 320), `OxiaError` (line 31), `OxiaRpcError` (line 61), `ClientError` (line 233), `ServerError` (line 278), `ShardError` (line 304).
-- **Observed:** **Concurrency Boundaries:**
-  - `ArcSwap` for lock-free state swaps (file `client/src/pool.rs`, line 69; file `client/src/shard.rs`, line 1665, 1666)
-  - `Mutex` for synchronizing channel creations (file `client/src/pool.rs`, line 70)
-  - `OnceCell` for lazy session creation (file `client/src/shard.rs`, line 332, 598)
-  - `watch::Sender` / `watch::Receiver` for notifying updates (file `client/src/shard.rs`, line 1669, 1808)
-  - `tokio::sync::Notify` for refresh signals (file `client/src/shard.rs`, line 1670, 1819)
-- **Observed:** **Task Spawning Boundaries:**
-  - Spawning heartbeat loops (file `client/src/shard.rs`, line 483)
-  - Spawning assignment sync loops (file `client/src/shard.rs`, line 1821)
-  - Spawning configuration watcher tasks (file `client/src/notification.rs`, line 163)
-- **Observed:** **Cancellation Semantics:**
-  - Background loops are monitored by `CancellationToken` (file `client/src/shard.rs`, line 298, 1667; file `client/src/notification.rs`, line 150) and handles are aborted on drop.
-- **Observed:** **Existing Telemetry Hooks:**
-  - Crate depends on `tracing` (file `client/Cargo.toml`, line 15) and logs extensively via `info!`, `warn!`, `debug!`, `error!`, and `trace!`.
+* **Observed:** **Streaming Operations:**
+  * Shard assignment updates stream `Streaming<oxia_proto::ShardAssignments>` (file `client/src/shard.rs`, line 1559)
+  * Notifications stream `Streaming<oxia_proto::NotificationBatch>` (file `client/src/shard.rs`, line 1445)
+  * `batch_get` result stream demuxing `demux_stream` (file `client/src/shard.rs`, line 834)
+* **Observed:** **Batching Operations:**
+  * Multi-key read batching in `Client::batch_get` (file `client/src/lib.rs`, line 1031)
+* **Observed:** **Error Types** (`client/src/errors.rs`):
+  * `Error` (line 320), `OxiaError` (line 31), `OxiaRpcError` (line 61), `ClientError` (line 233), `ServerError` (line 278), `ShardError` (line 304).
+* **Observed:** **Concurrency Boundaries:**
+  * `ArcSwap` for lock-free state swaps (file `client/src/pool.rs`, line 69; file `client/src/shard.rs`, line 1665, 1666)
+  * `Mutex` for synchronizing channel creations (file `client/src/pool.rs`, line 70)
+  * `OnceCell` for lazy session creation (file `client/src/shard.rs`, line 332, 598)
+  * `watch::Sender` / `watch::Receiver` for notifying updates (file `client/src/shard.rs`, line 1669, 1808)
+  * `tokio::sync::Notify` for refresh signals (file `client/src/shard.rs`, line 1670, 1819)
+* **Observed:** **Task Spawning Boundaries:**
+  * Spawning heartbeat loops (file `client/src/shard.rs`, line 483)
+  * Spawning assignment sync loops (file `client/src/shard.rs`, line 1821)
+  * Spawning configuration watcher tasks (file `client/src/notification.rs`, line 163)
+* **Observed:** **Cancellation Semantics:**
+  * Background loops are monitored by `CancellationToken` (file `client/src/shard.rs`, line 298, 1667; file `client/src/notification.rs`, line 150) and handles are aborted on drop.
+* **Observed:** **Existing Telemetry Hooks:**
+  * Crate depends on `tracing` (file `client/Cargo.toml`, line 15) and logs extensively via `info!`, `warn!`, `debug!`, `error!`, and `trace!`.
 
 ### 2.2 Go Reference Instrumentation Inventory
-
-- **Observed:** **Metrics** (`ext/oxia/oxia/internal/metrics/metrics.go`):
-  - `oxia_client_op` (Timer: sum counter and count counter): records call latency.
-  - `oxia_client_op_value` (Histogram, unit: `"By"`): records KV size for `put` and `get`.
-  - `oxia_client_batch_total` (Timer: sum counter and count counter): records time from request queueing to response.
-  - `oxia_client_batch_exec` (Timer: sum counter and count counter): records time elapsed during batch execution.
-  - `oxia_client_batch_value` (Histogram, unit: `"By"`): records total bytes processed in a batch.
-  - `oxia_client_batch_request` (Histogram): records count of requests inside a batch.
-  - Attributes registered per metric: `"type"` (operation name, e.g., `"get"`, `"put"`) and `"result"` (`"success"` or `"failure"`).
-- **Observed:** **Traces (Spans):**
-  - The Go client has no tracing instrumentation. `go.opentelemetry.io/otel/trace` is only listed as an `// indirect` dependency in `ext/oxia/oxia/go.mod` (line 40).
-- **Observed:** **Structured Log Events:**
-  - Go client uses structured logging (`log/slog`) for system state:
+* **Observed:** **Metrics** (`ext/oxia/oxia/internal/metrics/metrics.go`):
+  * `oxia_client_op` (Timer: sum counter and count counter): records call latency.
+  * `oxia_client_op_value` (Histogram, unit: `"By"`): records KV size for `put` and `get`.
+  * `oxia_client_batch_total` (Timer: sum counter and count counter): records time from request queueing to response.
+  * `oxia_client_batch_exec` (Timer: sum counter and count counter): records time elapsed during batch execution.
+  * `oxia_client_batch_value` (Histogram, unit: `"By"`): records total bytes processed in a batch.
+  * `oxia_client_batch_request` (Histogram): records count of requests inside a batch.
+  * Attributes registered per metric: `"type"` (operation name, e.g., `"get"`, `"put"`) and `"result"` (`"success"` or `"failure"`).
+* **Observed:** **Traces (Spans):**
+  * The Go client has no tracing instrumentation. `go.opentelemetry.io/otel/trace` is only listed as an `// indirect` dependency in `ext/oxia/oxia/go.mod` (line 40).
+* **Observed:** **Structured Log Events:**
+  * Go client uses structured logging (`log/slog`) for system state:
     - retry warnings (file `ext/oxia/oxia/async_client_impl.go`, line 433, 531)
     - notification events (file `ext/oxia/oxia/cache.go`, line 156)
     - batch rerouting notices (file `ext/oxia/oxia/internal/batch/read_batch.go`, line 96; file `ext/oxia/oxia/internal/batch/write_batch.go`, line 117)
     - connection warning/errors (file `ext/oxia/oxia/internal/executor.go`, line 153)
 
 ### 2.3 Cross-Language Mapping and Differences
-
-- **Observed:** **Go-to-Rust Equivalency mapping:**
-  - `DecoratePut` / `DecorateGet` / `DecorateDelete` -> Map directly to wrapping `Client::put_internal`, `Client::get_internal`, `Client::delete_internal` and `Client::batch_get` operations in `client/src/lib.rs`.
-  - `WriteCallback` / `ReadCallback` -> Maps to wrappers around `shard::Client::process_write` and `shard::Client::get`/`batch_get` (file `client/src/shard.rs`).
-- **Observed:** **Rust operations with no Go equivalent:**
-  - `Client::connect` (file `client/src/lib.rs`, line 886) - Go client performs lazy connection at executor level.
-  - `Client::reconnect` (file `client/src/lib.rs`, line 895).
-  - `stale_shard_map_retry` (file `client/src/lib.rs`, line 803) - explicit stale-map wait loop in Rust client.
-- **Observed:** **Go instrumentation with no Rust equivalent:**
-  - Go's custom `Timer` metric type (split into a sum Float64Counter and a count Int64Counter under the same name).
-  - Go's unstructured/slog logger. Rust utilizes `tracing` exclusively.
+* **Observed:** **Go-to-Rust Equivalency mapping:**
+  * `DecoratePut` / `DecorateGet` / `DecorateDelete` -> Map directly to wrapping `Client::put_internal`, `Client::get_internal`, `Client::delete_internal` and `Client::batch_get` operations in `client/src/lib.rs`.
+  * `WriteCallback` / `ReadCallback` -> Maps to wrappers around `shard::Client::process_write` and `shard::Client::get`/`batch_get` (file `client/src/shard.rs`).
+* **Observed:** **Rust operations with no Go equivalent:**
+  * `Client::connect` (file `client/src/lib.rs`, line 886) - Go client performs lazy connection at executor level.
+  * `Client::reconnect` (file `client/src/lib.rs`, line 895).
+  * `stale_shard_map_retry` (file `client/src/lib.rs`, line 803) - explicit stale-map wait loop in Rust client.
+* **Observed:** **Go instrumentation with no Rust equivalent:**
+  * Go's custom `Timer` metric type (split into a sum Float64Counter and a count Int64Counter under the same name).
+  * Go's unstructured/slog logger. Rust utilizes `tracing` exclusively.
 
 ---
 
 ## 3. Goals, Constraints, and Assumptions
 
 ### 3.1 Telemetry Framework Choice
-
-- **Proposed:** The library will use the **`tracing` crate** (already present in `client/Cargo.toml#L15`) as its tracing and logging facade, and the **`opentelemetry` API crate** (with the `metric` feature) as its metrics facade.
-- **Justification:**
+* **Proposed:** The library will use the **`tracing` crate** (already present in `client/Cargo.toml#L15`) as its tracing and logging facade, and the **`opentelemetry` API crate** (with the `metric` feature) as its metrics facade.
+* **Justification:**
   1. The `tracing` crate is the de facto standard in Rust. Using it ensures all spans and logs integrate out-of-the-box with downstream subscriber ecosystems (such as `tracing-opentelemetry`).
   2. Direct instrumentation using the `opentelemetry` tracing API inside a Rust library requires handling a heavy API layer, which is less idiomatic and more difficult to format and correlate than Rust's native `tracing::Span` structures.
   3. Spans can be bridged downstream using the standard `tracing-opentelemetry` subscriber.
-- **Proposed:** The library will interact only with the _facade/API layers_ (`tracing` and `opentelemetry::metric`). It will not instantiate or configure exporters, tracer providers, or meter providers internally, but it _will_ support user-supplied `MeterProvider` configurations.
-- **Assumption:** If no OTel SDK or `tracing` subscriber is registered by the parent application, all instrumentation calls compile down to no-ops with negligible runtime overhead.
-- **Proposed:** To ensure zero overhead when telemetry is disabled, the OTel metrics logic will be conditionally compiled behind a feature flag (see Section 8).
+* **Proposed:** The library will interact only with the *facade/API layers* (`tracing` and `opentelemetry::metric`). It will not instantiate or configure exporters, tracer providers, or meter providers internally, but it *will* support user-supplied `MeterProvider` configurations.
+* **Assumption:** If no OTel SDK or `tracing` subscriber is registered by the parent application, all instrumentation calls compile down to no-ops with negligible runtime overhead.
+* **Proposed:** To ensure zero overhead when telemetry is disabled, the OTel metrics logic will be conditionally compiled behind a feature flag (see Section 8).
 
 ---
 
 ## 4. Instrumentation Boundaries
 
 ### 4.1 Boundary Scope
-
-- **Proposed:** **Instrumented operations:**
-  - `Client::connect` and `Client::reconnect` (to track cluster connectivity).
-  - Main KV API entry points (`get`, `put`, `delete`, `delete_range`, `list`, `range_scan`, `batch_get`).
-  - Coordinator discovery requests (`discovery::CoordinatorServiceDiscovery::addresses`).
-  - Heartbeat loop cycles (to monitor session health).
-  - Background shard assignment sync loop runs.
-- **Proposed:** **Explicitly non-instrumented operations:**
-  - Lower-level internal utilities (`util::with_timeout`, `util::with_retry`) to avoid duplicate spans. Span details will instead be captured as attributes or retry events on the parent operation span.
+* **Proposed:** **Instrumented operations:**
+  * `Client::connect` and `Client::reconnect` (to track cluster connectivity).
+  * Main KV API entry points (`get`, `put`, `delete`, `delete_range`, `list`, `range_scan`, `batch_get`).
+  * Coordinator discovery requests (`discovery::CoordinatorServiceDiscovery::addresses`).
+  * Heartbeat loop cycles (to monitor session health).
+  * Background shard assignment sync loop runs.
+* **Proposed:** **Explicitly non-instrumented operations:**
+  * Lower-level internal utilities (`util::with_timeout`, `util::with_retry`) to avoid duplicate spans. Span details will instead be captured as attributes or retry events on the parent operation span.
 
 ### 4.2 Architectural Design Decisions
-
-- **Decision 1: Spans representation**
-  - **Selected Approach:** Maintain spans using `tracing::Span` and rely on downstream `tracing-opentelemetry` for OTel exporting.
-  - **Rejected Alternative:** Directly use the `opentelemetry::trace::Tracer` API in-crate.
-  - **Reason for Rejection:** Direct OTel trace API makes logs harder to correlate and diverges from the existing `tracing` macros already used in the codebase.
-- **Decision 2: Latency metrics implementation**
-  - **Selected Approach:** Use OTel `Histogram` for operation latencies.
-  - **Rejected Alternative:** Translate Go's dual-counter Timer approach literally (making a count counter and a latency sum counter).
-  - **Reason for Rejection:** A dual-counter Timer is not idiomatic in modern OpenTelemetry and is rejected by the OTel API in favor of histograms, which natively provide percentiles, counts, and sums.
+* **Decision 1: Spans representation**
+  * **Selected Approach:** Maintain spans using `tracing::Span` and rely on downstream `tracing-opentelemetry` for OTel exporting.
+  * **Rejected Alternative:** Directly use the `opentelemetry::trace::Tracer` API in-crate.
+  * **Reason for Rejection:** Direct OTel trace API makes logs harder to correlate and diverges from the existing `tracing` macros already used in the codebase.
+* **Decision 2: Latency metrics implementation**
+  * **Selected Approach:** Use OTel `Histogram` for operation latencies.
+  * **Rejected Alternative:** Translate Go's dual-counter Timer approach literally (making a count counter and a latency sum counter).
+  * **Reason for Rejection:** A dual-counter Timer is not idiomatic in modern OpenTelemetry and is rejected by the OTel API in favor of histograms, which natively provide percentiles, counts, and sums.
 
 ---
 
 ## 5. Tracing and Logging Design
 
 ### 5.1 Naming and Scope
-
-- **Proposed:** The tracer/telemetry scope name will be `"mauricebarnum_oxia_client"`.
-- **Proposed:** Spans will map to operations:
-  - `"client.connect"` (SpanKind::Client)
-  - `"db.operation.get"` (SpanKind::Client)
-  - `"db.operation.put"` (SpanKind::Client)
-  - `"db.operation.delete"` (SpanKind::Client)
-  - `"db.operation.delete_range"` (SpanKind::Client)
-  - `"db.operation.list"` (SpanKind::Client)
-  - `"db.operation.range_scan"` (SpanKind::Client)
-  - `"db.operation.batch_get"` (SpanKind::Client)
-  - `"shard.heartbeat"` (SpanKind::Internal)
-  - `"shard.assignment_sync"` (SpanKind::Internal)
+* **Proposed:** The tracer/telemetry scope name will be `"mauricebarnum_oxia_client"`.
+* **Proposed:** Spans will map to operations:
+  * `"client.connect"` (SpanKind::Client)
+  * `"db.operation.get"` (SpanKind::Client)
+  * `"db.operation.put"` (SpanKind::Client)
+  * `"db.operation.delete"` (SpanKind::Client)
+  * `"db.operation.delete_range"` (SpanKind::Client)
+  * `"db.operation.list"` (SpanKind::Client)
+  * `"db.operation.range_scan"` (SpanKind::Client)
+  * `"db.operation.batch_get"` (SpanKind::Client)
+  * `"shard.heartbeat"` (SpanKind::Internal)
+  * `"shard.assignment_sync"` (SpanKind::Internal)
 
 ### 5.2 Attributes (OpenTelemetry Semantic Conventions v1.41.0)
-
-- **Proposed:** All spans representing database operations must carry:
-  - `db.system`: `"oxia"` (static string)
-  - `db.name`: Namespace name from configuration (e.g., `"default"`)
-  - `db.operation`: Operation identifier (`"get"`, `"put"`, `"delete"`, etc.)
-  - `db.oxia.shard_id`: The ID of the shard targeted by the routing key
-  - `server.address`: Leader endpoint host (if resolved)
-  - `server.port`: Leader endpoint port
-  - `error.type`: The error string code on failure (e.g., `"KeyNotFound"`, `"TransportError"`)
+* **Proposed:** All spans representing database operations must carry:
+  * `db.system`: `"oxia"` (static string)
+  * `db.name`: Namespace name from configuration (e.g., `"default"`)
+  * `db.operation`: Operation identifier (`"get"`, `"put"`, `"delete"`, etc.)
+  * `db.oxia.shard_id`: The ID of the shard targeted by the routing key
+  * `server.address`: Leader endpoint host (if resolved)
+  * `server.port`: Leader endpoint port
+  * `error.type`: The error string code on failure (e.g., `"KeyNotFound"`, `"TransportError"`)
 
 ### 5.3 Error and Status Rules
-
-- **Proposed:** If an operation returns an `Err(Error::Oxia(OxiaError::KeyNotFound))` on a `get` operation, the span status remains `Ok` (this is a standard lookup result, not a system failure).
-- **Proposed:** For all other `Err` results, the span status must be set to `Error`, and the error description must be recorded in the `exception.message` event.
-- **Proposed:** Panics must be caught using `std::panic::AssertUnwindSafe` to set the span status to `Error` before resuming panic propagation.
+* **Proposed:** If an operation returns an `Err(Error::Oxia(OxiaError::KeyNotFound))` on a `get` operation, the span status remains `Ok` (this is a standard lookup result, not a system failure).
+* **Proposed:** For all other `Err` results, the span status must be set to `Error`, and the error description must be recorded in the `exception.message` event.
+* **Proposed:** Panics must be caught using `std::panic::AssertUnwindSafe` to set the span status to `Error` before resuming panic propagation.
 
 ### 5.4 Sampling and Logging Integration
-
-- **Proposed:** Attributes requiring allocations (like formatting the server address) must be lazily computed only if the span is active (`Span::is_disabled` checks).
-- **Proposed:** Existing logs will automatically inherit `trace_id` and `span_id` context when executed within the scope of active tracing spans.
+* **Proposed:** Attributes requiring allocations (like formatting the server address) must be lazily computed only if the span is active (`Span::is_disabled` checks).
+* **Proposed:** Existing logs will automatically inherit `trace_id` and `span_id` context when executed within the scope of active tracing spans.
 
 ---
 
 ## 6. Metrics Design
 
 ### 6.1 Metrics Specifications
-
-- **Proposed:** The client will register the following metrics:
-  
-  - `"oxia.client.op.size"` (Histogram, unit: `"By"`): Measures payload sizes of `put` values and `get` returned values.
-  - `"oxia.client.batch.total_duration"` (Histogram, unit: `"s"`): Measures total duration of batched requests (queueing + execution).
-  - `"oxia.client.batch.exec_duration"` (Histogram, unit: `"s"`): Measures actual network execution duration of batches.
-  - `"oxia.client.batch.size"` (Histogram, unit: `"By"`): Measures total payload size in a batch.
-  - `"oxia.client.batch.request_count"` (Histogram, unit: `"1"`): Measures count of operations packed in a batch.
+* **Proposed:** The client will register the following metrics:
+  * `"oxia.client.op.duration"` (Histogram, unit: `"s"`): Measures operation execution duration.
+  * `"oxia.client.op.size"` (Histogram, unit: `"By"`): Measures payload sizes of `put` values and `get` returned values.
+  * `"oxia.client.batch.total_duration"` (Histogram, unit: `"s"`): Measures total duration of batched requests (queueing + execution).
+  * `"oxia.client.batch.exec_duration"` (Histogram, unit: `"s"`): Measures actual network execution duration of batches.
+  * `"oxia.client.batch.size"` (Histogram, unit: `"By"`): Measures total payload size in a batch.
+  * `"oxia.client.batch.request_count"` (Histogram, unit: `"1"`): Measures count of operations packed in a batch.
 
 ### 6.2 Attributes and Bounded Cardinality
-
-- **Proposed:** All metrics will utilize the following dimensions:
-  - `db.system`: Bounded (Value: `"oxia"`)
-  - `db.name` (Namespace): Bounded (Value from config)
-  - `db.operation`: Bounded (Values: `"get"`, `"put"`, `"delete"`, etc.)
-  - `db.oxia.shard_id`: Bounded (Values: integers [0 - maximum sharding limit])
-  - `result`: Bounded (Values: `"success"`, `"failure"`)
-- **Proposed:** **Cardinality Risk Flag:** No dynamic, user-provided data (such as keys, values, or raw error messages containing user parameters) may be used as metric dimensions. Recording arbitrary keys as dimensions is strictly prohibited due to infinite cardinality risks.
+* **Proposed:** All metrics will utilize the following dimensions:
+  * `db.system`: Bounded (Value: `"oxia"`)
+  * `db.name` (Namespace): Bounded (Value from config)
+  * `db.operation`: Bounded (Values: `"get"`, `"put"`, `"delete"`, etc.)
+  * `db.oxia.shard_id`: Bounded (Values: integers [0 - maximum sharding limit])
+  * `result`: Bounded (Values: `"success"`, `"failure"`)
+* **Proposed:** **Cardinality Risk Flag:** No dynamic, user-provided data (such as keys, values, or raw error messages containing user parameters) may be used as metric dimensions. Recording arbitrary keys as dimensions is strictly prohibited due to infinite cardinality risks.
 
 ---
 
 ## 7. Context Propagation and Concurrency Design
 
 ### 7.1 Context over Boundaries
-
-- **Proposed:** Context enters the client via the implicit thread-local/async `tracing::Span::current()`.
-- **Proposed:** Since `client` operations are async and span boundaries, we must recommend:
-  - **Bridge via `tracing-opentelemetry`**: This handles propagating trace headers over spawned task boundaries (like the heartbeat and discovery tasks) using `tracing` parent span attachment.
-- **Proposed:** For background tasks (`ShardAssignmentTask` and heartbeats), we will construct detached root spans `"shard.assignment_sync"` and `"shard.heartbeat"`.
-- **Proposed:** If a caller cancels an operation future, the corresponding span will record a `"cancelled"` event and close immediately.
+* **Proposed:** Context enters the client via the implicit thread-local/async `tracing::Span::current()`.
+* **Proposed:** Since `client` operations are async and span boundaries, we must recommend:
+  * **Bridge via `tracing-opentelemetry`**: This handles propagating trace headers over spawned task boundaries (like the heartbeat and discovery tasks) using `tracing` parent span attachment.
+* **Proposed:** For background tasks (`ShardAssignmentTask` and heartbeats), we will construct detached root spans `"shard.assignment_sync"` and `"shard.heartbeat"`.
+* **Proposed:** If a caller cancels an operation future, the corresponding span will record a `"cancelled"` event and close immediately.
 
 ---
 
 ## 8. Public API and Internal Structure Impact
 
 ### 8.1 Feature Gating Decision
-
-- **Proposed:** Recommend **Option B: Feature-gated, opt-in**. Telemetry instrumentation logic (specifically the direct `opentelemetry` metrics API dependency and context-propagation functions) will compile only when downstream crates enable the `telemetry` feature flag.
-- **Rejected Alternative A (Always compiled):** Forces all users to download and compile `opentelemetry` API crates, increasing compile time and dependency trees for minimal-size environments.
-- **Rejected Alternative C (Opt-out):** Violates Rust best practices by enabling a large transitive dependency tree by default.
+* **Proposed:** Recommend **Option B: Feature-gated, opt-in**. Telemetry instrumentation logic (specifically the direct `opentelemetry` metrics API dependency and context-propagation functions) will compile only when downstream crates enable the `telemetry` feature flag.
+* **Rejected Alternative A (Always compiled):** Forces all users to download and compile `opentelemetry` API crates, increasing compile time and dependency trees for minimal-size environments.
+* **Rejected Alternative C (Opt-out):** Violates Rust best practices by enabling a large transitive dependency tree by default.
 
 ### 8.2 Dependency and API Impact
+* **Proposed:** Add `opentelemetry` (API crate) as an optional dependency under `[dependencies]` in `client/Cargo.toml`.
+* **Proposed:** Add `telemetry` feature to `client/Cargo.toml` enabling the optional dependency.
+* **Proposed:** Expose `meter_provider` setter field on `Config` and `ConfigBuilder` under the `telemetry` feature flag. This allows downstream consumers to explicitly inject custom OTel `MeterProvider` implementations (mapped as `Arc<dyn opentelemetry::metric::MeterProvider + Send + Sync>`). If not set, metrics fallback to `opentelemetry::global::meter_provider()`.
+* **Proposed:** MSRV impact is negligible, as `opentelemetry` supports modern stable Rust compilers matching the workspace's version.
 
-- **Proposed:** Add `opentelemetry` (API crate) as an optional dependency under `[dependencies]` in `client/Cargo.toml`.
-- **Proposed:** Add `telemetry` feature to `client/Cargo.toml` enabling the optional dependency.
-- **Proposed:** Expose `meter_provider` setter field on `Config` and `ConfigBuilder` under the `telemetry` feature flag. This allows downstream consumers to explicitly inject custom OTel `MeterProvider` implementations (mapped as `Arc<dyn opentelemetry::metric::MeterProvider + Send + Sync>`). If not set, metrics fallback to `opentelemetry::global::meter_provider()`.
-- **Proposed:** MSRV impact is negligible, as `opentelemetry` supports modern stable Rust compilers matching the workspace's version.
+### 8.3 Metric Naming Feature Flag: `go-metrics-compat`
+
+* **Proposed:** Add a second Cargo feature, `go-metrics-compat`, that selects the Go reference client's legacy metric name strings at **compile time** rather than at runtime.
+* **Rationale:** The two naming schemes (`db.client.operation.duration` vs `oxia_client_op`) differ only in the string constants used at histogram/counter creation. Selecting between them with `#[cfg(feature = "go-metrics-compat")]` eliminates all branching and string comparisons at runtime — the unused name is never materialized in the binary. This satisfies the requirement of zero runtime overhead.
+* **Feature independence:** `go-metrics-compat` is orthogonal to `telemetry`. Enabling `go-metrics-compat` without `telemetry` is meaningless and the implementation should emit a `compile_error!` or at minimum a `#[cfg(all(feature = "go-metrics-compat", not(feature = "telemetry")))]` warning.
+* **Proposed:** The Cargo feature declaration:
+
+  ```toml
+  # client/Cargo.toml  (illustrative — not yet implemented)
+  [features]
+  telemetry        = ["dep:opentelemetry"]
+  go-metrics-compat = ["telemetry"]   # implies telemetry; names only change when metrics are active
+  ```
+
+  Declaring `go-metrics-compat` as implying `telemetry` is the cleanest approach: it prevents silent no-ops and makes the dependency relationship explicit in the feature graph.
+
+* **Proposed:** Inside `client/src/telemetry.rs`, define the metric name strings as compile-time constants selected by the feature flag:
+
+  ```rust
+  // Illustrative — not yet implemented
+  #[cfg(not(feature = "go-metrics-compat"))]
+  mod names {
+      pub const OP_DURATION:        &str = "db.client.operation.duration";
+      pub const OP_SIZE:            &str = "db.client.operation.size";     // proposed OTel extension
+      pub const BATCH_TOTAL:        &str = "db.client.batch.duration";
+      pub const BATCH_EXEC:         &str = "db.client.batch.exec_duration";
+      pub const BATCH_SIZE:         &str = "db.client.batch.size";
+      pub const BATCH_REQUEST_COUNT:&str = "db.client.batch.request_count";
+  }
+
+  #[cfg(feature = "go-metrics-compat")]
+  mod names {
+      pub const OP_DURATION:        &str = "oxia_client_op_sum";          // Go: sum counter
+      pub const OP_SIZE:            &str = "oxia_client_op_value";
+      pub const BATCH_TOTAL:        &str = "oxia_client_batch_total_sum";
+      pub const BATCH_EXEC:         &str = "oxia_client_batch_exec_sum";
+      pub const BATCH_SIZE:         &str = "oxia_client_batch_value";
+      pub const BATCH_REQUEST_COUNT:&str = "oxia_client_batch_request";
+  }
+  ```
+
+  All histogram registrations reference `names::OP_DURATION`, etc., so no further code changes are needed when toggling the feature.
+
+* **Data migration:** Explicitly out of scope. Users switching between the two feature sets will see a gap or duplicate metric series in their observability backend. Documentation should note this; no migration tooling is provided by this library.
 
 ---
 
 ## 9. Semantic Conventions and Cross-Language Consistency
 
-- **Proposed:** Align strictly with OTel Semantic Conventions version `v1.41.0` (database client namespace).
-- **Proposed:** Go uses custom counter names `oxia_client_op`. We will export standard semantic convention metric names (`db.client.operation.duration`) by default, but allow custom mappings if required for legacy dashboard compatibility.
-- **Proposed:** **Handling Technology-Agnostic Naming:** To support setups where Oxia serves as an internal coordinator/metadata engine inside a larger database system (similar to etcd/zookeeper configurations):
-  - **Database system isolation:** Differentiating nested telemetry calls (e.g. outer database system client vs inner coordinator/metadata database client) is done purely via attributes. The inner Oxia calls will carry `db.system = "oxia"`, whereas the outer system client calls will carry `db.system = "my_custom_db"`.
-  - **Unified dashboard querying:** Using the standard semantic convention name `db.client.operation.duration` across both clients enables operators to aggregate database latency metrics globally or slice them by `db.system` to analyze the exact overhead contribution of the coordination layer.
+* **Proposed:** Align strictly with OTel Semantic Conventions version `v1.41.0` (database client namespace) by default.
+* **Proposed:** The `go-metrics-compat` Cargo feature (Section 8.3) is the **only supported mechanism** for selecting Go-compatible metric names. No runtime configuration knob is exposed for this choice — the selection is baked in at compile time.
+
+### 9.1 Technology-Agnostic Naming Rationale
+* **Proposed:** **Handling Technology-Agnostic Naming:** To support setups where Oxia serves as an internal coordinator/metadata engine inside a larger database system (similar to etcd/zookeeper configurations):
+  * **Database system isolation:** Differentiating nested telemetry calls (e.g. outer database system client vs inner coordinator/metadata database client) is done purely via attributes. The inner Oxia calls will carry `db.system = "oxia"`, whereas the outer system client calls will carry `db.system = "my_custom_db"`.
+  * **Unified dashboard querying:** Using the standard semantic convention name `db.client.operation.duration` across both clients enables operators to aggregate database latency metrics globally or slice them by `db.system` to analyze the exact overhead contribution of the coordination layer.
+
+### 9.2 Name Mapping Reference
+
+The table below is the authoritative mapping between the two naming regimes. The **`go-metrics-compat` name** column lists the exact string constants the Go reference client records metrics under; see Section 2.2 for observation source references.
+
+| Concept | Default (OTel v1.41.0) name | `go-metrics-compat` name | Notes |
+|---|---|---|---|
+| Operation latency | `db.client.operation.duration` | `oxia_client_op_sum` / `oxia_client_op_count` | Go uses dual counters; Rust uses a single Histogram in both modes |
+| Operation payload size | `db.client.operation.size` *(proposed extension)* | `oxia_client_op_value` | — |
+| Batch total duration | `db.client.batch.duration` | `oxia_client_batch_total_sum` | — |
+| Batch execution duration | `db.client.batch.exec_duration` | `oxia_client_batch_exec_sum` | — |
+| Batch payload size | `db.client.batch.size` | `oxia_client_batch_value` | — |
+| Batch request count | `db.client.batch.request_count` | `oxia_client_batch_request` | — |
+
+> [!NOTE]
+> The Go client splits each timer into a `_sum` counter and a `_count` counter. The Rust implementation collapses these into a single `Histogram` regardless of which naming mode is active, because OTel Histograms provide both sum and count natively. The `go-metrics-compat` names therefore reference only the sum counter's name as the histogram instrument name. Backends that expected a separate count counter will need to use the histogram's built-in count aggregation.
+
+### 9.3 Switching Overhead Analysis
+
+* **Zero runtime overhead:** Because the name strings are `const &str` values selected via `#[cfg]` attributes, the compiler eliminates the unused alternative entirely. There is no branch, no match expression, and no `if` check in the hot path.
+* **Binary size:** Each name variant compiles to a single null-terminated UTF-8 string in the read-only data segment. Switching variants changes which string is present; it does not add any code.
+* **No dynamic dispatch:** `MeterProvider::meter()` is called once during `Metrics::new()` (initialization, cold path). The name constant is passed at that point and never read again on the hot path.
 
 ---
 
 ## 10. Performance and Risk Analysis
-
-- **Proposed:** **Operation Path Classification:**
-  - **Hot path:** `Client::get`, `Client::put`, `Client::delete`, `Client::batch_get`.
-    - _Mitigation:_ Ensure attributes are constructed using static slices or pre-allocated elements. Do not format strings (e.g. `format!("shard-{}", id)`) on these paths.
-  - **Warm path:** `Client::delete_range`, `Client::list`, `Client::range_scan`, `Client::connect`, heartbeats.
-  - **Cold path:** Background task startups, stale map retries.
+* **Proposed:** **Operation Path Classification:**
+  * **Hot path:** `Client::get`, `Client::put`, `Client::delete`, `Client::batch_get`.
+    * *Mitigation:* Ensure attributes are constructed using static slices or pre-allocated elements. Do not format strings (e.g. `format!("shard-{}", id)`) on these paths.
+  * **Warm path:** `Client::delete_range`, `Client::list`, `Client::range_scan`, `Client::connect`, heartbeats.
+  * **Cold path:** Background task startups, stale map retries.
 
 ---
 
 ## 11. Rollout and Migration Plan
-
-- **Proposed:** **Phased Approach:**
-  - **Phase 1:** Add optional `telemetry` Cargo feature, introduce the `client/src/telemetry.rs` module, and configure the ZST metrics interface.
-  - **Phase 2:** Instrument tracing spans using `tracing` macros across the KV operations in `lib.rs` and `shard.rs`.
-  - **Phase 3:** Instrument metrics recorders inside the write batch and read batch streams. Expose the `meter_provider` setter on `Config` when the `telemetry` feature flag is active.
-  - **Phase 4:** Instrument background loops (heartbeat and assignment task).
+* **Proposed:** **Phased Approach:**
+  * **Phase 1:** Add optional `telemetry` Cargo feature, introduce the `client/src/telemetry.rs` module, and configure the ZST metrics interface.
+  * **Phase 2:** Instrument tracing spans using `tracing` macros across the KV operations in `lib.rs` and `shard.rs`.
+  * **Phase 3:** Instrument metrics recorders inside the write batch and read batch streams. Expose the `meter_provider` setter on `Config` when the `telemetry` feature flag is active.
+  * **Phase 4:** Instrument background loops (heartbeat and assignment task).
 
 ---
 
 ## 12. Testing and Validation Strategy
-
-- **Proposed:** Introduce unit tests under `client/tests/` using `otel-test` or `tracing-subscriber` mock layer to verify:
-  - Metric recordings match expected values (counts, sums) on success and failure.
-  - Spans have correct attributes and parent/child relationship.
-  - Custom injected `MeterProvider` receives the expected measurements.
-  - When `telemetry` feature is disabled, tests verify compilation succeeds and no metrics are registered.
+* **Proposed:** Introduce unit tests under `client/tests/` using `otel-test` or `tracing-subscriber` mock layer to verify:
+  * Metric recordings match expected values (counts, sums) on success and failure.
+  * Spans have correct attributes and parent/child relationship.
+  * Custom injected `MeterProvider` receives the expected measurements.
+  * When `telemetry` feature is disabled, tests verify compilation succeeds and no metrics are registered.
 
 ---
 
 ## 13. Open Questions
 
-- **Reviewer Input Required:**
-  1. Do downstream dashboards expect exact Go-compatible metric names (`oxia_client_op`) or should we migrate to standard OTel `v1.41.0` names (`db.client.operation.duration`)?
+* ~~Do downstream dashboards expect exact Go-compatible metric names (`oxia_client_op`) or should we migrate to standard OTel `v1.41.0` names (`db.client.operation.duration`)?~~ **Resolved:** Both naming schemes are supported via the `go-metrics-compat` compile-time feature flag (see Section 8.3). The default build uses OTel `v1.41.0` names. Consumers with existing Go-compatible dashboards enable `go-metrics-compat` at compile time. Data migration is explicitly out of scope.
+
+* **Reviewer Input Required:**
+  1. Should `go-metrics-compat` imply `telemetry` in the Cargo feature graph (recommended, see Section 8.3) or remain an independent flag that produces a `compile_error!` when `telemetry` is not also enabled?
+  2. The Go client emits `oxia_client_op_sum` and `oxia_client_op_count` as separate instruments. Should the `go-metrics-compat` Rust mode register two instruments to exactly replicate that wire format, or is the Histogram approach (with its built-in count) an acceptable deviation?
 
 ---
 
 # Part B: Implementation Handoff Spec
 
 ## B.1 Required Decisions
-
 - [x] Utilize the `tracing` crate facade with a target dependency on `tracing-opentelemetry` compatibility; do not take a direct dependency on `opentelemetry-sdk` in the library.
 - [x] Use Option B (Feature-gated, opt-in) via the `telemetry` Cargo feature.
 - [x] Use OTel `Histogram` for operation latencies instead of Go's counter-based timer approach.
 - [x] Prohibit dynamic user keys or values in metric attributes.
 - [x] Expose `meter_provider` setter on the `Config` builder when the `telemetry` feature flag is active.
+- [x] Add `go-metrics-compat` Cargo feature to select Go reference client metric name strings at compile time (zero runtime overhead). Default build uses OTel `v1.41.0` semantic convention names.
+- [ ] **Open:** Decide whether `go-metrics-compat` should imply `telemetry` in the feature graph, or fail loudly at compile time when `telemetry` is absent (see Section 8.3 and Open Question 1).
+- [ ] **Open:** Decide whether `go-metrics-compat` mode should register separate `_sum`/`_count` instruments to exactly replicate Go wire format, or use a single Histogram (see Open Question 2).
 
 ## B.2 Assumptions
-
 - **MSRV:** Target client's current edition (2021).
 - **Target OTel Version:** `v1.41.0` Semantic Conventions.
 - **Runtime:** Assumes `tokio` multi-threaded executor downstream.
@@ -337,23 +391,22 @@ This document provides a detailed design and implementation specification for ad
 
 ### Summary Mapping Table
 
-| Rust API Entry Point   | Span Name                     | Type (Span Kind)   | Metrics Emitted                                                           | Performance Classification |
-| ---------------------- | ----------------------------- | ------------------ | ------------------------------------------------------------------------- | -------------------------- |
-| `Client::connect`      | `"client.connect"`            | `SpanKind::Client` | —                                                                         | Warm path                  |
-| `Client::get`          | `"db.operation.get"`          | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Hot path                   |
-| `Client::put`          | `"db.operation.put"`          | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Hot path                   |
-| `Client::delete`       | `"db.operation.delete"`       | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Hot path                   |
-| `Client::delete_range` | `"db.operation.delete_range"` | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Warm path                  |
-| `Client::list`         | `"db.operation.list"`         | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Warm path                  |
-| `Client::range_scan`   | `"db.operation.range_scan"`   | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Warm path                  |
-| `Client::batch_get`    | `"db.operation.batch_get"`    | `SpanKind::Client` | `"oxia.client.batch.total_duration"`, `"oxia.client.batch.exec_duration"` | Hot path                   |
+| Rust API Entry Point | Span Name | Type (Span Kind) | Metrics Emitted | Performance Classification |
+|---|---|---|---|---|
+| `Client::connect` | `"client.connect"` | `SpanKind::Client` | — | Warm path |
+| `Client::get` | `"db.operation.get"` | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"` | Hot path |
+| `Client::put` | `"db.operation.put"` | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"` | Hot path |
+| `Client::delete` | `"db.operation.delete"` | `SpanKind::Client` | `"oxia.client.op.duration"` | Hot path |
+| `Client::delete_range`| `"db.operation.delete_range"`| `SpanKind::Client` | `"oxia.client.op.duration"` | Warm path |
+| `Client::list` | `"db.operation.list"` | `SpanKind::Client` | `"oxia.client.op.duration"` | Warm path |
+| `Client::range_scan` | `"db.operation.range_scan"` | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"` | Warm path |
+| `Client::batch_get` | `"db.operation.batch_get"` | `SpanKind::Client` | `"oxia.client.batch.total_duration"`, `"oxia.client.batch.exec_duration"` | Hot path |
 
 ---
 
 ### Detailed Operation Specifications
 
 ##### Operation: `Client::connect`
-
 - **Purpose:** Tracks connection and setup of the client's shard manager.
 - **Span Name:** `"client.connect"`
 - **Span Kind:** `SpanKind::Client`
@@ -365,7 +418,6 @@ This document provides a detailed design and implementation specification for ad
 - **Performance Notes:** Warm path, allocates client metadata during connection.
 
 ##### Operation: `Client::get`
-
 - **Purpose:** Fetches value for a key.
 - **Span Name:** `"db.operation.get"`
 - **Span Kind:** `SpanKind::Client`
@@ -380,7 +432,6 @@ This document provides a detailed design and implementation specification for ad
 - **Performance Notes:** Hot path. Minimize dynamic allocations in attributes.
 
 ##### Operation: `Client::put`
-
 - **Purpose:** Puts a key-value record.
 - **Span Name:** `"db.operation.put"`
 - **Span Kind:** `SpanKind::Client`
@@ -398,23 +449,29 @@ This document provides a detailed design and implementation specification for ad
 
 ## B.4 Metric Inventory
 
-| Metric Name                          | Instrument Type | Unit   | Attributes                                       | Attribute Cardinality | Semantic Convention Version | Lifecycle (init location)   | Cardinality Warnings |
-| ------------------------------------ | --------------- | ------ | ------------------------------------------------ | --------------------- | --------------------------- | --------------------------- | -------------------- |
-| `"oxia.client.op.duration"`          | Histogram       | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
-| `"oxia.client.op.size"`              | Histogram       | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
-| `"oxia.client.batch.total_duration"` | Histogram       | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
-| `"oxia.client.batch.exec_duration"`  | Histogram       | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
-| `"oxia.client.batch.size"`           | Histogram       | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
-| `"oxia.client.batch.request_count"`  | Histogram       | `"1"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded               | v1.41.0                     | `telemetry::Metrics::new()` | None                 |
+> [!IMPORTANT]
+> Metric names are selected at compile time. The **Default name** column applies when `go-metrics-compat` is **not** enabled. The **`go-metrics-compat` name** column applies when that feature is enabled. Instrument type, unit, and attributes are identical regardless of naming mode.
+
+| Concept | Default name (OTel v1.41.0) | `go-metrics-compat` name | Instrument | Unit | Attributes | Cardinality | Lifecycle |
+|---|---|---|---|---|---|---|---|
+| Operation latency | `db.client.operation.duration` | `oxia_client_op_sum` | Histogram | `"s"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
+| Operation payload size | `db.client.operation.size` | `oxia_client_op_value` | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
+| Batch total duration | `db.client.batch.duration` | `oxia_client_batch_total_sum` | Histogram | `"s"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
+| Batch exec duration | `db.client.batch.exec_duration` | `oxia_client_batch_exec_sum` | Histogram | `"s"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
+| Batch payload size | `db.client.batch.size` | `oxia_client_batch_value` | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
+| Batch request count | `db.client.batch.request_count` | `oxia_client_batch_request` | Histogram | `"1"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
 
 ---
 
 ## B.5 Module and File Plan
 
-- **[NEW] `client/src/telemetry.rs`**: Contains all metrics wrappers, declarations, and feature-conditional definitions. When `telemetry` feature is off, compile as a zero-overhead ZST.
+- **[NEW] `client/src/telemetry.rs`**: Contains all metrics wrappers, declarations, and feature-conditional definitions.
+  - When `telemetry` feature is off: compile as a zero-overhead ZST.
+  - When `telemetry` is on: defines `pub(crate) mod names` with `const &str` metric name constants selected via `#[cfg(feature = "go-metrics-compat")]` (see Section 8.3). All histogram registrations reference these constants. No `if` branches or runtime dispatch.
 - **[MODIFY] `client/Cargo.toml`**:
   - Add optional dependency `opentelemetry = { version = "0.27.0", features = ["metric"] }` (or matching latest stable version).
   - Add feature `telemetry = ["dep:opentelemetry"]`.
+  - Add feature `go-metrics-compat = ["telemetry"]` (implies `telemetry`; see Open Question 1 for the alternative).
 - **[MODIFY] `client/src/lib.rs`**:
   - Integrate operations tracing using `tracing::info_span!` macros inside `put_internal`, `get_internal`, `delete_internal`, etc.
   - Record execution metrics inside completion handlers.

--- a/otel-instrumentation-design.md
+++ b/otel-instrumentation-design.md
@@ -17,6 +17,15 @@ This document provides a detailed design and implementation specification for ad
   - Configuring exporters, tracing subscribers, or SDK pipelines within the library. The client library will only depend on telemetry APIs/facades.
   - System-level resource monitoring (CPU, memory), which is the responsibility of the server or the consumer application.
 
+### 1.1 Current Implementation Summary
+
+- **Implemented:** Direct OpenTelemetry metrics are compiled behind the optional `metrics` Cargo feature. The default build has no `opentelemetry` dependency and no metric timing, duration math, size extraction, or metric recording work.
+- **Implemented:** Public operation metrics are centralized in `client/src/metrics.rs` through `operation_start`, `record_operation_result`, `record_operation_result_with_size`, and `record_operation_sync`.
+- **Implemented:** Shard batch metrics are centralized in `client/src/metrics.rs` through `batch_start`, `batch_exec_duration`, and `record_batch`, preserving total duration, execution duration, payload size, and request count.
+- **Implemented:** Operation spans use `#[tracing::instrument]` where practical. `Client::connect` and `Client::batch_get` keep manual spans because their setup flow is more awkward to express with the attribute macro.
+- **Implemented:** `error.type` recording remains unconditional through `metrics::record_error_type`, including default builds where the `metrics` feature is disabled.
+- **Implemented:** `go-metrics-compat` implies `metrics` and selects Go-compatible metric names and timer instrument shapes at compile time.
+
 ---
 
 ## 2. Repository Findings
@@ -130,7 +139,7 @@ This document provides a detailed design and implementation specification for ad
   - `Client::reconnect` (file `client/src/lib.rs`, line 895).
   - `stale_shard_map_retry` (file `client/src/lib.rs`, line 803) - explicit stale-map wait loop in Rust client.
 - **Observed:** **Go instrumentation with no Rust equivalent:**
-  - Go's custom `Timer` metric type (split into a sum Float64Counter and a count Int64Counter under the same name).
+  - Go's custom `Timer` metric type (represented in Rust compat mode as a sum `Float64Counter` and a count `Counter<u64>`).
   - Go's unstructured/slog logger. Rust utilizes `tracing` exclusively.
 
 ---
@@ -139,14 +148,14 @@ This document provides a detailed design and implementation specification for ad
 
 ### 3.1 Telemetry Framework Choice
 
-- **Proposed:** The library will use the **`tracing` crate** (already present in `client/Cargo.toml#L15`) as its tracing and logging facade, and the **`opentelemetry` API crate** (with the `metric` feature) as its metrics facade.
+- **Implemented:** The library uses the **`tracing` crate** as its tracing and logging facade, and the optional **`opentelemetry` API crate** with its `metrics` feature as its metrics facade.
 - **Justification:**
   1. The `tracing` crate is the de facto standard in Rust. Using it ensures all spans and logs integrate out-of-the-box with downstream subscriber ecosystems (such as `tracing-opentelemetry`).
   2. Direct instrumentation using the `opentelemetry` tracing API inside a Rust library requires handling a heavy API layer, which is less idiomatic and more difficult to format and correlate than Rust's native `tracing::Span` structures.
   3. Spans can be bridged downstream using the standard `tracing-opentelemetry` subscriber.
-- **Proposed:** The library will interact only with the _facade/API layers_ (`tracing` and `opentelemetry::metric`). It will not instantiate or configure exporters, tracer providers, or meter providers internally, but it _will_ support user-supplied `MeterProvider` configurations.
-- **Assumption:** If no OTel SDK or `tracing` subscriber is registered by the parent application, all instrumentation calls compile down to no-ops with negligible runtime overhead.
-- **Proposed:** To ensure zero overhead when telemetry is disabled, the OTel metrics logic will be conditionally compiled behind a feature flag (see Section 8).
+- **Implemented:** The library interacts only with the facade/API layers (`tracing` and `opentelemetry::metrics`). It does not instantiate or configure exporters, tracing subscribers, SDK pipelines, or metric exporters internally, but it supports user-supplied `MeterProvider` configurations.
+- **Assumption:** If no `tracing` subscriber is registered by the parent application, tracing calls are handled by the normal `tracing` no-subscriber fast path.
+- **Implemented:** To ensure zero OTel metric overhead when metrics are disabled, direct OTel metrics logic is conditionally compiled behind the `metrics` feature flag (see Section 8).
 
 ---
 
@@ -154,9 +163,12 @@ This document provides a detailed design and implementation specification for ad
 
 ### 4.1 Boundary Scope
 
-- **Proposed:** **Instrumented operations:**
-  - `Client::connect` and `Client::reconnect` (to track cluster connectivity).
+- **Implemented:** **Instrumented operations:**
+  - `Client::connect` (to track cluster connectivity).
   - Main KV API entry points (`get`, `put`, `delete`, `delete_range`, `list`, `range_scan`, `batch_get`).
+  - Shard read/write batch paths.
+- **Planned:** **Additional instrumentation boundaries:**
+  - `Client::reconnect`.
   - Coordinator discovery requests (`discovery::CoordinatorServiceDiscovery::addresses`).
   - Heartbeat loop cycles (to monitor session health).
   - Background shard assignment sync loop runs.
@@ -171,7 +183,7 @@ This document provides a detailed design and implementation specification for ad
   - **Reason for Rejection:** Direct OTel trace API makes logs harder to correlate and diverges from the existing `tracing` macros already used in the codebase.
 - **Decision 2: Latency metrics implementation**
   - **Selected Approach (default / OTel mode):** Use OTel `Histogram` for operation latencies. A histogram provides percentiles, count, and sum natively without duplicating instruments.
-  - **Selected Approach (`go-metrics-compat` mode):** Register a `Float64Counter` (`_sum`) and an `Int64Counter` (`_count`) as separate instruments to exactly replicate the Go wire format. This is intentional: dashboards built against the Go client expect two distinct series.
+  - **Selected Approach (`go-metrics-compat` mode):** Register a `Float64Counter` (`_sum`) and a `Counter<u64>` (`_count`) as separate instruments to exactly replicate the Go wire format. This is intentional: dashboards built against the Go client expect two distinct series.
   - **Rejected Alternative for default mode:** Translate Go's dual-counter Timer approach literally. Rejected because it is not idiomatic in modern OpenTelemetry.
 
 ---
@@ -180,8 +192,8 @@ This document provides a detailed design and implementation specification for ad
 
 ### 5.1 Naming and Scope
 
-- **Proposed:** The tracer/telemetry scope name will be `"mauricebarnum_oxia_client"`.
-- **Proposed:** Spans will map to operations:
+- **Implemented:** The tracing and metrics scope name is `"mauricebarnum_oxia_client"`.
+- **Implemented:** Spans map to operations:
   - `"client.connect"` (SpanKind::Client)
   - `"db.operation.get"` (SpanKind::Client)
   - `"db.operation.put"` (SpanKind::Client)
@@ -190,30 +202,30 @@ This document provides a detailed design and implementation specification for ad
   - `"db.operation.list"` (SpanKind::Client)
   - `"db.operation.range_scan"` (SpanKind::Client)
   - `"db.operation.batch_get"` (SpanKind::Client)
-  - `"shard.heartbeat"` (SpanKind::Internal)
-  - `"shard.assignment_sync"` (SpanKind::Internal)
+  - `"shard.heartbeat"` (SpanKind::Internal, planned)
+  - `"shard.assignment_sync"` (SpanKind::Internal, planned)
 
 ### 5.2 Attributes (OpenTelemetry Semantic Conventions v1.41.0)
 
-- **Proposed:** All spans representing database operations must carry:
+- **Implemented:** Spans representing database operations carry:
   - `db.system`: `"oxia"` (static string)
   - `db.name`: Namespace name from configuration (e.g., `"default"`)
   - `db.operation`: Operation identifier (`"get"`, `"put"`, `"delete"`, etc.)
-  - `db.oxia.shard_id`: The ID of the shard targeted by the routing key
-  - `server.address`: Leader endpoint host (if resolved)
-  - `server.port`: Leader endpoint port
+  - `db.oxia.shard_id`: The ID of the shard targeted by the routing key, when known
   - `error.type`: The error string code on failure (e.g., `"KeyNotFound"`, `"TransportError"`)
+
+`server.address` and `server.port` are not currently recorded on public operation spans.
 
 ### 5.3 Error and Status Rules
 
-- **Proposed:** If an operation returns an `Err(Error::Oxia(OxiaError::KeyNotFound))` on a `get` operation, the span status remains `Ok` (this is a standard lookup result, not a system failure).
-- **Proposed:** For all other `Err` results, the span status must be set to `Error`, and the error description must be recorded in the `exception.message` event.
-- **Proposed:** Panics must be caught using `std::panic::AssertUnwindSafe` to set the span status to `Error` before resuming panic propagation.
+- **Implemented:** `error.type` is recorded on the current `tracing` span for `Err` results through `metrics::record_error_type`, regardless of whether the `metrics` feature is enabled.
+- **Implemented:** `get` treats `Err(Error::Oxia(OxiaError::KeyNotFound))` as a metrics success while still preserving the returned error and `error.type` span field.
+- **Not Implemented:** Span status mutation and `exception.message` events are not currently recorded by the client instrumentation.
+- **Not Implemented:** Operation wrappers do not catch panics. Panics propagate normally.
 
 ### 5.4 Sampling and Logging Integration
 
-- **Proposed:** Attributes requiring allocations (like formatting the server address) must be lazily computed only if the span is active (`Span::is_disabled` checks).
-- **Proposed:** Existing logs will automatically inherit `trace_id` and `span_id` context when executed within the scope of active tracing spans.
+- **Implemented:** Existing logs inherit active `tracing` span context when the caller installs a compatible subscriber.
 
 ---
 
@@ -221,22 +233,22 @@ This document provides a detailed design and implementation specification for ad
 
 ### 6.1 Metrics Specifications
 
-- **Proposed:** The client will register the following metrics:
-  - `"oxia.client.op.duration"` (Histogram, unit: `"s"`): Measures operation execution duration.
-  - `"oxia.client.op.size"` (Histogram, unit: `"By"`): Measures payload sizes of `put` values and `get` returned values.
-  - `"oxia.client.batch.total_duration"` (Histogram, unit: `"s"`): Measures total duration of batched requests (queueing + execution).
-  - `"oxia.client.batch.exec_duration"` (Histogram, unit: `"s"`): Measures actual network execution duration of batches.
-  - `"oxia.client.batch.size"` (Histogram, unit: `"By"`): Measures total payload size in a batch.
-  - `"oxia.client.batch.request_count"` (Histogram, unit: `"1"`): Measures count of operations packed in a batch.
+- **Implemented:** In default mode, the client registers the following metrics when the `metrics` feature is enabled:
+  - `"db.client.operation.duration"` (Histogram, unit: `"ms"`): Measures operation execution duration.
+  - `"db.client.operation.size"` (Histogram, unit: `"By"`): Measures payload sizes of `put` values and `get`/`range_scan` returned values.
+  - `"db.client.batch.duration"` (Histogram, unit: `"ms"`): Measures total duration of batched requests (queueing + execution).
+  - `"db.client.batch.exec_duration"` (Histogram, unit: `"ms"`): Measures actual network execution duration of batches.
+  - `"db.client.batch.size"` (Histogram, unit: `"By"`): Measures total payload size in a batch.
+  - `"db.client.batch.request_count"` (Histogram, unit: `"1"`): Measures count of operations packed in a batch.
 
 ### 6.2 Attributes and Bounded Cardinality
 
-- **Proposed:** All metrics will utilize the following dimensions:
+- **Implemented:** All metrics use the following dimensions:
   - `db.system`: Bounded (Value: `"oxia"`)
   - `db.name` (Namespace): Bounded (Value from config)
   - `db.operation`: Bounded (Values: `"get"`, `"put"`, `"delete"`, etc.)
-  - `db.oxia.shard_id`: Bounded (Values: integers [0 - maximum sharding limit])
   - `result`: Bounded (Values: `"success"`, `"failure"`)
+- **Implemented:** Shard IDs are intentionally not metric attributes. This keeps the public metric dimension set small and bounded.
 - **Proposed:** **Cardinality Risk Flag:** No dynamic, user-provided data (such as keys, values, or raw error messages containing user parameters) may be used as metric dimensions. Recording arbitrary keys as dimensions is strictly prohibited due to infinite cardinality risks.
 
 ---
@@ -246,10 +258,11 @@ This document provides a detailed design and implementation specification for ad
 ### 7.1 Context over Boundaries
 
 - **Proposed:** Context enters the client via the implicit thread-local/async `tracing::Span::current()`.
-- **Proposed:** Since `client` operations are async and span boundaries, we must recommend:
+- **Implemented:** Public operation spans enter through the implicit thread-local/async `tracing::Span::current()` context and are exported only if the caller installs a compatible subscriber.
+- **Proposed:** Since `client` operations are async and span boundaries, downstream applications should bridge via `tracing-opentelemetry`:
   - **Bridge via `tracing-opentelemetry`**: This handles propagating trace headers over spawned task boundaries (like the heartbeat and discovery tasks) using `tracing` parent span attachment.
 - **Proposed:** For background tasks (`ShardAssignmentTask` and heartbeats), we will construct detached root spans `"shard.assignment_sync"` and `"shard.heartbeat"`.
-- **Proposed:** If a caller cancels an operation future, the corresponding span will record a `"cancelled"` event and close immediately.
+- **Not Implemented:** Caller cancellation does not currently record a `"cancelled"` event. The span closes when the instrumented future is dropped.
 
 ---
 
@@ -257,38 +270,36 @@ This document provides a detailed design and implementation specification for ad
 
 ### 8.1 Feature Gating Decision
 
-- **Proposed:** Recommend **Option B: Feature-gated, opt-in**. Telemetry instrumentation logic (specifically the direct `opentelemetry` metrics API dependency and context-propagation functions) will compile only when downstream crates enable the `telemetry` feature flag.
+- **Implemented:** Option B is used: direct OpenTelemetry metrics instrumentation is feature-gated and opt-in. The `opentelemetry` dependency is compiled only when downstream crates enable the `metrics` feature flag.
 - **Rejected Alternative A (Always compiled):** Forces all users to download and compile `opentelemetry` API crates, increasing compile time and dependency trees for minimal-size environments.
 - **Rejected Alternative C (Opt-out):** Violates Rust best practices by enabling a large transitive dependency tree by default.
 
 ### 8.2 Dependency and API Impact
 
-- **Proposed:** Add `opentelemetry` (API crate) as an optional dependency under `[dependencies]` in `client/Cargo.toml`.
-- **Proposed:** Add `telemetry` feature to `client/Cargo.toml` enabling the optional dependency.
-- **Proposed:** Expose `meter_provider` setter field on `Config` and `ConfigBuilder` under the `telemetry` feature flag. This allows downstream consumers to explicitly inject custom OTel `MeterProvider` implementations (mapped as `Arc<dyn opentelemetry::metric::MeterProvider + Send + Sync>`). If not set, metrics fallback to `opentelemetry::global::meter_provider()`.
+- **Implemented:** `opentelemetry` is an optional dependency under `[dependencies]` in `client/Cargo.toml`.
+- **Implemented:** The `metrics` feature enables the optional dependency.
+- **Implemented:** `Config` and `ConfigBuilder` expose a `meter_provider` field and setter under the `metrics` feature flag. This allows downstream consumers to explicitly inject custom OTel `MeterProvider` implementations, mapped as `Arc<dyn opentelemetry::metrics::MeterProvider + Send + Sync>`. If not set, metrics fallback to `opentelemetry::global::meter_provider()`.
 - **Proposed:** MSRV impact is negligible, as `opentelemetry` supports modern stable Rust compilers matching the workspace's version.
 
 ### 8.3 Metric Naming Feature Flag: `go-metrics-compat`
 
 - **Resolved:** Add a second Cargo feature, `go-metrics-compat`, that selects the Go reference client's legacy metric name strings **and instrument types** at **compile time** rather than at runtime.
 - **Rationale:** The two naming schemes (`db.client.operation.duration` vs `oxia_client_op`) differ in both string constants and instrument shape. Selecting between them with `#[cfg(feature = "go-metrics-compat")]` eliminates all branching at runtime — the unused variant is never materialized in the binary. This satisfies the requirement of zero runtime overhead.
-- **Resolved:** `go-metrics-compat` implies `telemetry` in the Cargo feature graph. This prevents silent no-ops and makes the dependency relationship explicit.
-- **Resolved:** `go-metrics-compat` mode registers **two separate instruments** per timer concept (a `Float64Counter` for `_sum` and an `Int64Counter` for `_count`) to exactly replicate Go wire format. Default (OTel) mode uses a single `Histogram`.
-- **Proposed:** The Cargo feature declaration:
+- **Resolved:** `go-metrics-compat` implies `metrics` in the Cargo feature graph. This prevents silent no-ops and makes the dependency relationship explicit.
+- **Resolved:** `go-metrics-compat` mode registers **two separate instruments** per timer concept (a `Float64Counter` for `_sum` and a `Counter<u64>` for `_count`) to exactly replicate Go wire format. Default (OTel) mode uses a single `Histogram`.
+- **Implemented:** The Cargo feature declaration:
 
   ```toml
-  # client/Cargo.toml  (illustrative — not yet implemented)
+  # client/Cargo.toml
   [features]
-  telemetry         = ["dep:opentelemetry"]
-  go-metrics-compat = ["telemetry"]   # implies telemetry
+  metrics           = ["dep:opentelemetry"]
+  go-metrics-compat = ["metrics"]   # implies metrics
   ```
 
-- **Proposed:** Inside `client/src/telemetry.rs`, the instrument types and name strings are both selected by the feature flag:
+- **Implemented:** Inside `client/src/metrics.rs`, the instrument types and name strings are both selected by feature flags:
 
   ```rust
-  // Illustrative — not yet implemented
-
-  // ── Default (OTel) mode ──────────────────────────────────────────────────
+    // ── Default (OTel) mode ──────────────────────────────────────────────────
   #[cfg(not(feature = "go-metrics-compat"))]
   mod names {
       pub const OP_DURATION:         &str = "db.client.operation.duration";
@@ -300,7 +311,7 @@ This document provides a detailed design and implementation specification for ad
   }
 
   // ── go-metrics-compat mode ───────────────────────────────────────────────
-  // Timer concepts split into _sum (Float64Counter) + _count (Int64Counter)
+  // Timer concepts split into _sum (Float64Counter) + _count (Counter<u64>)
   // matching the Go client's wire format exactly.
   #[cfg(feature = "go-metrics-compat")]
   mod names {
@@ -319,7 +330,7 @@ This document provides a detailed design and implementation specification for ad
   }
   ```
 
-  In default mode, all registrations use `Histogram`. In `go-metrics-compat` mode, timer-concept registrations create one `Float64Counter` (sum) and one `Int64Counter` (count); size/request-count concepts remain `Histogram`.
+  In default mode, all registrations use `Histogram`. In `go-metrics-compat` mode, timer-concept registrations create one `Float64Counter` (sum) and one `Counter<u64>` (count); size/request-count concepts remain `Histogram`.
 
 - **Data migration:** Explicitly out of scope. Users switching feature sets will see a gap or duplicate series in their observability backend. The library documentation should note this.
 
@@ -343,17 +354,17 @@ The table below is the authoritative mapping between the two naming regimes. The
 | Concept                           | Default (OTel v1.41.0) name                       | `go-metrics-compat` instrument(s)                                            | Notes                                                                          |
 | --------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | Operation latency (sum)           | `db.client.operation.duration` (Histogram)        | `oxia_client_op_sum` (Float64Counter)                                        | Default: single Histogram. Compat: separate sum + count counters               |
-| Operation latency (count)         | _(provided by Histogram internally)_              | `oxia_client_op_count` (Int64Counter)                                        | Compat-mode only; not a separate instrument in default mode                    |
+| Operation latency (count)         | _(provided by Histogram internally)_              | `oxia_client_op_count` (Counter<u64>)                                        | Compat-mode only; not a separate instrument in default mode                    |
 | Operation payload size            | `db.client.operation.size` _(proposed extension)_ (Histogram) | `oxia_client_op_value` (Histogram)                              | Histogram in both modes                                                        |
 | Batch total duration (sum)        | `db.client.batch.duration` (Histogram)            | `oxia_client_batch_total_sum` (Float64Counter)                               | Default: single Histogram. Compat: separate sum + count counters               |
-| Batch total duration (count)      | _(provided by Histogram internally)_              | `oxia_client_batch_total_count` (Int64Counter)                               | Compat-mode only                                                               |
+| Batch total duration (count)      | _(provided by Histogram internally)_              | `oxia_client_batch_total_count` (Counter<u64>)                               | Compat-mode only                                                               |
 | Batch execution duration (sum)    | `db.client.batch.exec_duration` (Histogram)       | `oxia_client_batch_exec_sum` (Float64Counter)                                | Default: single Histogram. Compat: separate sum + count counters               |
-| Batch execution duration (count)  | _(provided by Histogram internally)_              | `oxia_client_batch_exec_count` (Int64Counter)                                | Compat-mode only                                                               |
+| Batch execution duration (count)  | _(provided by Histogram internally)_              | `oxia_client_batch_exec_count` (Counter<u64>)                                | Compat-mode only                                                               |
 | Batch payload size                | `db.client.batch.size` (Histogram)                | `oxia_client_batch_value` (Histogram)                                        | Histogram in both modes                                                        |
 | Batch request count               | `db.client.batch.request_count` (Histogram)       | `oxia_client_batch_request` (Histogram)                                      | Histogram in both modes                                                        |
 
 > [!NOTE]
-> In **default mode** a single OTel `Histogram` covers each timer concept; count and sum are derived from the histogram's built-in aggregation. In **`go-metrics-compat` mode** each timer concept is split into a `Float64Counter` (`_sum`) and an `Int64Counter` (`_count`) to exactly replicate the Go client's wire format. Size and request-count concepts use `Histogram` in both modes.
+> In **default mode** a single OTel `Histogram` covers each timer concept; count and sum are derived from the histogram's built-in aggregation. In **`go-metrics-compat` mode** each timer concept is split into a `Float64Counter` (`_sum`) and a `Counter<u64>` (`_count`) to exactly replicate the Go client's wire format. Size and request-count concepts use `Histogram` in both modes.
 
 ### 9.3 Switching Overhead Analysis
 
@@ -375,21 +386,27 @@ The table below is the authoritative mapping between the two naming regimes. The
 
 ## 11. Rollout and Migration Plan
 
-- **Proposed:** **Phased Approach:**
-  - **Phase 1:** Add optional `telemetry` Cargo feature, introduce the `client/src/telemetry.rs` module, and configure the ZST metrics interface.
-  - **Phase 2:** Instrument tracing spans using `tracing` macros across the KV operations in `lib.rs` and `shard.rs`.
-  - **Phase 3:** Instrument metrics recorders inside the write batch and read batch streams. Expose the `meter_provider` setter on `Config` when the `telemetry` feature flag is active.
-  - **Phase 4:** Instrument background loops (heartbeat and assignment task).
+- **Implemented:**
+  - **Phase 1:** Added optional `metrics` Cargo feature, introduced the `client/src/metrics.rs` module, and configured the disabled-feature ZST metrics interface.
+  - **Phase 2:** Instrumented public KV operation spans with `#[tracing::instrument]` where practical. `connect` and `batch_get` keep manual spans.
+  - **Phase 3:** Centralized public operation metrics and shard read/write batch metrics. Exposed the `meter_provider` setter on `Config` when the `metrics` feature flag is active.
+- **Planned:**
+  - **Phase 4:** Instrument background loops such as heartbeat and assignment sync.
 
 ---
 
 ## 12. Testing and Validation Strategy
 
-- **Proposed:** Introduce unit tests under `client/tests/` using `otel-test` or `tracing-subscriber` mock layer to verify:
-  - Metric recordings match expected values (counts, sums) on success and failure.
-  - Spans have correct attributes and parent/child relationship.
-  - Custom injected `MeterProvider` receives the expected measurements.
-  - When `telemetry` feature is disabled, tests verify compilation succeeds and no metrics are registered.
+- **Implemented validation commands:**
+  - `just fmt`
+  - `cargo check --package mauricebarnum-oxia-client`
+  - `cargo check --package mauricebarnum-oxia-client --features metrics`
+  - `cargo check --package mauricebarnum-oxia-client --features go-metrics-compat`
+  - `just build-all`
+  - `just test-all`
+  - `just lint`
+- **Implemented tests:** Unit tests cover Go-compatible histogram boundaries and `KeyNotFound` result classification.
+- **Remaining test opportunities:** A tracing-subscriber mock layer could verify span field propagation and a custom OTel test meter could verify exact emitted measurements.
 
 ---
 
@@ -397,7 +414,7 @@ The table below is the authoritative mapping between the two naming regimes. The
 
 - ~~Do downstream dashboards expect exact Go-compatible metric names (`oxia_client_op`) or should we migrate to standard OTel `v1.41.0` names (`db.client.operation.duration`)?~~ **Resolved:** Both naming schemes are supported via the `go-metrics-compat` compile-time feature flag (see Section 8.3). The default build uses OTel `v1.41.0` names. Consumers with existing Go-compatible dashboards enable `go-metrics-compat` at compile time. Data migration is explicitly out of scope.
 
-- ~~Should `go-metrics-compat` imply `telemetry` in the Cargo feature graph (recommended, see Section 8.3) or remain an independent flag that produces a `compile_error!` when `telemetry` is not also enabled?~~ **Resolved**: `go-metrics-compat` feature implies `telemetry` in the feature graph.
+- ~~Should `go-metrics-compat` imply `metrics` in the Cargo feature graph (recommended, see Section 8.3) or remain an independent flag that produces a `compile_error!` when `metrics` is not also enabled?~~ **Resolved**: `go-metrics-compat` feature implies `metrics` in the feature graph.
 
 - ~~The Go client emits `oxia_client_op_sum` and `oxia_client_op_count` as separate instruments. Should the `go-metrics-compat` Rust mode register two instruments to exactly replicate that wire format, or is the Histogram approach (with its built-in count) an acceptable deviation?~~ **Resolved**: `go-metrics-compat` will register and use separate `_sum/_count` instruments.
 
@@ -408,13 +425,13 @@ The table below is the authoritative mapping between the two naming regimes. The
 ## B.1 Required Decisions
 
 - [x] Utilize the `tracing` crate facade with a target dependency on `tracing-opentelemetry` compatibility; do not take a direct dependency on `opentelemetry-sdk` in the library.
-- [x] Use Option B (Feature-gated, opt-in) via the `telemetry` Cargo feature.
+- [x] Use Option B (Feature-gated, opt-in) via the `metrics` Cargo feature.
 - [x] Use OTel `Histogram` for operation latencies instead of Go's counter-based timer approach.
 - [x] Prohibit dynamic user keys or values in metric attributes.
-- [x] Expose `meter_provider` setter on the `Config` builder when the `telemetry` feature flag is active.
+- [x] Expose `meter_provider` setter on the `Config` builder when the `metrics` feature flag is active.
 - [x] Add `go-metrics-compat` Cargo feature to select Go reference client metric name strings and instrument types at compile time (zero runtime overhead). Default build uses OTel `v1.41.0` semantic convention names.
-- [x] `go-metrics-compat` implies `telemetry` in the Cargo feature graph.
-- [x] `go-metrics-compat` mode registers separate `Float64Counter` (`_sum`) and `Int64Counter` (`_count`) instruments per timer concept to exactly replicate Go wire format. Default (OTel) mode uses a single `Histogram` per concept.
+- [x] `go-metrics-compat` implies `metrics` in the Cargo feature graph.
+- [x] `go-metrics-compat` mode registers separate `Float64Counter` (`_sum`) and `Counter<u64>` (`_count`) instruments per timer concept to exactly replicate Go wire format. Default (OTel) mode uses a single `Histogram` per concept.
 
 ## B.2 Assumptions
 
@@ -429,13 +446,13 @@ The table below is the authoritative mapping between the two naming regimes. The
 | Rust API Entry Point   | Span Name                     | Type (Span Kind)   | Metrics Emitted                                                           | Performance Classification |
 | ---------------------- | ----------------------------- | ------------------ | ------------------------------------------------------------------------- | -------------------------- |
 | `Client::connect`      | `"client.connect"`            | `SpanKind::Client` | —                                                                         | Warm path                  |
-| `Client::get`          | `"db.operation.get"`          | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Hot path                   |
-| `Client::put`          | `"db.operation.put"`          | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Hot path                   |
-| `Client::delete`       | `"db.operation.delete"`       | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Hot path                   |
-| `Client::delete_range` | `"db.operation.delete_range"` | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Warm path                  |
-| `Client::list`         | `"db.operation.list"`         | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Warm path                  |
-| `Client::range_scan`   | `"db.operation.range_scan"`   | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Warm path                  |
-| `Client::batch_get`    | `"db.operation.batch_get"`    | `SpanKind::Client` | `"oxia.client.batch.total_duration"`, `"oxia.client.batch.exec_duration"` | Hot path                   |
+| `Client::get`          | `"db.operation.get"`          | `SpanKind::Client` | `db.client.operation.duration`, `db.client.operation.size`                         | Hot path                   |
+| `Client::put`          | `"db.operation.put"`          | `SpanKind::Client` | `db.client.operation.duration`, `db.client.operation.size`                         | Hot path                   |
+| `Client::delete`       | `"db.operation.delete"`       | `SpanKind::Client` | `db.client.operation.duration`                                                    | Hot path                   |
+| `Client::delete_range` | `"db.operation.delete_range"` | `SpanKind::Client` | `db.client.operation.duration`                                                    | Warm path                  |
+| `Client::list`         | `"db.operation.list"`         | `SpanKind::Client` | `db.client.operation.duration`                                                    | Warm path                  |
+| `Client::range_scan`   | `"db.operation.range_scan"`   | `SpanKind::Client` | `db.client.operation.duration`, `db.client.operation.size`                         | Warm path                  |
+| `Client::batch_get`    | `"db.operation.batch_get"`    | `SpanKind::Client` | `db.client.operation.duration` for setup; shard layer emits batch metrics per read | Hot path                   |
 
 ---
 
@@ -450,7 +467,7 @@ The table below is the authoritative mapping between the two naming regimes. The
 - **Attributes:**
   - `db.system`: `"oxia"`
   - `db.name`: Namespace name (e.g. `"default"`)
-- **Error / Status Behavior:** Sets status to `Error` if connection to coordinator fails.
+- **Error / Status Behavior:** Records `error.type` if connection to coordinator fails.
 - **Performance Notes:** Warm path, allocates client metadata during connection.
 
 ##### Operation: `Client::get`
@@ -465,7 +482,7 @@ The table below is the authoritative mapping between the two naming regimes. The
   - `db.operation`: `"get"`
   - `db.oxia.shard_id`: Targeted shard ID
   - `error.type`: Set on failure.
-- **Error / Status Behavior:** `KeyNotFound` is marked `Ok`. Other failures set status to `Error`.
+- **Error / Status Behavior:** `KeyNotFound` is classified as metrics success. All `Err` results record `error.type` on the current span.
 - **Performance Notes:** Hot path. Minimize dynamic allocations in attributes.
 
 ##### Operation: `Client::put`
@@ -480,7 +497,7 @@ The table below is the authoritative mapping between the two naming regimes. The
   - `db.operation`: `"put"`
   - `db.oxia.shard_id`: Targeted shard ID
   - `error.type`: Set on failure.
-- **Error / Status Behavior:** Fails with `Error` status on version mismatches or network failures.
+- **Error / Status Behavior:** Version mismatches or network failures record `error.type` on the current span and classify the metrics result as failure.
 - **Performance Notes:** Hot path. Do not clone payload bytes for attribute logging.
 
 ---
@@ -494,41 +511,57 @@ The table below is the authoritative mapping between the two naming regimes. The
 
 | Concept                | Instrument name                  | Type      | Unit   | Attributes                                       | Cardinality | Lifecycle                   |
 | ---------------------- | -------------------------------- | --------- | ------ | ------------------------------------------------ | ----------- | --------------------------- |
-| Operation latency      | `db.client.operation.duration`   | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Operation payload size | `db.client.operation.size`       | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch total duration   | `db.client.batch.duration`       | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch exec duration    | `db.client.batch.exec_duration`  | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch payload size     | `db.client.batch.size`           | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch request count    | `db.client.batch.request_count`  | Histogram | `"1"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Operation latency      | `db.client.operation.duration`   | Histogram | `"ms"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Operation payload size | `db.client.operation.size`       | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch total duration   | `db.client.batch.duration`       | Histogram | `"ms"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch exec duration    | `db.client.batch.exec_duration`  | Histogram | `"ms"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch payload size     | `db.client.batch.size`           | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch request count    | `db.client.batch.request_count`  | Histogram | `"1"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 
 **`go-metrics-compat` mode**
 
 | Concept                          | Instrument name                      | Type             | Unit    | Attributes                                       | Cardinality | Lifecycle                   |
 | -------------------------------- | ------------------------------------ | ---------------- | ------- | ------------------------------------------------ | ----------- | --------------------------- |
-| Operation latency — sum          | `oxia_client_op_sum`                 | Float64Counter   | `"s"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Operation latency — count        | `oxia_client_op_count`               | Int64Counter     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Operation payload size           | `oxia_client_op_value`               | Histogram        | `"By"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch total duration — sum       | `oxia_client_batch_total_sum`        | Float64Counter   | `"s"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch total duration — count     | `oxia_client_batch_total_count`      | Int64Counter     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch exec duration — sum        | `oxia_client_batch_exec_sum`         | Float64Counter   | `"s"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch exec duration — count      | `oxia_client_batch_exec_count`       | Int64Counter     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch payload size               | `oxia_client_batch_value`            | Histogram        | `"By"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch request count              | `oxia_client_batch_request`          | Histogram        | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Operation latency — sum          | `oxia_client_op_sum`                 | Float64Counter   | `"ms"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Operation latency — count        | `oxia_client_op_count`               | Counter<u64>     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Operation payload size           | `oxia_client_op_value`               | Histogram        | `"By"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch total duration — sum       | `oxia_client_batch_total_sum`        | Float64Counter   | `"ms"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch total duration — count     | `oxia_client_batch_total_count`      | Counter<u64>     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch exec duration — sum        | `oxia_client_batch_exec_sum`         | Float64Counter   | `"ms"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch exec duration — count      | `oxia_client_batch_exec_count`       | Counter<u64>     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch payload size               | `oxia_client_batch_value`            | Histogram        | `"By"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch request count              | `oxia_client_batch_request`          | Histogram        | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 
 ---
 
 ## B.5 Module and File Plan
 
-- **[NEW] `client/src/telemetry.rs`**: Contains all metrics wrappers, declarations, and feature-conditional definitions.
-  - When `telemetry` feature is off: compile as a zero-overhead ZST.
-  - When `telemetry` is on and `go-metrics-compat` is **off**: defines `pub(crate) mod names` with `const &str` name constants for OTel instruments; all timer concepts use `Histogram`.
-  - When `telemetry` is on and `go-metrics-compat` is **on**: defines `pub(crate) mod names` with separate `_sum`/`_count` name constants; timer concepts register a `Float64Counter` (sum) and an `Int64Counter` (count) each. Size/count concepts remain `Histogram`. No `if` branches or runtime dispatch in either path.
-- **[MODIFY] `client/Cargo.toml`**:
-  - Add optional dependency `opentelemetry = { version = "0.27.0", features = ["metric"] }` (or matching latest stable version).
-  - Add feature `telemetry = ["dep:opentelemetry"]`.
-  - Add feature `go-metrics-compat = ["telemetry"]` (implies `telemetry`).
-- **[MODIFY] `client/src/lib.rs`**:
-  - Integrate operations tracing using `tracing::info_span!` macros inside `put_internal`, `get_internal`, `delete_internal`, etc.
-  - Record execution metrics inside completion handlers.
-- **[MODIFY] `client/src/config.rs`**:
-  - Expose `meter_provider` field under `#[cfg(feature = "telemetry")]` using `Option<Arc<dyn opentelemetry::metric::MeterProvider + Send + Sync>>` with a setter in the `ConfigBuilder`.
+- **[IMPLEMENTED] `client/src/metrics.rs`**: Contains all metrics wrappers, declarations, result classifiers, size extractors, and feature-conditional definitions.
+  - When `metrics` feature is off: compiles as a ZST metrics interface. Metric wrappers still record tracing span `error.type` for `Err` results, but avoid `Instant::now()`, duration math, result classifier calls, size extraction, OTel calls, and the `opentelemetry` dependency.
+  - When `metrics` is on and `go-metrics-compat` is **off**: defines `pub(crate) mod names` with `const &str` name constants for OTel instruments; all timer concepts use `Histogram`.
+  - When `metrics` is on and `go-metrics-compat` is **on**: defines `pub(crate) mod names` with separate `_sum`/`_count` name constants; timer concepts register a `Float64Counter` (sum) and a `Counter<u64>` (count) each. Size/count concepts remain `Histogram`. No `if` branches or runtime dispatch in either path.
+  - Public operation helpers include `operation_start`, `record_operation_result`, `record_operation_result_with_size`, and `record_operation_sync`.
+  - Shard batch helpers include `batch_start`, `batch_exec_duration`, and `record_batch`.
+  - Result classifiers include `result_kind` and `get_result_kind`; size extractors include `get_response_size` and `range_scan_response_size`.
+- **[IMPLEMENTED] `client/Cargo.toml`**:
+  - Added optional dependency `opentelemetry = { version = "0.29.1", features = ["metrics"] }`.
+  - Added feature `metrics = ["dep:opentelemetry"]`.
+  - Added feature `go-metrics-compat = ["metrics"]` (implies `metrics`).
+  - Preserved the external type allowlist entry for `opentelemetry::metrics::meter::MeterProvider`.
+- **[IMPLEMENTED] `client/src/lib.rs`**:
+  - Added `mod metrics;`.
+  - Added `metrics: metrics::Metrics` to `Client`.
+  - `Client::new` creates `Metrics::new(config.meter_provider())` when the `metrics` feature is enabled and `Metrics::new(None)` otherwise.
+  - `get_internal`, `put_internal`, `delete_internal`, `delete_range_internal`, `list_internal`, and `range_scan_internal` use `#[tracing::instrument(...)]` with `db.system`, `db.name`, `db.operation`, `db.oxia.shard_id`, and `error.type` fields.
+  - `connect` and `batch_get` retain manual spans and call centralized helpers for `error.type` and operation metrics.
+  - Public operation metrics are recorded once after the operation future resolves, including early shard selection and setup errors.
+- **[IMPLEMENTED] `client/src/shard.rs`**:
+  - Shard client data carries `metrics::Metrics`.
+  - Write batch handling builds one result and calls `metrics::record_batch` once.
+  - Read batch demux setup classifies result, value size, and request count once and calls `metrics::record_batch` once.
+  - Retry paths measure retry execution duration separately and preserve total duration, execution duration, value size, and request count.
+- **[IMPLEMENTED] `client/src/config.rs`**:
+  - Exposes `meter_provider` under `#[cfg(feature = "metrics")]` using `Option<Arc<dyn opentelemetry::metrics::MeterProvider + Send + Sync>>` with a setter in the `ConfigBuilder`.
+- **[IMPLEMENTED] `Justfile`**:
+  - Added `build-all` to build with metrics off, `metrics`, and `go-metrics-compat`.
+  - Added `test-all` to run nextest with metrics off, `metrics`, and `go-metrics-compat`.

--- a/otel-instrumentation-design.md
+++ b/otel-instrumentation-design.md
@@ -170,9 +170,9 @@ This document provides a detailed design and implementation specification for ad
   - **Rejected Alternative:** Directly use the `opentelemetry::trace::Tracer` API in-crate.
   - **Reason for Rejection:** Direct OTel trace API makes logs harder to correlate and diverges from the existing `tracing` macros already used in the codebase.
 - **Decision 2: Latency metrics implementation**
-  - **Selected Approach:** Use OTel `Histogram` for operation latencies.
-  - **Rejected Alternative:** Translate Go's dual-counter Timer approach literally (making a count counter and a latency sum counter).
-  - **Reason for Rejection:** A dual-counter Timer is not idiomatic in modern OpenTelemetry and is rejected by the OTel API in favor of histograms, which natively provide percentiles, counts, and sums.
+  - **Selected Approach (default / OTel mode):** Use OTel `Histogram` for operation latencies. A histogram provides percentiles, count, and sum natively without duplicating instruments.
+  - **Selected Approach (`go-metrics-compat` mode):** Register a `Float64Counter` (`_sum`) and an `Int64Counter` (`_count`) as separate instruments to exactly replicate the Go wire format. This is intentional: dashboards built against the Go client expect two distinct series.
+  - **Rejected Alternative for default mode:** Translate Go's dual-counter Timer approach literally. Rejected because it is not idiomatic in modern OpenTelemetry.
 
 ---
 
@@ -270,48 +270,58 @@ This document provides a detailed design and implementation specification for ad
 
 ### 8.3 Metric Naming Feature Flag: `go-metrics-compat`
 
-- **Proposed:** Add a second Cargo feature, `go-metrics-compat`, that selects the Go reference client's legacy metric name strings at **compile time** rather than at runtime.
-- **Rationale:** The two naming schemes (`db.client.operation.duration` vs `oxia_client_op`) differ only in the string constants used at histogram/counter creation. Selecting between them with `#[cfg(feature = "go-metrics-compat")]` eliminates all branching and string comparisons at runtime — the unused name is never materialized in the binary. This satisfies the requirement of zero runtime overhead.
-- **Feature independence:** `go-metrics-compat` is orthogonal to `telemetry`. Enabling `go-metrics-compat` without `telemetry` is meaningless and the implementation should emit a `compile_error!` or at minimum a `#[cfg(all(feature = "go-metrics-compat", not(feature = "telemetry")))]` warning.
+- **Resolved:** Add a second Cargo feature, `go-metrics-compat`, that selects the Go reference client's legacy metric name strings **and instrument types** at **compile time** rather than at runtime.
+- **Rationale:** The two naming schemes (`db.client.operation.duration` vs `oxia_client_op`) differ in both string constants and instrument shape. Selecting between them with `#[cfg(feature = "go-metrics-compat")]` eliminates all branching at runtime — the unused variant is never materialized in the binary. This satisfies the requirement of zero runtime overhead.
+- **Resolved:** `go-metrics-compat` implies `telemetry` in the Cargo feature graph. This prevents silent no-ops and makes the dependency relationship explicit.
+- **Resolved:** `go-metrics-compat` mode registers **two separate instruments** per timer concept (a `Float64Counter` for `_sum` and an `Int64Counter` for `_count`) to exactly replicate Go wire format. Default (OTel) mode uses a single `Histogram`.
 - **Proposed:** The Cargo feature declaration:
 
   ```toml
   # client/Cargo.toml  (illustrative — not yet implemented)
   [features]
-  telemetry        = ["dep:opentelemetry"]
-  go-metrics-compat = ["telemetry"]   # implies telemetry; names only change when metrics are active
+  telemetry         = ["dep:opentelemetry"]
+  go-metrics-compat = ["telemetry"]   # implies telemetry
   ```
 
-  Declaring `go-metrics-compat` as implying `telemetry` is the cleanest approach: it prevents silent no-ops and makes the dependency relationship explicit in the feature graph.
-
-- **Proposed:** Inside `client/src/telemetry.rs`, define the metric name strings as compile-time constants selected by the feature flag:
+- **Proposed:** Inside `client/src/telemetry.rs`, the instrument types and name strings are both selected by the feature flag:
 
   ```rust
   // Illustrative — not yet implemented
+
+  // ── Default (OTel) mode ──────────────────────────────────────────────────
   #[cfg(not(feature = "go-metrics-compat"))]
   mod names {
-      pub const OP_DURATION:        &str = "db.client.operation.duration";
-      pub const OP_SIZE:            &str = "db.client.operation.size";     // proposed OTel extension
-      pub const BATCH_TOTAL:        &str = "db.client.batch.duration";
-      pub const BATCH_EXEC:         &str = "db.client.batch.exec_duration";
-      pub const BATCH_SIZE:         &str = "db.client.batch.size";
-      pub const BATCH_REQUEST_COUNT:&str = "db.client.batch.request_count";
+      pub const OP_DURATION:         &str = "db.client.operation.duration";
+      pub const OP_SIZE:             &str = "db.client.operation.size";  // proposed OTel extension
+      pub const BATCH_TOTAL:         &str = "db.client.batch.duration";
+      pub const BATCH_EXEC:          &str = "db.client.batch.exec_duration";
+      pub const BATCH_SIZE:          &str = "db.client.batch.size";
+      pub const BATCH_REQUEST_COUNT: &str = "db.client.batch.request_count";
   }
 
+  // ── go-metrics-compat mode ───────────────────────────────────────────────
+  // Timer concepts split into _sum (Float64Counter) + _count (Int64Counter)
+  // matching the Go client's wire format exactly.
   #[cfg(feature = "go-metrics-compat")]
   mod names {
-      pub const OP_DURATION:        &str = "oxia_client_op_sum";          // Go: sum counter
-      pub const OP_SIZE:            &str = "oxia_client_op_value";
-      pub const BATCH_TOTAL:        &str = "oxia_client_batch_total_sum";
-      pub const BATCH_EXEC:         &str = "oxia_client_batch_exec_sum";
-      pub const BATCH_SIZE:         &str = "oxia_client_batch_value";
-      pub const BATCH_REQUEST_COUNT:&str = "oxia_client_batch_request";
+      // sum counters
+      pub const OP_DURATION_SUM:         &str = "oxia_client_op_sum";
+      pub const BATCH_TOTAL_SUM:         &str = "oxia_client_batch_total_sum";
+      pub const BATCH_EXEC_SUM:          &str = "oxia_client_batch_exec_sum";
+      // count counters
+      pub const OP_DURATION_COUNT:       &str = "oxia_client_op_count";
+      pub const BATCH_TOTAL_COUNT:       &str = "oxia_client_batch_total_count";
+      pub const BATCH_EXEC_COUNT:        &str = "oxia_client_batch_exec_count";
+      // histograms (same in both modes)
+      pub const OP_SIZE:                 &str = "oxia_client_op_value";
+      pub const BATCH_SIZE:              &str = "oxia_client_batch_value";
+      pub const BATCH_REQUEST_COUNT:     &str = "oxia_client_batch_request";
   }
   ```
 
-  All histogram registrations reference `names::OP_DURATION`, etc., so no further code changes are needed when toggling the feature.
+  In default mode, all registrations use `Histogram`. In `go-metrics-compat` mode, timer-concept registrations create one `Float64Counter` (sum) and one `Int64Counter` (count); size/request-count concepts remain `Histogram`.
 
-- **Data migration:** Explicitly out of scope. Users switching between the two feature sets will see a gap or duplicate metric series in their observability backend. Documentation should note this; no migration tooling is provided by this library.
+- **Data migration:** Explicitly out of scope. Users switching feature sets will see a gap or duplicate series in their observability backend. The library documentation should note this.
 
 ---
 
@@ -330,17 +340,20 @@ This document provides a detailed design and implementation specification for ad
 
 The table below is the authoritative mapping between the two naming regimes. The **`go-metrics-compat` name** column lists the exact string constants the Go reference client records metrics under; see Section 2.2 for observation source references.
 
-| Concept                  | Default (OTel v1.41.0) name                       | `go-metrics-compat` name                      | Notes                                                             |
-| ------------------------ | ------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------- |
-| Operation latency        | `db.client.operation.duration`                    | `oxia_client_op_sum` / `oxia_client_op_count` | Go uses dual counters; Rust uses a single Histogram in both modes |
-| Operation payload size   | `db.client.operation.size` _(proposed extension)_ | `oxia_client_op_value`                        | —                                                                 |
-| Batch total duration     | `db.client.batch.duration`                        | `oxia_client_batch_total_sum`                 | —                                                                 |
-| Batch execution duration | `db.client.batch.exec_duration`                   | `oxia_client_batch_exec_sum`                  | —                                                                 |
-| Batch payload size       | `db.client.batch.size`                            | `oxia_client_batch_value`                     | —                                                                 |
-| Batch request count      | `db.client.batch.request_count`                   | `oxia_client_batch_request`                   | —                                                                 |
+| Concept                           | Default (OTel v1.41.0) name                       | `go-metrics-compat` instrument(s)                                            | Notes                                                                          |
+| --------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Operation latency (sum)           | `db.client.operation.duration` (Histogram)        | `oxia_client_op_sum` (Float64Counter)                                        | Default: single Histogram. Compat: separate sum + count counters               |
+| Operation latency (count)         | _(provided by Histogram internally)_              | `oxia_client_op_count` (Int64Counter)                                        | Compat-mode only; not a separate instrument in default mode                    |
+| Operation payload size            | `db.client.operation.size` _(proposed extension)_ (Histogram) | `oxia_client_op_value` (Histogram)                              | Histogram in both modes                                                        |
+| Batch total duration (sum)        | `db.client.batch.duration` (Histogram)            | `oxia_client_batch_total_sum` (Float64Counter)                               | Default: single Histogram. Compat: separate sum + count counters               |
+| Batch total duration (count)      | _(provided by Histogram internally)_              | `oxia_client_batch_total_count` (Int64Counter)                               | Compat-mode only                                                               |
+| Batch execution duration (sum)    | `db.client.batch.exec_duration` (Histogram)       | `oxia_client_batch_exec_sum` (Float64Counter)                                | Default: single Histogram. Compat: separate sum + count counters               |
+| Batch execution duration (count)  | _(provided by Histogram internally)_              | `oxia_client_batch_exec_count` (Int64Counter)                                | Compat-mode only                                                               |
+| Batch payload size                | `db.client.batch.size` (Histogram)                | `oxia_client_batch_value` (Histogram)                                        | Histogram in both modes                                                        |
+| Batch request count               | `db.client.batch.request_count` (Histogram)       | `oxia_client_batch_request` (Histogram)                                      | Histogram in both modes                                                        |
 
 > [!NOTE]
-> The Go client splits each timer into a `_sum` counter and a `_count` counter. The Rust implementation collapses these into a single `Histogram` regardless of which naming mode is active, because OTel Histograms provide both sum and count natively. The `go-metrics-compat` names therefore reference only the sum counter's name as the histogram instrument name. Backends that expected a separate count counter will need to use the histogram's built-in count aggregation.
+> In **default mode** a single OTel `Histogram` covers each timer concept; count and sum are derived from the histogram's built-in aggregation. In **`go-metrics-compat` mode** each timer concept is split into a `Float64Counter` (`_sum`) and an `Int64Counter` (`_count`) to exactly replicate the Go client's wire format. Size and request-count concepts use `Histogram` in both modes.
 
 ### 9.3 Switching Overhead Analysis
 
@@ -399,9 +412,9 @@ The table below is the authoritative mapping between the two naming regimes. The
 - [x] Use OTel `Histogram` for operation latencies instead of Go's counter-based timer approach.
 - [x] Prohibit dynamic user keys or values in metric attributes.
 - [x] Expose `meter_provider` setter on the `Config` builder when the `telemetry` feature flag is active.
-- [x] Add `go-metrics-compat` Cargo feature to select Go reference client metric name strings at compile time (zero runtime overhead). Default build uses OTel `v1.41.0` semantic convention names.
-- [x] `go-metrics-compat` should imply `telemetry` in the feature graph.
-- [x] `go-metrics-compat` mode will not register separate `_sum`/`_count` instruments to exactly replicate Go wire format
+- [x] Add `go-metrics-compat` Cargo feature to select Go reference client metric name strings and instrument types at compile time (zero runtime overhead). Default build uses OTel `v1.41.0` semantic convention names.
+- [x] `go-metrics-compat` implies `telemetry` in the Cargo feature graph.
+- [x] `go-metrics-compat` mode registers separate `Float64Counter` (`_sum`) and `Int64Counter` (`_count`) instruments per timer concept to exactly replicate Go wire format. Default (OTel) mode uses a single `Histogram` per concept.
 
 ## B.2 Assumptions
 
@@ -475,16 +488,32 @@ The table below is the authoritative mapping between the two naming regimes. The
 ## B.4 Metric Inventory
 
 > [!IMPORTANT]
-> Metric names are selected at compile time. The **Default name** column applies when `go-metrics-compat` is **not** enabled. The **`go-metrics-compat` name** column applies when that feature is enabled. Instrument type, unit, and attributes are identical regardless of naming mode.
+> Metric names **and instrument types** are selected at compile time. The **Default** columns apply when `go-metrics-compat` is **not** enabled. The **`go-metrics-compat`** columns apply when it is. In compat mode, timer concepts emit two instruments; size/count concepts remain Histograms.
 
-| Concept                | Default name (OTel v1.41.0)     | `go-metrics-compat` name      | Instrument | Unit   | Attributes                                       | Cardinality | Lifecycle                   |
-| ---------------------- | ------------------------------- | ----------------------------- | ---------- | ------ | ------------------------------------------------ | ----------- | --------------------------- |
-| Operation latency      | `db.client.operation.duration`  | `oxia_client_op_sum`          | Histogram  | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Operation payload size | `db.client.operation.size`      | `oxia_client_op_value`        | Histogram  | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch total duration   | `db.client.batch.duration`      | `oxia_client_batch_total_sum` | Histogram  | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch exec duration    | `db.client.batch.exec_duration` | `oxia_client_batch_exec_sum`  | Histogram  | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch payload size     | `db.client.batch.size`          | `oxia_client_batch_value`     | Histogram  | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
-| Batch request count    | `db.client.batch.request_count` | `oxia_client_batch_request`   | Histogram  | `"1"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+**Default mode (OTel v1.41.0)**
+
+| Concept                | Instrument name                  | Type      | Unit   | Attributes                                       | Cardinality | Lifecycle                   |
+| ---------------------- | -------------------------------- | --------- | ------ | ------------------------------------------------ | ----------- | --------------------------- |
+| Operation latency      | `db.client.operation.duration`   | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Operation payload size | `db.client.operation.size`       | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch total duration   | `db.client.batch.duration`       | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch exec duration    | `db.client.batch.exec_duration`  | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch payload size     | `db.client.batch.size`           | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch request count    | `db.client.batch.request_count`  | Histogram | `"1"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+
+**`go-metrics-compat` mode**
+
+| Concept                          | Instrument name                      | Type             | Unit    | Attributes                                       | Cardinality | Lifecycle                   |
+| -------------------------------- | ------------------------------------ | ---------------- | ------- | ------------------------------------------------ | ----------- | --------------------------- |
+| Operation latency — sum          | `oxia_client_op_sum`                 | Float64Counter   | `"s"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Operation latency — count        | `oxia_client_op_count`               | Int64Counter     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Operation payload size           | `oxia_client_op_value`               | Histogram        | `"By"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch total duration — sum       | `oxia_client_batch_total_sum`        | Float64Counter   | `"s"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch total duration — count     | `oxia_client_batch_total_count`      | Int64Counter     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch exec duration — sum        | `oxia_client_batch_exec_sum`         | Float64Counter   | `"s"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch exec duration — count      | `oxia_client_batch_exec_count`       | Int64Counter     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch payload size               | `oxia_client_batch_value`            | Histogram        | `"By"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch request count              | `oxia_client_batch_request`          | Histogram        | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
 
 ---
 
@@ -492,11 +521,12 @@ The table below is the authoritative mapping between the two naming regimes. The
 
 - **[NEW] `client/src/telemetry.rs`**: Contains all metrics wrappers, declarations, and feature-conditional definitions.
   - When `telemetry` feature is off: compile as a zero-overhead ZST.
-  - When `telemetry` is on: defines `pub(crate) mod names` with `const &str` metric name constants selected via `#[cfg(feature = "go-metrics-compat")]` (see Section 8.3). All histogram registrations reference these constants. No `if` branches or runtime dispatch.
+  - When `telemetry` is on and `go-metrics-compat` is **off**: defines `pub(crate) mod names` with `const &str` name constants for OTel instruments; all timer concepts use `Histogram`.
+  - When `telemetry` is on and `go-metrics-compat` is **on**: defines `pub(crate) mod names` with separate `_sum`/`_count` name constants; timer concepts register a `Float64Counter` (sum) and an `Int64Counter` (count) each. Size/count concepts remain `Histogram`. No `if` branches or runtime dispatch in either path.
 - **[MODIFY] `client/Cargo.toml`**:
   - Add optional dependency `opentelemetry = { version = "0.27.0", features = ["metric"] }` (or matching latest stable version).
   - Add feature `telemetry = ["dep:opentelemetry"]`.
-  - Add feature `go-metrics-compat = ["telemetry"]` (implies `telemetry`; see Open Question 1 for the alternative).
+  - Add feature `go-metrics-compat = ["telemetry"]` (implies `telemetry`).
 - **[MODIFY] `client/src/lib.rs`**:
   - Integrate operations tracing using `tracing::info_span!` macros inside `put_internal`, `get_internal`, `delete_internal`, etc.
   - Record execution metrics inside completion handlers.

--- a/otel-instrumentation-design.md
+++ b/otel-instrumentation-design.md
@@ -24,7 +24,9 @@ This document provides a detailed design and implementation specification for ad
 - **Implemented:** Shard batch metrics are centralized in `client/src/metrics.rs` through `batch_start`, `batch_exec_duration`, and `record_batch`, preserving total duration, execution duration, payload size, and request count.
 - **Implemented:** Operation spans use `#[tracing::instrument]` where practical. `Client::connect` and `Client::batch_get` keep manual spans because their setup flow is more awkward to express with the attribute macro.
 - **Implemented:** `error.type` recording remains unconditional through `metrics::record_error_type`, including default builds where the `metrics` feature is disabled.
-- **Implemented:** `go-metrics-compat` implies `metrics` and selects Go-compatible metric names and timer instrument shapes at compile time.
+- **Implemented:** `go-metrics-compat` implies `metrics` and adds Go-compatible latency sum/count counters at compile time while keeping the semantic OTel histogram instruments enabled.
+- **Implemented:** Semantic duration metrics use seconds (`"s"`) and semantic size metrics use bytes (`"By"`) following OTel metric unit guidance.
+- **Implemented:** Semantic latency, size, and request-count metrics are OTel histogram instruments without explicit client-side boundaries. Applications configure SDK views to aggregate them as `ExponentialHistogram` data points; the CLI is the canonical example.
 
 ---
 
@@ -138,8 +140,9 @@ This document provides a detailed design and implementation specification for ad
   - `Client::connect` (file `client/src/lib.rs`, line 886) - Go client performs lazy connection at executor level.
   - `Client::reconnect` (file `client/src/lib.rs`, line 895).
   - `stale_shard_map_retry` (file `client/src/lib.rs`, line 803) - explicit stale-map wait loop in Rust client.
-- **Observed:** **Go instrumentation with no Rust equivalent:**
+- **Observed:** **Go instrumentation with limited Rust compatibility support:**
   - Go's custom `Timer` metric type (represented in Rust compat mode as a sum `Float64Counter` and a count `Counter<u64>`).
+  - Go's size histograms (`oxia_client_op_value`, `oxia_client_batch_value`, `oxia_client_batch_request`) are intentionally not reproduced in Rust compat mode; semantic histogram instruments remain the supported size/count shape.
   - Go's unstructured/slog logger. Rust utilizes `tracing` exclusively.
 
 ---
@@ -182,8 +185,8 @@ This document provides a detailed design and implementation specification for ad
   - **Rejected Alternative:** Directly use the `opentelemetry::trace::Tracer` API in-crate.
   - **Reason for Rejection:** Direct OTel trace API makes logs harder to correlate and diverges from the existing `tracing` macros already used in the codebase.
 - **Decision 2: Latency metrics implementation**
-  - **Selected Approach (default / OTel mode):** Use OTel `Histogram` for operation latencies. A histogram provides percentiles, count, and sum natively without duplicating instruments.
-  - **Selected Approach (`go-metrics-compat` mode):** Register a `Float64Counter` (`_sum`) and a `Counter<u64>` (`_count`) as separate instruments to exactly replicate the Go wire format. This is intentional: dashboards built against the Go client expect two distinct series.
+  - **Selected Approach (semantic / OTel mode):** Use OTel `Histogram` instruments for operation latencies, payload sizes, and request counts. The client records measurements only; applications configure SDK views to aggregate those instruments as `ExponentialHistogram` data points.
+  - **Selected Approach (`go-metrics-compat` mode):** Keep the semantic histograms enabled and additionally register a `Float64Counter` (`_sum`) and a `Counter<u64>` (`_count`) per timer concept to replicate the Go latency wire format. This is intentional: dashboards built against the Go client expect two distinct latency series.
   - **Rejected Alternative for default mode:** Translate Go's dual-counter Timer approach literally. Rejected because it is not idiomatic in modern OpenTelemetry.
 
 ---
@@ -233,13 +236,14 @@ This document provides a detailed design and implementation specification for ad
 
 ### 6.1 Metrics Specifications
 
-- **Implemented:** In default mode, the client registers the following metrics when the `metrics` feature is enabled:
-  - `"db.client.operation.duration"` (Histogram, unit: `"ms"`): Measures operation execution duration.
+- **Implemented:** With the `metrics` feature enabled, the client always registers the following semantic OTel histogram instruments:
+  - `"db.client.operation.duration"` (Histogram, unit: `"s"`): Measures operation execution duration.
   - `"db.client.operation.size"` (Histogram, unit: `"By"`): Measures payload sizes of `put` values and `get`/`range_scan` returned values.
-  - `"db.client.batch.duration"` (Histogram, unit: `"ms"`): Measures total duration of batched requests (queueing + execution).
-  - `"db.client.batch.exec_duration"` (Histogram, unit: `"ms"`): Measures actual network execution duration of batches.
+  - `"db.client.batch.duration"` (Histogram, unit: `"s"`): Measures total duration of batched requests (queueing + execution).
+  - `"db.client.batch.exec_duration"` (Histogram, unit: `"s"`): Measures actual network execution duration of batches.
   - `"db.client.batch.size"` (Histogram, unit: `"By"`): Measures total payload size in a batch.
   - `"db.client.batch.request_count"` (Histogram, unit: `"1"`): Measures count of operations packed in a batch.
+- **Implemented:** The client does not set explicit bucket boundaries on these instruments. Callers configure SDK views for `Base2ExponentialHistogram` aggregation if they need mergeable quantile estimation. The CLI installs such a view in `cmd/src/metrics.rs`.
 
 ### 6.2 Attributes and Bounded Cardinality
 
@@ -281,12 +285,13 @@ This document provides a detailed design and implementation specification for ad
 - **Implemented:** `Config` and `ConfigBuilder` expose a `meter_provider` field and setter under the `metrics` feature flag. This allows downstream consumers to explicitly inject custom OTel `MeterProvider` implementations, mapped as `Arc<dyn opentelemetry::metrics::MeterProvider + Send + Sync>`. If not set, metrics fallback to `opentelemetry::global::meter_provider()`.
 - **Proposed:** MSRV impact is negligible, as `opentelemetry` supports modern stable Rust compilers matching the workspace's version.
 
-### 8.3 Metric Naming Feature Flag: `go-metrics-compat`
+### 8.3 Compatibility Feature Flag: `go-metrics-compat`
 
-- **Resolved:** Add a second Cargo feature, `go-metrics-compat`, that selects the Go reference client's legacy metric name strings **and instrument types** at **compile time** rather than at runtime.
-- **Rationale:** The two naming schemes (`db.client.operation.duration` vs `oxia_client_op`) differ in both string constants and instrument shape. Selecting between them with `#[cfg(feature = "go-metrics-compat")]` eliminates all branching at runtime — the unused variant is never materialized in the binary. This satisfies the requirement of zero runtime overhead.
+- **Resolved:** Add a second Cargo feature, `go-metrics-compat`, that adds Go reference-client latency sum/count instruments at **compile time** rather than at runtime.
+- **Rationale:** The Go latency timer shape (`oxia_client_*_sum` plus `oxia_client_*_count`) differs from semantic OTel histogram instruments. Adding the Go-compatible counters with `#[cfg(feature = "go-metrics-compat")]` eliminates runtime branching in the hot path.
 - **Resolved:** `go-metrics-compat` implies `metrics` in the Cargo feature graph. This prevents silent no-ops and makes the dependency relationship explicit.
-- **Resolved:** `go-metrics-compat` mode registers **two separate instruments** per timer concept (a `Float64Counter` for `_sum` and a `Counter<u64>` for `_count`) to exactly replicate Go wire format. Default (OTel) mode uses a single `Histogram`.
+- **Resolved:** `go-metrics-compat` mode registers **two additional instruments** per timer concept (a `Float64Counter` for `_sum` and a `Counter<u64>` for `_count`) to replicate Go latency wire format. Semantic OTel histograms remain registered in both modes.
+- **Resolved:** Go-compatible size/count histograms are intentionally not emitted. The semantic size/count histograms are the only Rust client size/count metric shape.
 - **Implemented:** The Cargo feature declaration:
 
   ```toml
@@ -296,25 +301,24 @@ This document provides a detailed design and implementation specification for ad
   go-metrics-compat = ["metrics"]   # implies metrics
   ```
 
-- **Implemented:** Inside `client/src/metrics.rs`, the instrument types and name strings are both selected by feature flags:
+- **Implemented:** Inside `client/src/metrics.rs`, semantic names are always registered when `metrics` is enabled, and Go latency counters are added when `go-metrics-compat` is enabled:
 
   ```rust
-    // ── Default (OTel) mode ──────────────────────────────────────────────────
-  #[cfg(not(feature = "go-metrics-compat"))]
-  mod names {
+  // ── Semantic OTel histograms ──────────────────────────────────────────────
+  pub(crate) mod names {
       pub const OP_DURATION:         &str = "db.client.operation.duration";
-      pub const OP_SIZE:             &str = "db.client.operation.size";  // proposed OTel extension
+      pub const OP_SIZE:             &str = "db.client.operation.size";
       pub const BATCH_TOTAL:         &str = "db.client.batch.duration";
       pub const BATCH_EXEC:          &str = "db.client.batch.exec_duration";
       pub const BATCH_SIZE:          &str = "db.client.batch.size";
       pub const BATCH_REQUEST_COUNT: &str = "db.client.batch.request_count";
   }
 
-  // ── go-metrics-compat mode ───────────────────────────────────────────────
+  // ── go-metrics-compat latency counters ───────────────────────────────────
   // Timer concepts split into _sum (Float64Counter) + _count (Counter<u64>)
   // matching the Go client's wire format exactly.
   #[cfg(feature = "go-metrics-compat")]
-  mod names {
+  mod compat_names {
       // sum counters
       pub const OP_DURATION_SUM:         &str = "oxia_client_op_sum";
       pub const BATCH_TOTAL_SUM:         &str = "oxia_client_batch_total_sum";
@@ -323,14 +327,10 @@ This document provides a detailed design and implementation specification for ad
       pub const OP_DURATION_COUNT:       &str = "oxia_client_op_count";
       pub const BATCH_TOTAL_COUNT:       &str = "oxia_client_batch_total_count";
       pub const BATCH_EXEC_COUNT:        &str = "oxia_client_batch_exec_count";
-      // histograms (same in both modes)
-      pub const OP_SIZE:                 &str = "oxia_client_op_value";
-      pub const BATCH_SIZE:              &str = "oxia_client_batch_value";
-      pub const BATCH_REQUEST_COUNT:     &str = "oxia_client_batch_request";
   }
   ```
 
-  In default mode, all registrations use `Histogram`. In `go-metrics-compat` mode, timer-concept registrations create one `Float64Counter` (sum) and one `Counter<u64>` (count); size/request-count concepts remain `Histogram`.
+  Semantic registrations use `Histogram` in both modes. In `go-metrics-compat` mode, timer-concept registrations additionally create one `Float64Counter` (sum) and one `Counter<u64>` (count).
 
 - **Data migration:** Explicitly out of scope. Users switching feature sets will see a gap or duplicate series in their observability backend. The library documentation should note this.
 
@@ -339,7 +339,7 @@ This document provides a detailed design and implementation specification for ad
 ## 9. Semantic Conventions and Cross-Language Consistency
 
 - **Proposed:** Align strictly with OTel Semantic Conventions version `v1.41.0` (database client namespace) by default.
-- **Proposed:** The `go-metrics-compat` Cargo feature (Section 8.3) is the **only supported mechanism** for selecting Go-compatible metric names. No runtime configuration knob is exposed for this choice — the selection is baked in at compile time.
+- **Implemented:** The `go-metrics-compat` Cargo feature (Section 8.3) is the **only supported mechanism** for adding Go-compatible latency metric names. No runtime configuration knob is exposed for this choice.
 
 ### 9.1 Technology-Agnostic Naming Rationale
 
@@ -349,22 +349,22 @@ This document provides a detailed design and implementation specification for ad
 
 ### 9.2 Name Mapping Reference
 
-The table below is the authoritative mapping between the two naming regimes. The **`go-metrics-compat` name** column lists the exact string constants the Go reference client records metrics under; see Section 2.2 for observation source references.
+The table below is the authoritative mapping between semantic OTel metrics and optional Go-compatible latency metrics. The **`go-metrics-compat` instrument(s)** column lists the extra latency instruments emitted for Go-dashboard compatibility.
 
 | Concept                           | Default (OTel v1.41.0) name                       | `go-metrics-compat` instrument(s)                                            | Notes                                                                          |
 | --------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Operation latency (sum)           | `db.client.operation.duration` (Histogram)        | `oxia_client_op_sum` (Float64Counter)                                        | Default: single Histogram. Compat: separate sum + count counters               |
-| Operation latency (count)         | _(provided by Histogram internally)_              | `oxia_client_op_count` (Counter<u64>)                                        | Compat-mode only; not a separate instrument in default mode                    |
-| Operation payload size            | `db.client.operation.size` _(proposed extension)_ (Histogram) | `oxia_client_op_value` (Histogram)                              | Histogram in both modes                                                        |
-| Batch total duration (sum)        | `db.client.batch.duration` (Histogram)            | `oxia_client_batch_total_sum` (Float64Counter)                               | Default: single Histogram. Compat: separate sum + count counters               |
+| Operation latency (sum)           | `db.client.operation.duration` (Histogram)        | `oxia_client_op_sum` (Float64Counter)                                        | Semantic Histogram always emitted. Compat adds sum + count counters            |
+| Operation latency (count)         | _(provided by Histogram internally)_              | `oxia_client_op_count` (Counter<u64>)                                        | Compat-mode only as an additional counter                                      |
+| Operation payload size            | `db.client.operation.size` (Histogram)            | _none_                                                                       | Go size histogram is intentionally not emitted                                 |
+| Batch total duration (sum)        | `db.client.batch.duration` (Histogram)            | `oxia_client_batch_total_sum` (Float64Counter)                               | Semantic Histogram always emitted. Compat adds sum + count counters            |
 | Batch total duration (count)      | _(provided by Histogram internally)_              | `oxia_client_batch_total_count` (Counter<u64>)                               | Compat-mode only                                                               |
-| Batch execution duration (sum)    | `db.client.batch.exec_duration` (Histogram)       | `oxia_client_batch_exec_sum` (Float64Counter)                                | Default: single Histogram. Compat: separate sum + count counters               |
+| Batch execution duration (sum)    | `db.client.batch.exec_duration` (Histogram)       | `oxia_client_batch_exec_sum` (Float64Counter)                                | Semantic Histogram always emitted. Compat adds sum + count counters            |
 | Batch execution duration (count)  | _(provided by Histogram internally)_              | `oxia_client_batch_exec_count` (Counter<u64>)                                | Compat-mode only                                                               |
-| Batch payload size                | `db.client.batch.size` (Histogram)                | `oxia_client_batch_value` (Histogram)                                        | Histogram in both modes                                                        |
-| Batch request count               | `db.client.batch.request_count` (Histogram)       | `oxia_client_batch_request` (Histogram)                                      | Histogram in both modes                                                        |
+| Batch payload size                | `db.client.batch.size` (Histogram)                | _none_                                                                       | Go size histogram is intentionally not emitted                                 |
+| Batch request count               | `db.client.batch.request_count` (Histogram)       | _none_                                                                       | Go count histogram is intentionally not emitted                                |
 
 > [!NOTE]
-> In **default mode** a single OTel `Histogram` covers each timer concept; count and sum are derived from the histogram's built-in aggregation. In **`go-metrics-compat` mode** each timer concept is split into a `Float64Counter` (`_sum`) and a `Counter<u64>` (`_count`) to exactly replicate the Go client's wire format. Size and request-count concepts use `Histogram` in both modes.
+> The semantic `Histogram` instruments are emitted in both modes. In **`go-metrics-compat` mode** each timer concept also emits a `Float64Counter` (`_sum`) and a `Counter<u64>` (`_count`) to replicate the Go client's latency wire format.
 
 ### 9.3 Switching Overhead Analysis
 
@@ -402,21 +402,24 @@ The table below is the authoritative mapping between the two naming regimes. The
   - `cargo check --package mauricebarnum-oxia-client`
   - `cargo check --package mauricebarnum-oxia-client --features metrics`
   - `cargo check --package mauricebarnum-oxia-client --features go-metrics-compat`
+  - `cargo check --package mauricebarnum-oxia-cmd`
+  - `cargo nextest run -E 'kind(lib)' --package mauricebarnum-oxia-client --features metrics`
+  - `cargo nextest run -E 'kind(lib)' --package mauricebarnum-oxia-client --features go-metrics-compat`
   - `just build-all`
   - `just test-all`
   - `just lint`
-- **Implemented tests:** Unit tests cover Go-compatible histogram boundaries and `KeyNotFound` result classification.
-- **Remaining test opportunities:** A tracing-subscriber mock layer could verify span field propagation and a custom OTel test meter could verify exact emitted measurements.
+- **Implemented tests:** Unit tests cover `KeyNotFound` result classification, semantic `ExponentialHistogram` SDK aggregation, semantic units, compatibility latency sum/count counters, and absence of Go-compatible size histograms.
+- **Remaining test opportunities:** A tracing-subscriber mock layer could verify span field propagation.
 
 ---
 
 ## 13. Open Questions
 
-- ~~Do downstream dashboards expect exact Go-compatible metric names (`oxia_client_op`) or should we migrate to standard OTel `v1.41.0` names (`db.client.operation.duration`)?~~ **Resolved:** Both naming schemes are supported via the `go-metrics-compat` compile-time feature flag (see Section 8.3). The default build uses OTel `v1.41.0` names. Consumers with existing Go-compatible dashboards enable `go-metrics-compat` at compile time. Data migration is explicitly out of scope.
+- ~~Do downstream dashboards expect exact Go-compatible metric names (`oxia_client_op`) or should we migrate to standard OTel `v1.41.0` names (`db.client.operation.duration`)?~~ **Resolved:** Semantic OTel names are always emitted when `metrics` is enabled. Consumers with existing Go-compatible latency dashboards enable `go-metrics-compat` to add the Go latency sum/count counters at compile time. Data migration is explicitly out of scope.
 
 - ~~Should `go-metrics-compat` imply `metrics` in the Cargo feature graph (recommended, see Section 8.3) or remain an independent flag that produces a `compile_error!` when `metrics` is not also enabled?~~ **Resolved**: `go-metrics-compat` feature implies `metrics` in the feature graph.
 
-- ~~The Go client emits `oxia_client_op_sum` and `oxia_client_op_count` as separate instruments. Should the `go-metrics-compat` Rust mode register two instruments to exactly replicate that wire format, or is the Histogram approach (with its built-in count) an acceptable deviation?~~ **Resolved**: `go-metrics-compat` will register and use separate `_sum/_count` instruments.
+- ~~The Go client emits `oxia_client_op_sum` and `oxia_client_op_count` as separate instruments. Should the `go-metrics-compat` Rust mode register two instruments to exactly replicate that wire format, or is the Histogram approach (with its built-in count) an acceptable deviation?~~ **Resolved**: `go-metrics-compat` registers and uses separate `_sum/_count` instruments in addition to semantic histograms.
 
 ---
 
@@ -424,14 +427,14 @@ The table below is the authoritative mapping between the two naming regimes. The
 
 ## B.1 Required Decisions
 
-- [x] Utilize the `tracing` crate facade with a target dependency on `tracing-opentelemetry` compatibility; do not take a direct dependency on `opentelemetry-sdk` in the library.
+- [x] Utilize the `tracing` crate facade with a target dependency on `tracing-opentelemetry` compatibility; do not take a non-dev dependency on `opentelemetry-sdk` in the library.
 - [x] Use Option B (Feature-gated, opt-in) via the `metrics` Cargo feature.
 - [x] Use OTel `Histogram` for operation latencies instead of Go's counter-based timer approach.
 - [x] Prohibit dynamic user keys or values in metric attributes.
 - [x] Expose `meter_provider` setter on the `Config` builder when the `metrics` feature flag is active.
 - [x] Add `go-metrics-compat` Cargo feature to select Go reference client metric name strings and instrument types at compile time (zero runtime overhead). Default build uses OTel `v1.41.0` semantic convention names.
 - [x] `go-metrics-compat` implies `metrics` in the Cargo feature graph.
-- [x] `go-metrics-compat` mode registers separate `Float64Counter` (`_sum`) and `Counter<u64>` (`_count`) instruments per timer concept to exactly replicate Go wire format. Default (OTel) mode uses a single `Histogram` per concept.
+- [x] `go-metrics-compat` mode registers separate `Float64Counter` (`_sum`) and `Counter<u64>` (`_count`) instruments per timer concept to replicate Go latency wire format. Semantic OTel histograms remain enabled.
 
 ## B.2 Assumptions
 
@@ -505,16 +508,16 @@ The table below is the authoritative mapping between the two naming regimes. The
 ## B.4 Metric Inventory
 
 > [!IMPORTANT]
-> Metric names **and instrument types** are selected at compile time. The **Default** columns apply when `go-metrics-compat` is **not** enabled. The **`go-metrics-compat`** columns apply when it is. In compat mode, timer concepts emit two instruments; size/count concepts remain Histograms.
+> Semantic metric names and instrument types are always registered when `metrics` is enabled. The **`go-metrics-compat`** table lists additional latency instruments emitted when that feature is enabled.
 
 **Default mode (OTel v1.41.0)**
 
 | Concept                | Instrument name                  | Type      | Unit   | Attributes                                       | Cardinality | Lifecycle                   |
 | ---------------------- | -------------------------------- | --------- | ------ | ------------------------------------------------ | ----------- | --------------------------- |
-| Operation latency      | `db.client.operation.duration`   | Histogram | `"ms"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Operation latency      | `db.client.operation.duration`   | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 | Operation payload size | `db.client.operation.size`       | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
-| Batch total duration   | `db.client.batch.duration`       | Histogram | `"ms"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
-| Batch exec duration    | `db.client.batch.exec_duration`  | Histogram | `"ms"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch total duration   | `db.client.batch.duration`       | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
+| Batch exec duration    | `db.client.batch.exec_duration`  | Histogram | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 | Batch payload size     | `db.client.batch.size`           | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 | Batch request count    | `db.client.batch.request_count`  | Histogram | `"1"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 
@@ -524,13 +527,10 @@ The table below is the authoritative mapping between the two naming regimes. The
 | -------------------------------- | ------------------------------------ | ---------------- | ------- | ------------------------------------------------ | ----------- | --------------------------- |
 | Operation latency — sum          | `oxia_client_op_sum`                 | Float64Counter   | `"ms"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 | Operation latency — count        | `oxia_client_op_count`               | Counter<u64>     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
-| Operation payload size           | `oxia_client_op_value`               | Histogram        | `"By"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 | Batch total duration — sum       | `oxia_client_batch_total_sum`        | Float64Counter   | `"ms"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 | Batch total duration — count     | `oxia_client_batch_total_count`      | Counter<u64>     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 | Batch exec duration — sum        | `oxia_client_batch_exec_sum`         | Float64Counter   | `"ms"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 | Batch exec duration — count      | `oxia_client_batch_exec_count`       | Counter<u64>     | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
-| Batch payload size               | `oxia_client_batch_value`            | Histogram        | `"By"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
-| Batch request count              | `oxia_client_batch_request`          | Histogram        | `"1"`   | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `metrics::Metrics::new()` |
 
 ---
 
@@ -538,15 +538,17 @@ The table below is the authoritative mapping between the two naming regimes. The
 
 - **[IMPLEMENTED] `client/src/metrics.rs`**: Contains all metrics wrappers, declarations, result classifiers, size extractors, and feature-conditional definitions.
   - When `metrics` feature is off: compiles as a ZST metrics interface. Metric wrappers still record tracing span `error.type` for `Err` results, but avoid `Instant::now()`, duration math, result classifier calls, size extraction, OTel calls, and the `opentelemetry` dependency.
-  - When `metrics` is on and `go-metrics-compat` is **off**: defines `pub(crate) mod names` with `const &str` name constants for OTel instruments; all timer concepts use `Histogram`.
-  - When `metrics` is on and `go-metrics-compat` is **on**: defines `pub(crate) mod names` with separate `_sum`/`_count` name constants; timer concepts register a `Float64Counter` (sum) and a `Counter<u64>` (count) each. Size/count concepts remain `Histogram`. No `if` branches or runtime dispatch in either path.
+  - When `metrics` is on: defines `pub(crate) mod names` with `const &str` name constants for semantic OTel instruments; latency, size, and request-count concepts use `Histogram`.
+  - Semantic duration histograms use unit `"s"` and record seconds. Semantic size histograms use unit `"By"`, and request-count histograms use unit `"1"`.
+  - When `metrics` is on and `go-metrics-compat` is **on**: defines `compat_names` with separate `_sum`/`_count` constants; timer concepts additionally register a `Float64Counter` (sum) and a `Counter<u64>` (count) each. Go-compatible size/count histograms are not emitted.
   - Public operation helpers include `operation_start`, `record_operation_result`, `record_operation_result_with_size`, and `record_operation_sync`.
   - Shard batch helpers include `batch_start`, `batch_exec_duration`, and `record_batch`.
   - Result classifiers include `result_kind` and `get_result_kind`; size extractors include `get_response_size` and `range_scan_response_size`.
 - **[IMPLEMENTED] `client/Cargo.toml`**:
-  - Added optional dependency `opentelemetry = { version = "0.29.1", features = ["metrics"] }`.
+  - Added optional dependency `opentelemetry = { version = "0.27.0", features = ["metrics"] }`.
   - Added feature `metrics = ["dep:opentelemetry"]`.
   - Added feature `go-metrics-compat = ["metrics"]` (implies `metrics`).
+  - Added `opentelemetry_sdk` as a dev-dependency with `metrics` and `spec_unstable_metrics_views` for SDK aggregation tests.
   - Preserved the external type allowlist entry for `opentelemetry::metrics::meter::MeterProvider`.
 - **[IMPLEMENTED] `client/src/lib.rs`**:
   - Added `mod metrics;`.
@@ -565,3 +567,9 @@ The table below is the authoritative mapping between the two naming regimes. The
 - **[IMPLEMENTED] `Justfile`**:
   - Added `build-all` to build with metrics off, `metrics`, and `go-metrics-compat`.
   - Added `test-all` to run nextest with metrics off, `metrics`, and `go-metrics-compat`.
+- **[IMPLEMENTED] `cmd/src/metrics.rs`**:
+  - Configures the CLI `SdkMeterProvider` with a view matching the six semantic histogram instruments.
+  - The view uses `Aggregation::Base2ExponentialHistogram { max_size: 160, max_scale: 20, record_min_max: false }`.
+  - This file is the canonical implementation reference for callers that need `ExponentialHistogram` data points from their own `MeterProvider`.
+- **[IMPLEMENTED] `cmd/Cargo.toml`**:
+  - Enables `opentelemetry_sdk` features `metrics` and `spec_unstable_metrics_views` so the CLI can install the exponential histogram view.

--- a/otel-instrumentation-design.md
+++ b/otel-instrumentation-design.md
@@ -7,66 +7,68 @@ This document provides a detailed design and implementation specification for ad
 # Part A: Design Narrative (For Human Review)
 
 ## 1. Executive Summary
-* **Proposed:** This design defines a standard, idiomatic telemetry layer for the Rust Oxia client library (`client` crate), aligned with OpenTelemetry Semantic Conventions version `v1.41.0`.
-* **Proposed:** Telemetry will include:
-  * **Traces (Spans):** High-level client operation boundaries (e.g., `get`, `put`, `delete`, etc.), client connection, background task events (discovery refreshes, heartbeat loops), and lower-level gRPC RPC calls.
-  * **Metrics:** Client operation latencies, batching latencies, value/payload sizes, and request counts, ensuring behavioral and namespacing consistency with the Go reference library (`ext/oxia`).
-  * **Logs:** Structured log correlation linking existing logging calls to active spans.
-* **Proposed:** The following are out of scope:
-  * Configuring exporters, tracing subscribers, or SDK pipelines within the library. The client library will only depend on telemetry APIs/facades.
-  * System-level resource monitoring (CPU, memory), which is the responsibility of the server or the consumer application.
+
+- **Proposed:** This design defines a standard, idiomatic telemetry layer for the Rust Oxia client library (`client` crate), aligned with OpenTelemetry Semantic Conventions version `v1.41.0`.
+- **Proposed:** Telemetry will include:
+  - **Traces (Spans):** High-level client operation boundaries (e.g., `get`, `put`, `delete`, etc.), client connection, background task events (discovery refreshes, heartbeat loops), and lower-level gRPC RPC calls.
+  - **Metrics:** Client operation latencies, batching latencies, value/payload sizes, and request counts, ensuring behavioral and namespacing consistency with the Go reference library (`ext/oxia`).
+  - **Logs:** Structured log correlation linking existing logging calls to active spans.
+- **Proposed:** The following are out of scope:
+  - Configuring exporters, tracing subscribers, or SDK pipelines within the library. The client library will only depend on telemetry APIs/facades.
+  - System-level resource monitoring (CPU, memory), which is the responsibility of the server or the consumer application.
 
 ---
 
 ## 2. Repository Findings
 
 ### 2.1 Rust Crate Inventory
-* **Observed:** **Public API Surface** (`client/src/lib.rs`):
-  * `Client::new(config: Arc<config::Config>) -> Self` (line 869)
-  * `Client::connect(&mut self) -> Result<()>` (line 886)
-  * `Client::reconnect(&mut self) -> impl Future<Output = Result<()>>` (line 895)
-  * `Client::get(&self, k: impl Into<String>) -> impl Future<Output = Result<Option<GetResponse>>>` (line 960)
-  * `Client::get_with_options(&self, key: impl Into<String>, options: GetOptions) -> impl Future<Output = Result<Option<GetResponse>>>` (line 965)
-  * `Client::batch_get(&self, req: batch_get::Request) -> Result<impl Stream<Item = batch_get::ResponseItem>>` (line 1031)
-  * `Client::put(&self, key: impl Into<String>, value: impl Into<Bytes>) -> impl Future<Output = Result<PutResponse>>` (line 1087)
-  * `Client::put_with_options(&self, key: impl Into<String>, value: impl Into<Bytes>, options: PutOptions) -> impl Future<Output = Result<PutResponse>>` (line 1096)
-  * `Client::delete(&self, key: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1124)
-  * `Client::delete_with_options(&self, key: impl Into<String>, options: DeleteOptions) -> impl Future<Output = Result<()>>` (line 1128)
-  * `Client::delete_range(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1150)
-  * `Client::delete_range_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: DeleteRangeOptions) -> impl Future<Output = Result<()>>` (line 1163)
-  * `Client::list(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<ListResponse>>` (line 1242)
-  * `Client::list_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: ListOptions) -> impl Future<Output = Result<ListResponse>>` (line 1251)
-  * `Client::range_scan(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<RangeScanResponse>>` (line 1325)
-  * `Client::range_scan_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: RangeScanOptions) -> impl Future<Output = Result<RangeScanResponse>>` (line 1334)
-  * `Client::create_notifications_stream(&self) -> Result<NotificationsStream>` (line 1408)
-  * `Client::create_notifications_stream_with_options(&self, options: NotificationsOptions) -> Result<NotificationsStream>` (line 1413)
-* **Observed:** **Async Entry Points:**
-  * `Client::connect` (file `client/src/lib.rs`, line 886)
-  * `Client::get_internal` (file `client/src/lib.rs`, line 973)
-  * `Client::put_internal` (file `client/src/lib.rs`, line 1105)
-  * `Client::delete_internal` (file `client/src/lib.rs`, line 1137)
-  * `Client::delete_range_internal` (file `client/src/lib.rs`, line 1176)
-  * `Client::list_internal` (file `client/src/lib.rs`, line 1264)
-  * `Client::range_scan_internal` (file `client/src/lib.rs`, line 1347)
-  * `shard::Client::get` (file `client/src/shard.rs`, line 796)
-  * `shard::Client::put` (file `client/src/shard.rs`, line 958)
-  * `shard::Client::delete` (file `client/src/shard.rs`, line 984)
-  * `shard::Client::delete_range` (file `client/src/shard.rs`, line 996)
-  * `shard::Client::list` (file `client/src/shard.rs`, line 1009)
-  * `shard::Client::range_scan` (file `client/src/shard.rs`, line 1059)
-  * `shard::Client::get_notifications` (file `client/src/shard.rs`, line 1091)
-  * `shard::Client::create_session` (file `client/src/shard.rs`, line 579)
-* **Observed:** **Background Tasks:**
-  * Shard assignment syncing loop `ShardAssignmentTask::run` (file `client/src/shard.rs`, line 1642)
-  * Session heartbeat loop task spawned in `Client::start_heartbeat` (file `client/src/shard.rs`, line 483)
-  * Notification stream change listener task spawned in `NotificationsStream::new` (file `client/src/notification.rs`, line 163)
-* **Observed:** **Retry Loops:**
-  * Transient/timeout retries in `execute_with_retry` (file `client/src/lib.rs`, line 741)
-  * Wrong-leader routing retries in `stale_shard_map_retry` (file `client/src/lib.rs`, line 803)
-  * Shard assignment stream reconnection loop in `ShardAssignmentTask::get_stream` (file `client/src/shard.rs`, line 1611)
-* **Observed:** **Network Operations:**
-  * Connecting gRPC channel in `ChannelPool::get` (file `client/src/pool.rs`, line 177)
-  * Tonic gRPC calls:
+
+- **Observed:** **Public API Surface** (`client/src/lib.rs`):
+  - `Client::new(config: Arc<config::Config>) -> Self` (line 869)
+  - `Client::connect(&mut self) -> Result<()>` (line 886)
+  - `Client::reconnect(&mut self) -> impl Future<Output = Result<()>>` (line 895)
+  - `Client::get(&self, k: impl Into<String>) -> impl Future<Output = Result<Option<GetResponse>>>` (line 960)
+  - `Client::get_with_options(&self, key: impl Into<String>, options: GetOptions) -> impl Future<Output = Result<Option<GetResponse>>>` (line 965)
+  - `Client::batch_get(&self, req: batch_get::Request) -> Result<impl Stream<Item = batch_get::ResponseItem>>` (line 1031)
+  - `Client::put(&self, key: impl Into<String>, value: impl Into<Bytes>) -> impl Future<Output = Result<PutResponse>>` (line 1087)
+  - `Client::put_with_options(&self, key: impl Into<String>, value: impl Into<Bytes>, options: PutOptions) -> impl Future<Output = Result<PutResponse>>` (line 1096)
+  - `Client::delete(&self, key: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1124)
+  - `Client::delete_with_options(&self, key: impl Into<String>, options: DeleteOptions) -> impl Future<Output = Result<()>>` (line 1128)
+  - `Client::delete_range(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<()>>` (line 1150)
+  - `Client::delete_range_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: DeleteRangeOptions) -> impl Future<Output = Result<()>>` (line 1163)
+  - `Client::list(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<ListResponse>>` (line 1242)
+  - `Client::list_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: ListOptions) -> impl Future<Output = Result<ListResponse>>` (line 1251)
+  - `Client::range_scan(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>) -> impl Future<Output = Result<RangeScanResponse>>` (line 1325)
+  - `Client::range_scan_with_options(&self, start_inclusive: impl Into<String>, end_exclusive: impl Into<String>, options: RangeScanOptions) -> impl Future<Output = Result<RangeScanResponse>>` (line 1334)
+  - `Client::create_notifications_stream(&self) -> Result<NotificationsStream>` (line 1408)
+  - `Client::create_notifications_stream_with_options(&self, options: NotificationsOptions) -> Result<NotificationsStream>` (line 1413)
+- **Observed:** **Async Entry Points:**
+  - `Client::connect` (file `client/src/lib.rs`, line 886)
+  - `Client::get_internal` (file `client/src/lib.rs`, line 973)
+  - `Client::put_internal` (file `client/src/lib.rs`, line 1105)
+  - `Client::delete_internal` (file `client/src/lib.rs`, line 1137)
+  - `Client::delete_range_internal` (file `client/src/lib.rs`, line 1176)
+  - `Client::list_internal` (file `client/src/lib.rs`, line 1264)
+  - `Client::range_scan_internal` (file `client/src/lib.rs`, line 1347)
+  - `shard::Client::get` (file `client/src/shard.rs`, line 796)
+  - `shard::Client::put` (file `client/src/shard.rs`, line 958)
+  - `shard::Client::delete` (file `client/src/shard.rs`, line 984)
+  - `shard::Client::delete_range` (file `client/src/shard.rs`, line 996)
+  - `shard::Client::list` (file `client/src/shard.rs`, line 1009)
+  - `shard::Client::range_scan` (file `client/src/shard.rs`, line 1059)
+  - `shard::Client::get_notifications` (file `client/src/shard.rs`, line 1091)
+  - `shard::Client::create_session` (file `client/src/shard.rs`, line 579)
+- **Observed:** **Background Tasks:**
+  - Shard assignment syncing loop `ShardAssignmentTask::run` (file `client/src/shard.rs`, line 1642)
+  - Session heartbeat loop task spawned in `Client::start_heartbeat` (file `client/src/shard.rs`, line 483)
+  - Notification stream change listener task spawned in `NotificationsStream::new` (file `client/src/notification.rs`, line 163)
+- **Observed:** **Retry Loops:**
+  - Transient/timeout retries in `execute_with_retry` (file `client/src/lib.rs`, line 741)
+  - Wrong-leader routing retries in `stale_shard_map_retry` (file `client/src/lib.rs`, line 803)
+  - Shard assignment stream reconnection loop in `ShardAssignmentTask::get_stream` (file `client/src/shard.rs`, line 1611)
+- **Observed:** **Network Operations:**
+  - Connecting gRPC channel in `ChannelPool::get` (file `client/src/pool.rs`, line 177)
+  - Tonic gRPC calls:
     - `get_shard_assignments` (file `client/src/shard.rs`, line 1596)
     - `create_session` (file `client/src/shard.rs`, line 587)
     - `keep_alive` (file `client/src/shard.rs`, line 524)
@@ -76,188 +78,202 @@ This document provides a detailed design and implementation specification for ad
     - `range_scan` (file `client/src/shard.rs`, line 1071)
     - `get_notifications` (file `client/src/shard.rs`, line 1101)
     - `list_nodes` (file `client/src/discovery.rs`, line 109)
-* **Observed:** **Streaming Operations:**
-  * Shard assignment updates stream `Streaming<oxia_proto::ShardAssignments>` (file `client/src/shard.rs`, line 1559)
-  * Notifications stream `Streaming<oxia_proto::NotificationBatch>` (file `client/src/shard.rs`, line 1445)
-  * `batch_get` result stream demuxing `demux_stream` (file `client/src/shard.rs`, line 834)
-* **Observed:** **Batching Operations:**
-  * Multi-key read batching in `Client::batch_get` (file `client/src/lib.rs`, line 1031)
-* **Observed:** **Error Types** (`client/src/errors.rs`):
-  * `Error` (line 320), `OxiaError` (line 31), `OxiaRpcError` (line 61), `ClientError` (line 233), `ServerError` (line 278), `ShardError` (line 304).
-* **Observed:** **Concurrency Boundaries:**
-  * `ArcSwap` for lock-free state swaps (file `client/src/pool.rs`, line 69; file `client/src/shard.rs`, line 1665, 1666)
-  * `Mutex` for synchronizing channel creations (file `client/src/pool.rs`, line 70)
-  * `OnceCell` for lazy session creation (file `client/src/shard.rs`, line 332, 598)
-  * `watch::Sender` / `watch::Receiver` for notifying updates (file `client/src/shard.rs`, line 1669, 1808)
-  * `tokio::sync::Notify` for refresh signals (file `client/src/shard.rs`, line 1670, 1819)
-* **Observed:** **Task Spawning Boundaries:**
-  * Spawning heartbeat loops (file `client/src/shard.rs`, line 483)
-  * Spawning assignment sync loops (file `client/src/shard.rs`, line 1821)
-  * Spawning configuration watcher tasks (file `client/src/notification.rs`, line 163)
-* **Observed:** **Cancellation Semantics:**
-  * Background loops are monitored by `CancellationToken` (file `client/src/shard.rs`, line 298, 1667; file `client/src/notification.rs`, line 150) and handles are aborted on drop.
-* **Observed:** **Existing Telemetry Hooks:**
-  * Crate depends on `tracing` (file `client/Cargo.toml`, line 15) and logs extensively via `info!`, `warn!`, `debug!`, `error!`, and `trace!`.
+- **Observed:** **Streaming Operations:**
+  - Shard assignment updates stream `Streaming<oxia_proto::ShardAssignments>` (file `client/src/shard.rs`, line 1559)
+  - Notifications stream `Streaming<oxia_proto::NotificationBatch>` (file `client/src/shard.rs`, line 1445)
+  - `batch_get` result stream demuxing `demux_stream` (file `client/src/shard.rs`, line 834)
+- **Observed:** **Batching Operations:**
+  - Multi-key read batching in `Client::batch_get` (file `client/src/lib.rs`, line 1031)
+- **Observed:** **Error Types** (`client/src/errors.rs`):
+  - `Error` (line 320), `OxiaError` (line 31), `OxiaRpcError` (line 61), `ClientError` (line 233), `ServerError` (line 278), `ShardError` (line 304).
+- **Observed:** **Concurrency Boundaries:**
+  - `ArcSwap` for lock-free state swaps (file `client/src/pool.rs`, line 69; file `client/src/shard.rs`, line 1665, 1666)
+  - `Mutex` for synchronizing channel creations (file `client/src/pool.rs`, line 70)
+  - `OnceCell` for lazy session creation (file `client/src/shard.rs`, line 332, 598)
+  - `watch::Sender` / `watch::Receiver` for notifying updates (file `client/src/shard.rs`, line 1669, 1808)
+  - `tokio::sync::Notify` for refresh signals (file `client/src/shard.rs`, line 1670, 1819)
+- **Observed:** **Task Spawning Boundaries:**
+  - Spawning heartbeat loops (file `client/src/shard.rs`, line 483)
+  - Spawning assignment sync loops (file `client/src/shard.rs`, line 1821)
+  - Spawning configuration watcher tasks (file `client/src/notification.rs`, line 163)
+- **Observed:** **Cancellation Semantics:**
+  - Background loops are monitored by `CancellationToken` (file `client/src/shard.rs`, line 298, 1667; file `client/src/notification.rs`, line 150) and handles are aborted on drop.
+- **Observed:** **Existing Telemetry Hooks:**
+  - Crate depends on `tracing` (file `client/Cargo.toml`, line 15) and logs extensively via `info!`, `warn!`, `debug!`, `error!`, and `trace!`.
 
 ### 2.2 Go Reference Instrumentation Inventory
-* **Observed:** **Metrics** (`ext/oxia/oxia/internal/metrics/metrics.go`):
-  * `oxia_client_op` (Timer: sum counter and count counter): records call latency.
-  * `oxia_client_op_value` (Histogram, unit: `"By"`): records KV size for `put` and `get`.
-  * `oxia_client_batch_total` (Timer: sum counter and count counter): records time from request queueing to response.
-  * `oxia_client_batch_exec` (Timer: sum counter and count counter): records time elapsed during batch execution.
-  * `oxia_client_batch_value` (Histogram, unit: `"By"`): records total bytes processed in a batch.
-  * `oxia_client_batch_request` (Histogram): records count of requests inside a batch.
-  * Attributes registered per metric: `"type"` (operation name, e.g., `"get"`, `"put"`) and `"result"` (`"success"` or `"failure"`).
-* **Observed:** **Traces (Spans):**
-  * The Go client has no tracing instrumentation. `go.opentelemetry.io/otel/trace` is only listed as an `// indirect` dependency in `ext/oxia/oxia/go.mod` (line 40).
-* **Observed:** **Structured Log Events:**
-  * Go client uses structured logging (`log/slog`) for system state:
+
+- **Observed:** **Metrics** (`ext/oxia/oxia/internal/metrics/metrics.go`):
+  - `oxia_client_op` (Timer: sum counter and count counter): records call latency.
+  - `oxia_client_op_value` (Histogram, unit: `"By"`): records KV size for `put` and `get`.
+  - `oxia_client_batch_total` (Timer: sum counter and count counter): records time from request queueing to response.
+  - `oxia_client_batch_exec` (Timer: sum counter and count counter): records time elapsed during batch execution.
+  - `oxia_client_batch_value` (Histogram, unit: `"By"`): records total bytes processed in a batch.
+  - `oxia_client_batch_request` (Histogram): records count of requests inside a batch.
+  - Attributes registered per metric: `"type"` (operation name, e.g., `"get"`, `"put"`) and `"result"` (`"success"` or `"failure"`).
+- **Observed:** **Traces (Spans):**
+  - The Go client has no tracing instrumentation. `go.opentelemetry.io/otel/trace` is only listed as an `// indirect` dependency in `ext/oxia/oxia/go.mod` (line 40).
+- **Observed:** **Structured Log Events:**
+  - Go client uses structured logging (`log/slog`) for system state:
     - retry warnings (file `ext/oxia/oxia/async_client_impl.go`, line 433, 531)
     - notification events (file `ext/oxia/oxia/cache.go`, line 156)
     - batch rerouting notices (file `ext/oxia/oxia/internal/batch/read_batch.go`, line 96; file `ext/oxia/oxia/internal/batch/write_batch.go`, line 117)
     - connection warning/errors (file `ext/oxia/oxia/internal/executor.go`, line 153)
 
 ### 2.3 Cross-Language Mapping and Differences
-* **Observed:** **Go-to-Rust Equivalency mapping:**
-  * `DecoratePut` / `DecorateGet` / `DecorateDelete` -> Map directly to wrapping `Client::put_internal`, `Client::get_internal`, `Client::delete_internal` and `Client::batch_get` operations in `client/src/lib.rs`.
-  * `WriteCallback` / `ReadCallback` -> Maps to wrappers around `shard::Client::process_write` and `shard::Client::get`/`batch_get` (file `client/src/shard.rs`).
-* **Observed:** **Rust operations with no Go equivalent:**
-  * `Client::connect` (file `client/src/lib.rs`, line 886) - Go client performs lazy connection at executor level.
-  * `Client::reconnect` (file `client/src/lib.rs`, line 895).
-  * `stale_shard_map_retry` (file `client/src/lib.rs`, line 803) - explicit stale-map wait loop in Rust client.
-* **Observed:** **Go instrumentation with no Rust equivalent:**
-  * Go's custom `Timer` metric type (split into a sum Float64Counter and a count Int64Counter under the same name).
-  * Go's unstructured/slog logger. Rust utilizes `tracing` exclusively.
+
+- **Observed:** **Go-to-Rust Equivalency mapping:**
+  - `DecoratePut` / `DecorateGet` / `DecorateDelete` -> Map directly to wrapping `Client::put_internal`, `Client::get_internal`, `Client::delete_internal` and `Client::batch_get` operations in `client/src/lib.rs`.
+  - `WriteCallback` / `ReadCallback` -> Maps to wrappers around `shard::Client::process_write` and `shard::Client::get`/`batch_get` (file `client/src/shard.rs`).
+- **Observed:** **Rust operations with no Go equivalent:**
+  - `Client::connect` (file `client/src/lib.rs`, line 886) - Go client performs lazy connection at executor level.
+  - `Client::reconnect` (file `client/src/lib.rs`, line 895).
+  - `stale_shard_map_retry` (file `client/src/lib.rs`, line 803) - explicit stale-map wait loop in Rust client.
+- **Observed:** **Go instrumentation with no Rust equivalent:**
+  - Go's custom `Timer` metric type (split into a sum Float64Counter and a count Int64Counter under the same name).
+  - Go's unstructured/slog logger. Rust utilizes `tracing` exclusively.
 
 ---
 
 ## 3. Goals, Constraints, and Assumptions
 
 ### 3.1 Telemetry Framework Choice
-* **Proposed:** The library will use the **`tracing` crate** (already present in `client/Cargo.toml#L15`) as its tracing and logging facade, and the **`opentelemetry` API crate** (with the `metric` feature) as its metrics facade.
-* **Justification:**
+
+- **Proposed:** The library will use the **`tracing` crate** (already present in `client/Cargo.toml#L15`) as its tracing and logging facade, and the **`opentelemetry` API crate** (with the `metric` feature) as its metrics facade.
+- **Justification:**
   1. The `tracing` crate is the de facto standard in Rust. Using it ensures all spans and logs integrate out-of-the-box with downstream subscriber ecosystems (such as `tracing-opentelemetry`).
   2. Direct instrumentation using the `opentelemetry` tracing API inside a Rust library requires handling a heavy API layer, which is less idiomatic and more difficult to format and correlate than Rust's native `tracing::Span` structures.
   3. Spans can be bridged downstream using the standard `tracing-opentelemetry` subscriber.
-* **Proposed:** The library will interact only with the *facade/API layers* (`tracing` and `opentelemetry::metric`). It will not instantiate or configure exporters, tracer providers, or meter providers internally, but it *will* support user-supplied `MeterProvider` configurations.
-* **Assumption:** If no OTel SDK or `tracing` subscriber is registered by the parent application, all instrumentation calls compile down to no-ops with negligible runtime overhead.
-* **Proposed:** To ensure zero overhead when telemetry is disabled, the OTel metrics logic will be conditionally compiled behind a feature flag (see Section 8).
+- **Proposed:** The library will interact only with the _facade/API layers_ (`tracing` and `opentelemetry::metric`). It will not instantiate or configure exporters, tracer providers, or meter providers internally, but it _will_ support user-supplied `MeterProvider` configurations.
+- **Assumption:** If no OTel SDK or `tracing` subscriber is registered by the parent application, all instrumentation calls compile down to no-ops with negligible runtime overhead.
+- **Proposed:** To ensure zero overhead when telemetry is disabled, the OTel metrics logic will be conditionally compiled behind a feature flag (see Section 8).
 
 ---
 
 ## 4. Instrumentation Boundaries
 
 ### 4.1 Boundary Scope
-* **Proposed:** **Instrumented operations:**
-  * `Client::connect` and `Client::reconnect` (to track cluster connectivity).
-  * Main KV API entry points (`get`, `put`, `delete`, `delete_range`, `list`, `range_scan`, `batch_get`).
-  * Coordinator discovery requests (`discovery::CoordinatorServiceDiscovery::addresses`).
-  * Heartbeat loop cycles (to monitor session health).
-  * Background shard assignment sync loop runs.
-* **Proposed:** **Explicitly non-instrumented operations:**
-  * Lower-level internal utilities (`util::with_timeout`, `util::with_retry`) to avoid duplicate spans. Span details will instead be captured as attributes or retry events on the parent operation span.
+
+- **Proposed:** **Instrumented operations:**
+  - `Client::connect` and `Client::reconnect` (to track cluster connectivity).
+  - Main KV API entry points (`get`, `put`, `delete`, `delete_range`, `list`, `range_scan`, `batch_get`).
+  - Coordinator discovery requests (`discovery::CoordinatorServiceDiscovery::addresses`).
+  - Heartbeat loop cycles (to monitor session health).
+  - Background shard assignment sync loop runs.
+- **Proposed:** **Explicitly non-instrumented operations:**
+  - Lower-level internal utilities (`util::with_timeout`, `util::with_retry`) to avoid duplicate spans. Span details will instead be captured as attributes or retry events on the parent operation span.
 
 ### 4.2 Architectural Design Decisions
-* **Decision 1: Spans representation**
-  * **Selected Approach:** Maintain spans using `tracing::Span` and rely on downstream `tracing-opentelemetry` for OTel exporting.
-  * **Rejected Alternative:** Directly use the `opentelemetry::trace::Tracer` API in-crate.
-  * **Reason for Rejection:** Direct OTel trace API makes logs harder to correlate and diverges from the existing `tracing` macros already used in the codebase.
-* **Decision 2: Latency metrics implementation**
-  * **Selected Approach:** Use OTel `Histogram` for operation latencies.
-  * **Rejected Alternative:** Translate Go's dual-counter Timer approach literally (making a count counter and a latency sum counter).
-  * **Reason for Rejection:** A dual-counter Timer is not idiomatic in modern OpenTelemetry and is rejected by the OTel API in favor of histograms, which natively provide percentiles, counts, and sums.
+
+- **Decision 1: Spans representation**
+  - **Selected Approach:** Maintain spans using `tracing::Span` and rely on downstream `tracing-opentelemetry` for OTel exporting.
+  - **Rejected Alternative:** Directly use the `opentelemetry::trace::Tracer` API in-crate.
+  - **Reason for Rejection:** Direct OTel trace API makes logs harder to correlate and diverges from the existing `tracing` macros already used in the codebase.
+- **Decision 2: Latency metrics implementation**
+  - **Selected Approach:** Use OTel `Histogram` for operation latencies.
+  - **Rejected Alternative:** Translate Go's dual-counter Timer approach literally (making a count counter and a latency sum counter).
+  - **Reason for Rejection:** A dual-counter Timer is not idiomatic in modern OpenTelemetry and is rejected by the OTel API in favor of histograms, which natively provide percentiles, counts, and sums.
 
 ---
 
 ## 5. Tracing and Logging Design
 
 ### 5.1 Naming and Scope
-* **Proposed:** The tracer/telemetry scope name will be `"mauricebarnum_oxia_client"`.
-* **Proposed:** Spans will map to operations:
-  * `"client.connect"` (SpanKind::Client)
-  * `"db.operation.get"` (SpanKind::Client)
-  * `"db.operation.put"` (SpanKind::Client)
-  * `"db.operation.delete"` (SpanKind::Client)
-  * `"db.operation.delete_range"` (SpanKind::Client)
-  * `"db.operation.list"` (SpanKind::Client)
-  * `"db.operation.range_scan"` (SpanKind::Client)
-  * `"db.operation.batch_get"` (SpanKind::Client)
-  * `"shard.heartbeat"` (SpanKind::Internal)
-  * `"shard.assignment_sync"` (SpanKind::Internal)
+
+- **Proposed:** The tracer/telemetry scope name will be `"mauricebarnum_oxia_client"`.
+- **Proposed:** Spans will map to operations:
+  - `"client.connect"` (SpanKind::Client)
+  - `"db.operation.get"` (SpanKind::Client)
+  - `"db.operation.put"` (SpanKind::Client)
+  - `"db.operation.delete"` (SpanKind::Client)
+  - `"db.operation.delete_range"` (SpanKind::Client)
+  - `"db.operation.list"` (SpanKind::Client)
+  - `"db.operation.range_scan"` (SpanKind::Client)
+  - `"db.operation.batch_get"` (SpanKind::Client)
+  - `"shard.heartbeat"` (SpanKind::Internal)
+  - `"shard.assignment_sync"` (SpanKind::Internal)
 
 ### 5.2 Attributes (OpenTelemetry Semantic Conventions v1.41.0)
-* **Proposed:** All spans representing database operations must carry:
-  * `db.system`: `"oxia"` (static string)
-  * `db.name`: Namespace name from configuration (e.g., `"default"`)
-  * `db.operation`: Operation identifier (`"get"`, `"put"`, `"delete"`, etc.)
-  * `db.oxia.shard_id`: The ID of the shard targeted by the routing key
-  * `server.address`: Leader endpoint host (if resolved)
-  * `server.port`: Leader endpoint port
-  * `error.type`: The error string code on failure (e.g., `"KeyNotFound"`, `"TransportError"`)
+
+- **Proposed:** All spans representing database operations must carry:
+  - `db.system`: `"oxia"` (static string)
+  - `db.name`: Namespace name from configuration (e.g., `"default"`)
+  - `db.operation`: Operation identifier (`"get"`, `"put"`, `"delete"`, etc.)
+  - `db.oxia.shard_id`: The ID of the shard targeted by the routing key
+  - `server.address`: Leader endpoint host (if resolved)
+  - `server.port`: Leader endpoint port
+  - `error.type`: The error string code on failure (e.g., `"KeyNotFound"`, `"TransportError"`)
 
 ### 5.3 Error and Status Rules
-* **Proposed:** If an operation returns an `Err(Error::Oxia(OxiaError::KeyNotFound))` on a `get` operation, the span status remains `Ok` (this is a standard lookup result, not a system failure).
-* **Proposed:** For all other `Err` results, the span status must be set to `Error`, and the error description must be recorded in the `exception.message` event.
-* **Proposed:** Panics must be caught using `std::panic::AssertUnwindSafe` to set the span status to `Error` before resuming panic propagation.
+
+- **Proposed:** If an operation returns an `Err(Error::Oxia(OxiaError::KeyNotFound))` on a `get` operation, the span status remains `Ok` (this is a standard lookup result, not a system failure).
+- **Proposed:** For all other `Err` results, the span status must be set to `Error`, and the error description must be recorded in the `exception.message` event.
+- **Proposed:** Panics must be caught using `std::panic::AssertUnwindSafe` to set the span status to `Error` before resuming panic propagation.
 
 ### 5.4 Sampling and Logging Integration
-* **Proposed:** Attributes requiring allocations (like formatting the server address) must be lazily computed only if the span is active (`Span::is_disabled` checks).
-* **Proposed:** Existing logs will automatically inherit `trace_id` and `span_id` context when executed within the scope of active tracing spans.
+
+- **Proposed:** Attributes requiring allocations (like formatting the server address) must be lazily computed only if the span is active (`Span::is_disabled` checks).
+- **Proposed:** Existing logs will automatically inherit `trace_id` and `span_id` context when executed within the scope of active tracing spans.
 
 ---
 
 ## 6. Metrics Design
 
 ### 6.1 Metrics Specifications
-* **Proposed:** The client will register the following metrics:
-  * `"oxia.client.op.duration"` (Histogram, unit: `"s"`): Measures operation execution duration.
-  * `"oxia.client.op.size"` (Histogram, unit: `"By"`): Measures payload sizes of `put` values and `get` returned values.
-  * `"oxia.client.batch.total_duration"` (Histogram, unit: `"s"`): Measures total duration of batched requests (queueing + execution).
-  * `"oxia.client.batch.exec_duration"` (Histogram, unit: `"s"`): Measures actual network execution duration of batches.
-  * `"oxia.client.batch.size"` (Histogram, unit: `"By"`): Measures total payload size in a batch.
-  * `"oxia.client.batch.request_count"` (Histogram, unit: `"1"`): Measures count of operations packed in a batch.
+
+- **Proposed:** The client will register the following metrics:
+  - `"oxia.client.op.duration"` (Histogram, unit: `"s"`): Measures operation execution duration.
+  - `"oxia.client.op.size"` (Histogram, unit: `"By"`): Measures payload sizes of `put` values and `get` returned values.
+  - `"oxia.client.batch.total_duration"` (Histogram, unit: `"s"`): Measures total duration of batched requests (queueing + execution).
+  - `"oxia.client.batch.exec_duration"` (Histogram, unit: `"s"`): Measures actual network execution duration of batches.
+  - `"oxia.client.batch.size"` (Histogram, unit: `"By"`): Measures total payload size in a batch.
+  - `"oxia.client.batch.request_count"` (Histogram, unit: `"1"`): Measures count of operations packed in a batch.
 
 ### 6.2 Attributes and Bounded Cardinality
-* **Proposed:** All metrics will utilize the following dimensions:
-  * `db.system`: Bounded (Value: `"oxia"`)
-  * `db.name` (Namespace): Bounded (Value from config)
-  * `db.operation`: Bounded (Values: `"get"`, `"put"`, `"delete"`, etc.)
-  * `db.oxia.shard_id`: Bounded (Values: integers [0 - maximum sharding limit])
-  * `result`: Bounded (Values: `"success"`, `"failure"`)
-* **Proposed:** **Cardinality Risk Flag:** No dynamic, user-provided data (such as keys, values, or raw error messages containing user parameters) may be used as metric dimensions. Recording arbitrary keys as dimensions is strictly prohibited due to infinite cardinality risks.
+
+- **Proposed:** All metrics will utilize the following dimensions:
+  - `db.system`: Bounded (Value: `"oxia"`)
+  - `db.name` (Namespace): Bounded (Value from config)
+  - `db.operation`: Bounded (Values: `"get"`, `"put"`, `"delete"`, etc.)
+  - `db.oxia.shard_id`: Bounded (Values: integers [0 - maximum sharding limit])
+  - `result`: Bounded (Values: `"success"`, `"failure"`)
+- **Proposed:** **Cardinality Risk Flag:** No dynamic, user-provided data (such as keys, values, or raw error messages containing user parameters) may be used as metric dimensions. Recording arbitrary keys as dimensions is strictly prohibited due to infinite cardinality risks.
 
 ---
 
 ## 7. Context Propagation and Concurrency Design
 
 ### 7.1 Context over Boundaries
-* **Proposed:** Context enters the client via the implicit thread-local/async `tracing::Span::current()`.
-* **Proposed:** Since `client` operations are async and span boundaries, we must recommend:
-  * **Bridge via `tracing-opentelemetry`**: This handles propagating trace headers over spawned task boundaries (like the heartbeat and discovery tasks) using `tracing` parent span attachment.
-* **Proposed:** For background tasks (`ShardAssignmentTask` and heartbeats), we will construct detached root spans `"shard.assignment_sync"` and `"shard.heartbeat"`.
-* **Proposed:** If a caller cancels an operation future, the corresponding span will record a `"cancelled"` event and close immediately.
+
+- **Proposed:** Context enters the client via the implicit thread-local/async `tracing::Span::current()`.
+- **Proposed:** Since `client` operations are async and span boundaries, we must recommend:
+  - **Bridge via `tracing-opentelemetry`**: This handles propagating trace headers over spawned task boundaries (like the heartbeat and discovery tasks) using `tracing` parent span attachment.
+- **Proposed:** For background tasks (`ShardAssignmentTask` and heartbeats), we will construct detached root spans `"shard.assignment_sync"` and `"shard.heartbeat"`.
+- **Proposed:** If a caller cancels an operation future, the corresponding span will record a `"cancelled"` event and close immediately.
 
 ---
 
 ## 8. Public API and Internal Structure Impact
 
 ### 8.1 Feature Gating Decision
-* **Proposed:** Recommend **Option B: Feature-gated, opt-in**. Telemetry instrumentation logic (specifically the direct `opentelemetry` metrics API dependency and context-propagation functions) will compile only when downstream crates enable the `telemetry` feature flag.
-* **Rejected Alternative A (Always compiled):** Forces all users to download and compile `opentelemetry` API crates, increasing compile time and dependency trees for minimal-size environments.
-* **Rejected Alternative C (Opt-out):** Violates Rust best practices by enabling a large transitive dependency tree by default.
+
+- **Proposed:** Recommend **Option B: Feature-gated, opt-in**. Telemetry instrumentation logic (specifically the direct `opentelemetry` metrics API dependency and context-propagation functions) will compile only when downstream crates enable the `telemetry` feature flag.
+- **Rejected Alternative A (Always compiled):** Forces all users to download and compile `opentelemetry` API crates, increasing compile time and dependency trees for minimal-size environments.
+- **Rejected Alternative C (Opt-out):** Violates Rust best practices by enabling a large transitive dependency tree by default.
 
 ### 8.2 Dependency and API Impact
-* **Proposed:** Add `opentelemetry` (API crate) as an optional dependency under `[dependencies]` in `client/Cargo.toml`.
-* **Proposed:** Add `telemetry` feature to `client/Cargo.toml` enabling the optional dependency.
-* **Proposed:** Expose `meter_provider` setter field on `Config` and `ConfigBuilder` under the `telemetry` feature flag. This allows downstream consumers to explicitly inject custom OTel `MeterProvider` implementations (mapped as `Arc<dyn opentelemetry::metric::MeterProvider + Send + Sync>`). If not set, metrics fallback to `opentelemetry::global::meter_provider()`.
-* **Proposed:** MSRV impact is negligible, as `opentelemetry` supports modern stable Rust compilers matching the workspace's version.
+
+- **Proposed:** Add `opentelemetry` (API crate) as an optional dependency under `[dependencies]` in `client/Cargo.toml`.
+- **Proposed:** Add `telemetry` feature to `client/Cargo.toml` enabling the optional dependency.
+- **Proposed:** Expose `meter_provider` setter field on `Config` and `ConfigBuilder` under the `telemetry` feature flag. This allows downstream consumers to explicitly inject custom OTel `MeterProvider` implementations (mapped as `Arc<dyn opentelemetry::metric::MeterProvider + Send + Sync>`). If not set, metrics fallback to `opentelemetry::global::meter_provider()`.
+- **Proposed:** MSRV impact is negligible, as `opentelemetry` supports modern stable Rust compilers matching the workspace's version.
 
 ### 8.3 Metric Naming Feature Flag: `go-metrics-compat`
 
-* **Proposed:** Add a second Cargo feature, `go-metrics-compat`, that selects the Go reference client's legacy metric name strings at **compile time** rather than at runtime.
-* **Rationale:** The two naming schemes (`db.client.operation.duration` vs `oxia_client_op`) differ only in the string constants used at histogram/counter creation. Selecting between them with `#[cfg(feature = "go-metrics-compat")]` eliminates all branching and string comparisons at runtime — the unused name is never materialized in the binary. This satisfies the requirement of zero runtime overhead.
-* **Feature independence:** `go-metrics-compat` is orthogonal to `telemetry`. Enabling `go-metrics-compat` without `telemetry` is meaningless and the implementation should emit a `compile_error!` or at minimum a `#[cfg(all(feature = "go-metrics-compat", not(feature = "telemetry")))]` warning.
-* **Proposed:** The Cargo feature declaration:
+- **Proposed:** Add a second Cargo feature, `go-metrics-compat`, that selects the Go reference client's legacy metric name strings at **compile time** rather than at runtime.
+- **Rationale:** The two naming schemes (`db.client.operation.duration` vs `oxia_client_op`) differ only in the string constants used at histogram/counter creation. Selecting between them with `#[cfg(feature = "go-metrics-compat")]` eliminates all branching and string comparisons at runtime — the unused name is never materialized in the binary. This satisfies the requirement of zero runtime overhead.
+- **Feature independence:** `go-metrics-compat` is orthogonal to `telemetry`. Enabling `go-metrics-compat` without `telemetry` is meaningless and the implementation should emit a `compile_error!` or at minimum a `#[cfg(all(feature = "go-metrics-compat", not(feature = "telemetry")))]` warning.
+- **Proposed:** The Cargo feature declaration:
 
   ```toml
   # client/Cargo.toml  (illustrative — not yet implemented)
@@ -268,7 +284,7 @@ This document provides a detailed design and implementation specification for ad
 
   Declaring `go-metrics-compat` as implying `telemetry` is the cleanest approach: it prevents silent no-ops and makes the dependency relationship explicit in the feature graph.
 
-* **Proposed:** Inside `client/src/telemetry.rs`, define the metric name strings as compile-time constants selected by the feature flag:
+- **Proposed:** Inside `client/src/telemetry.rs`, define the metric name strings as compile-time constants selected by the feature flag:
 
   ```rust
   // Illustrative — not yet implemented
@@ -295,94 +311,100 @@ This document provides a detailed design and implementation specification for ad
 
   All histogram registrations reference `names::OP_DURATION`, etc., so no further code changes are needed when toggling the feature.
 
-* **Data migration:** Explicitly out of scope. Users switching between the two feature sets will see a gap or duplicate metric series in their observability backend. Documentation should note this; no migration tooling is provided by this library.
+- **Data migration:** Explicitly out of scope. Users switching between the two feature sets will see a gap or duplicate metric series in their observability backend. Documentation should note this; no migration tooling is provided by this library.
 
 ---
 
 ## 9. Semantic Conventions and Cross-Language Consistency
 
-* **Proposed:** Align strictly with OTel Semantic Conventions version `v1.41.0` (database client namespace) by default.
-* **Proposed:** The `go-metrics-compat` Cargo feature (Section 8.3) is the **only supported mechanism** for selecting Go-compatible metric names. No runtime configuration knob is exposed for this choice — the selection is baked in at compile time.
+- **Proposed:** Align strictly with OTel Semantic Conventions version `v1.41.0` (database client namespace) by default.
+- **Proposed:** The `go-metrics-compat` Cargo feature (Section 8.3) is the **only supported mechanism** for selecting Go-compatible metric names. No runtime configuration knob is exposed for this choice — the selection is baked in at compile time.
 
 ### 9.1 Technology-Agnostic Naming Rationale
-* **Proposed:** **Handling Technology-Agnostic Naming:** To support setups where Oxia serves as an internal coordinator/metadata engine inside a larger database system (similar to etcd/zookeeper configurations):
-  * **Database system isolation:** Differentiating nested telemetry calls (e.g. outer database system client vs inner coordinator/metadata database client) is done purely via attributes. The inner Oxia calls will carry `db.system = "oxia"`, whereas the outer system client calls will carry `db.system = "my_custom_db"`.
-  * **Unified dashboard querying:** Using the standard semantic convention name `db.client.operation.duration` across both clients enables operators to aggregate database latency metrics globally or slice them by `db.system` to analyze the exact overhead contribution of the coordination layer.
+
+- **Proposed:** **Handling Technology-Agnostic Naming:** To support setups where Oxia serves as an internal coordinator/metadata engine inside a larger database system (similar to etcd/zookeeper configurations):
+  - **Database system isolation:** Differentiating nested telemetry calls (e.g. outer database system client vs inner coordinator/metadata database client) is done purely via attributes. The inner Oxia calls will carry `db.system = "oxia"`, whereas the outer system client calls will carry `db.system = "my_custom_db"`.
+  - **Unified dashboard querying:** Using the standard semantic convention name `db.client.operation.duration` across both clients enables operators to aggregate database latency metrics globally or slice them by `db.system` to analyze the exact overhead contribution of the coordination layer.
 
 ### 9.2 Name Mapping Reference
 
 The table below is the authoritative mapping between the two naming regimes. The **`go-metrics-compat` name** column lists the exact string constants the Go reference client records metrics under; see Section 2.2 for observation source references.
 
-| Concept | Default (OTel v1.41.0) name | `go-metrics-compat` name | Notes |
-|---|---|---|---|
-| Operation latency | `db.client.operation.duration` | `oxia_client_op_sum` / `oxia_client_op_count` | Go uses dual counters; Rust uses a single Histogram in both modes |
-| Operation payload size | `db.client.operation.size` *(proposed extension)* | `oxia_client_op_value` | — |
-| Batch total duration | `db.client.batch.duration` | `oxia_client_batch_total_sum` | — |
-| Batch execution duration | `db.client.batch.exec_duration` | `oxia_client_batch_exec_sum` | — |
-| Batch payload size | `db.client.batch.size` | `oxia_client_batch_value` | — |
-| Batch request count | `db.client.batch.request_count` | `oxia_client_batch_request` | — |
+| Concept                  | Default (OTel v1.41.0) name                       | `go-metrics-compat` name                      | Notes                                                             |
+| ------------------------ | ------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------- |
+| Operation latency        | `db.client.operation.duration`                    | `oxia_client_op_sum` / `oxia_client_op_count` | Go uses dual counters; Rust uses a single Histogram in both modes |
+| Operation payload size   | `db.client.operation.size` _(proposed extension)_ | `oxia_client_op_value`                        | —                                                                 |
+| Batch total duration     | `db.client.batch.duration`                        | `oxia_client_batch_total_sum`                 | —                                                                 |
+| Batch execution duration | `db.client.batch.exec_duration`                   | `oxia_client_batch_exec_sum`                  | —                                                                 |
+| Batch payload size       | `db.client.batch.size`                            | `oxia_client_batch_value`                     | —                                                                 |
+| Batch request count      | `db.client.batch.request_count`                   | `oxia_client_batch_request`                   | —                                                                 |
 
 > [!NOTE]
 > The Go client splits each timer into a `_sum` counter and a `_count` counter. The Rust implementation collapses these into a single `Histogram` regardless of which naming mode is active, because OTel Histograms provide both sum and count natively. The `go-metrics-compat` names therefore reference only the sum counter's name as the histogram instrument name. Backends that expected a separate count counter will need to use the histogram's built-in count aggregation.
 
 ### 9.3 Switching Overhead Analysis
 
-* **Zero runtime overhead:** Because the name strings are `const &str` values selected via `#[cfg]` attributes, the compiler eliminates the unused alternative entirely. There is no branch, no match expression, and no `if` check in the hot path.
-* **Binary size:** Each name variant compiles to a single null-terminated UTF-8 string in the read-only data segment. Switching variants changes which string is present; it does not add any code.
-* **No dynamic dispatch:** `MeterProvider::meter()` is called once during `Metrics::new()` (initialization, cold path). The name constant is passed at that point and never read again on the hot path.
+- **Zero runtime overhead:** Because the name strings are `const &str` values selected via `#[cfg]` attributes, the compiler eliminates the unused alternative entirely. There is no branch, no match expression, and no `if` check in the hot path.
+- **Binary size:** Each name variant compiles to a single null-terminated UTF-8 string in the read-only data segment. Switching variants changes which string is present; it does not add any code.
+- **No dynamic dispatch:** `MeterProvider::meter()` is called once during `Metrics::new()` (initialization, cold path). The name constant is passed at that point and never read again on the hot path.
 
 ---
 
 ## 10. Performance and Risk Analysis
-* **Proposed:** **Operation Path Classification:**
-  * **Hot path:** `Client::get`, `Client::put`, `Client::delete`, `Client::batch_get`.
-    * *Mitigation:* Ensure attributes are constructed using static slices or pre-allocated elements. Do not format strings (e.g. `format!("shard-{}", id)`) on these paths.
-  * **Warm path:** `Client::delete_range`, `Client::list`, `Client::range_scan`, `Client::connect`, heartbeats.
-  * **Cold path:** Background task startups, stale map retries.
+
+- **Proposed:** **Operation Path Classification:**
+  - **Hot path:** `Client::get`, `Client::put`, `Client::delete`, `Client::batch_get`.
+    - _Mitigation:_ Ensure attributes are constructed using static slices or pre-allocated elements. Do not format strings (e.g. `format!("shard-{}", id)`) on these paths.
+  - **Warm path:** `Client::delete_range`, `Client::list`, `Client::range_scan`, `Client::connect`, heartbeats.
+  - **Cold path:** Background task startups, stale map retries.
 
 ---
 
 ## 11. Rollout and Migration Plan
-* **Proposed:** **Phased Approach:**
-  * **Phase 1:** Add optional `telemetry` Cargo feature, introduce the `client/src/telemetry.rs` module, and configure the ZST metrics interface.
-  * **Phase 2:** Instrument tracing spans using `tracing` macros across the KV operations in `lib.rs` and `shard.rs`.
-  * **Phase 3:** Instrument metrics recorders inside the write batch and read batch streams. Expose the `meter_provider` setter on `Config` when the `telemetry` feature flag is active.
-  * **Phase 4:** Instrument background loops (heartbeat and assignment task).
+
+- **Proposed:** **Phased Approach:**
+  - **Phase 1:** Add optional `telemetry` Cargo feature, introduce the `client/src/telemetry.rs` module, and configure the ZST metrics interface.
+  - **Phase 2:** Instrument tracing spans using `tracing` macros across the KV operations in `lib.rs` and `shard.rs`.
+  - **Phase 3:** Instrument metrics recorders inside the write batch and read batch streams. Expose the `meter_provider` setter on `Config` when the `telemetry` feature flag is active.
+  - **Phase 4:** Instrument background loops (heartbeat and assignment task).
 
 ---
 
 ## 12. Testing and Validation Strategy
-* **Proposed:** Introduce unit tests under `client/tests/` using `otel-test` or `tracing-subscriber` mock layer to verify:
-  * Metric recordings match expected values (counts, sums) on success and failure.
-  * Spans have correct attributes and parent/child relationship.
-  * Custom injected `MeterProvider` receives the expected measurements.
-  * When `telemetry` feature is disabled, tests verify compilation succeeds and no metrics are registered.
+
+- **Proposed:** Introduce unit tests under `client/tests/` using `otel-test` or `tracing-subscriber` mock layer to verify:
+  - Metric recordings match expected values (counts, sums) on success and failure.
+  - Spans have correct attributes and parent/child relationship.
+  - Custom injected `MeterProvider` receives the expected measurements.
+  - When `telemetry` feature is disabled, tests verify compilation succeeds and no metrics are registered.
 
 ---
 
 ## 13. Open Questions
 
-* ~~Do downstream dashboards expect exact Go-compatible metric names (`oxia_client_op`) or should we migrate to standard OTel `v1.41.0` names (`db.client.operation.duration`)?~~ **Resolved:** Both naming schemes are supported via the `go-metrics-compat` compile-time feature flag (see Section 8.3). The default build uses OTel `v1.41.0` names. Consumers with existing Go-compatible dashboards enable `go-metrics-compat` at compile time. Data migration is explicitly out of scope.
+- ~~Do downstream dashboards expect exact Go-compatible metric names (`oxia_client_op`) or should we migrate to standard OTel `v1.41.0` names (`db.client.operation.duration`)?~~ **Resolved:** Both naming schemes are supported via the `go-metrics-compat` compile-time feature flag (see Section 8.3). The default build uses OTel `v1.41.0` names. Consumers with existing Go-compatible dashboards enable `go-metrics-compat` at compile time. Data migration is explicitly out of scope.
 
-* **Reviewer Input Required:**
-  1. Should `go-metrics-compat` imply `telemetry` in the Cargo feature graph (recommended, see Section 8.3) or remain an independent flag that produces a `compile_error!` when `telemetry` is not also enabled?
-  2. The Go client emits `oxia_client_op_sum` and `oxia_client_op_count` as separate instruments. Should the `go-metrics-compat` Rust mode register two instruments to exactly replicate that wire format, or is the Histogram approach (with its built-in count) an acceptable deviation?
+- ~~Should `go-metrics-compat` imply `telemetry` in the Cargo feature graph (recommended, see Section 8.3) or remain an independent flag that produces a `compile_error!` when `telemetry` is not also enabled?~~ **Resolved**: `go-metrics-compat` feature implies `telemetry` in the feature graph.
+
+- ~~The Go client emits `oxia_client_op_sum` and `oxia_client_op_count` as separate instruments. Should the `go-metrics-compat` Rust mode register two instruments to exactly replicate that wire format, or is the Histogram approach (with its built-in count) an acceptable deviation?~~ **Resolved**: `go-metrics-compat` will register and use separate `_sum/_count` instruments.
 
 ---
 
 # Part B: Implementation Handoff Spec
 
 ## B.1 Required Decisions
+
 - [x] Utilize the `tracing` crate facade with a target dependency on `tracing-opentelemetry` compatibility; do not take a direct dependency on `opentelemetry-sdk` in the library.
 - [x] Use Option B (Feature-gated, opt-in) via the `telemetry` Cargo feature.
 - [x] Use OTel `Histogram` for operation latencies instead of Go's counter-based timer approach.
 - [x] Prohibit dynamic user keys or values in metric attributes.
 - [x] Expose `meter_provider` setter on the `Config` builder when the `telemetry` feature flag is active.
 - [x] Add `go-metrics-compat` Cargo feature to select Go reference client metric name strings at compile time (zero runtime overhead). Default build uses OTel `v1.41.0` semantic convention names.
-- [ ] **Open:** Decide whether `go-metrics-compat` should imply `telemetry` in the feature graph, or fail loudly at compile time when `telemetry` is absent (see Section 8.3 and Open Question 1).
-- [ ] **Open:** Decide whether `go-metrics-compat` mode should register separate `_sum`/`_count` instruments to exactly replicate Go wire format, or use a single Histogram (see Open Question 2).
+- [x] `go-metrics-compat` should imply `telemetry` in the feature graph.
+- [x] `go-metrics-compat` mode will not register separate `_sum`/`_count` instruments to exactly replicate Go wire format
 
 ## B.2 Assumptions
+
 - **MSRV:** Target client's current edition (2021).
 - **Target OTel Version:** `v1.41.0` Semantic Conventions.
 - **Runtime:** Assumes `tokio` multi-threaded executor downstream.
@@ -391,22 +413,23 @@ The table below is the authoritative mapping between the two naming regimes. The
 
 ### Summary Mapping Table
 
-| Rust API Entry Point | Span Name | Type (Span Kind) | Metrics Emitted | Performance Classification |
-|---|---|---|---|---|
-| `Client::connect` | `"client.connect"` | `SpanKind::Client` | — | Warm path |
-| `Client::get` | `"db.operation.get"` | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"` | Hot path |
-| `Client::put` | `"db.operation.put"` | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"` | Hot path |
-| `Client::delete` | `"db.operation.delete"` | `SpanKind::Client` | `"oxia.client.op.duration"` | Hot path |
-| `Client::delete_range`| `"db.operation.delete_range"`| `SpanKind::Client` | `"oxia.client.op.duration"` | Warm path |
-| `Client::list` | `"db.operation.list"` | `SpanKind::Client` | `"oxia.client.op.duration"` | Warm path |
-| `Client::range_scan` | `"db.operation.range_scan"` | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"` | Warm path |
-| `Client::batch_get` | `"db.operation.batch_get"` | `SpanKind::Client` | `"oxia.client.batch.total_duration"`, `"oxia.client.batch.exec_duration"` | Hot path |
+| Rust API Entry Point   | Span Name                     | Type (Span Kind)   | Metrics Emitted                                                           | Performance Classification |
+| ---------------------- | ----------------------------- | ------------------ | ------------------------------------------------------------------------- | -------------------------- |
+| `Client::connect`      | `"client.connect"`            | `SpanKind::Client` | —                                                                         | Warm path                  |
+| `Client::get`          | `"db.operation.get"`          | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Hot path                   |
+| `Client::put`          | `"db.operation.put"`          | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Hot path                   |
+| `Client::delete`       | `"db.operation.delete"`       | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Hot path                   |
+| `Client::delete_range` | `"db.operation.delete_range"` | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Warm path                  |
+| `Client::list`         | `"db.operation.list"`         | `SpanKind::Client` | `"oxia.client.op.duration"`                                               | Warm path                  |
+| `Client::range_scan`   | `"db.operation.range_scan"`   | `SpanKind::Client` | `"oxia.client.op.duration"`, `"oxia.client.op.size"`                      | Warm path                  |
+| `Client::batch_get`    | `"db.operation.batch_get"`    | `SpanKind::Client` | `"oxia.client.batch.total_duration"`, `"oxia.client.batch.exec_duration"` | Hot path                   |
 
 ---
 
 ### Detailed Operation Specifications
 
 ##### Operation: `Client::connect`
+
 - **Purpose:** Tracks connection and setup of the client's shard manager.
 - **Span Name:** `"client.connect"`
 - **Span Kind:** `SpanKind::Client`
@@ -418,6 +441,7 @@ The table below is the authoritative mapping between the two naming regimes. The
 - **Performance Notes:** Warm path, allocates client metadata during connection.
 
 ##### Operation: `Client::get`
+
 - **Purpose:** Fetches value for a key.
 - **Span Name:** `"db.operation.get"`
 - **Span Kind:** `SpanKind::Client`
@@ -432,6 +456,7 @@ The table below is the authoritative mapping between the two naming regimes. The
 - **Performance Notes:** Hot path. Minimize dynamic allocations in attributes.
 
 ##### Operation: `Client::put`
+
 - **Purpose:** Puts a key-value record.
 - **Span Name:** `"db.operation.put"`
 - **Span Kind:** `SpanKind::Client`
@@ -452,14 +477,14 @@ The table below is the authoritative mapping between the two naming regimes. The
 > [!IMPORTANT]
 > Metric names are selected at compile time. The **Default name** column applies when `go-metrics-compat` is **not** enabled. The **`go-metrics-compat` name** column applies when that feature is enabled. Instrument type, unit, and attributes are identical regardless of naming mode.
 
-| Concept | Default name (OTel v1.41.0) | `go-metrics-compat` name | Instrument | Unit | Attributes | Cardinality | Lifecycle |
-|---|---|---|---|---|---|---|---|
-| Operation latency | `db.client.operation.duration` | `oxia_client_op_sum` | Histogram | `"s"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
-| Operation payload size | `db.client.operation.size` | `oxia_client_op_value` | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
-| Batch total duration | `db.client.batch.duration` | `oxia_client_batch_total_sum` | Histogram | `"s"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
-| Batch exec duration | `db.client.batch.exec_duration` | `oxia_client_batch_exec_sum` | Histogram | `"s"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
-| Batch payload size | `db.client.batch.size` | `oxia_client_batch_value` | Histogram | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
-| Batch request count | `db.client.batch.request_count` | `oxia_client_batch_request` | Histogram | `"1"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded | `telemetry::Metrics::new()` |
+| Concept                | Default name (OTel v1.41.0)     | `go-metrics-compat` name      | Instrument | Unit   | Attributes                                       | Cardinality | Lifecycle                   |
+| ---------------------- | ------------------------------- | ----------------------------- | ---------- | ------ | ------------------------------------------------ | ----------- | --------------------------- |
+| Operation latency      | `db.client.operation.duration`  | `oxia_client_op_sum`          | Histogram  | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Operation payload size | `db.client.operation.size`      | `oxia_client_op_value`        | Histogram  | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch total duration   | `db.client.batch.duration`      | `oxia_client_batch_total_sum` | Histogram  | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch exec duration    | `db.client.batch.exec_duration` | `oxia_client_batch_exec_sum`  | Histogram  | `"s"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch payload size     | `db.client.batch.size`          | `oxia_client_batch_value`     | Histogram  | `"By"` | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
+| Batch request count    | `db.client.batch.request_count` | `oxia_client_batch_request`   | Histogram  | `"1"`  | `db.system`, `db.name`, `db.operation`, `result` | Bounded     | `telemetry::Metrics::new()` |
 
 ---
 


### PR DESCRIPTION
- **docs: establish AGENTS.md, configure CLAUDE.md, and create project memory**
- **ai: agy design snapshot**
- **ai: first claude-via-agy update**
- **resolve open questions in design re: feature graph and compact _sum/_count**
- **ai: update design after resolving questions**
- **just fmt: update to use nightly**
- **update commands to prefer `just` targets over `cargo`**
- **Implement OTel client metrics instrumentation**
- **Client::connect() - do not trace when already connected**
- **Build CI with metrics feature**
- **Print command metrics on exit**
