### PR TITLE
Metrics implementation

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -127,14 +127,14 @@ jobs:
           cargo fetch --locked   # fetch dependencies: last network dependency
 
       - name: build
-        run: cargo build $RELEASE_FLAG --frozen --all-targets
+        run: cargo build $RELEASE_FLAG --frozen --all-targets --features metrics
 
       - name: clippy
-        run: cargo clippy $RELEASE_FLAG --no-deps --all-targets --frozen -- -D warnings
+        run: cargo clippy $RELEASE_FLAG --no-deps --frozen --all-targets --features metrics -- -D warnings
 
       - name: test
         timeout-minutes: 15 # release builds may be slower
-        run: cargo nextest run $NEXTEST_FLAG --frozen --no-fail-fast --verbose
+        run: cargo nextest run $NEXTEST_FLAG --frozen --features metrics --no-fail-fast --verbose
 
       - name: doc-test
         if: env.CARGO_PROFILE == 'ci-test-release'
@@ -143,7 +143,7 @@ jobs:
       - name: miri-client
         run: |
           unset RUSTC_WRAPPER
-          cargo +nightly miri nextest run --package mauricebarnum-oxia-client --frozen
+          cargo +nightly miri nextest run --package mauricebarnum-oxia-client --features metrics --frozen
         env:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md – Project Guidance for AI Coding Assistants
+
+This guide outlines rules, architecture, testing frameworks, and style constraints for AI coding assistants working in this experimental Rust Oxia client repository. Follow strictly for safe and efficient collaboration.
+
+## Safety & Workflow Rules
+
+- **Branches**: ALWAYS work on a dedicated task branch. Check out a new branch before making edits: `git checkout -b <prefix>-<task-name>`. Never modify or push directly to `main` or `origin/main`.
+- **Isolation**: For major changes, draft code in a temporary directory (e.g., `./agent-temp/` or similar) first, review diffs, and confirm before writing to main repository files.
+- **Git Safety**: Stash changes when appropriate to avoid conflicts. No raw commits or pushes without checking compatibility and verifying changes. Do not run destructive git operations.
+- **Commit Annotations**: All commits created with assistance from an AI agent must include an annotation in the commit message body indicating AI assistance (e.g., `Created with assistance from <AssistantName>`).
+- **Read-Only Paths**: NEVER modify `./ext/oxia/` (vendored Oxia mirror).
+- **Work in Progress**: Always consider unmerged commits on the current branch. Run `git status` or check diffs relative to upstream tracking branches at the start of a session.
+
+## Project Overview
+
+Experimental Rust Oxia client with sharding, gRPC support, and notifications. 
+- Workspace crates: `common` (bindings), `client` (async API), `cmd` (CLI `oxia-cmd`), `oxia-bin-util` (server binary compiler).
+
+## Build & Test Commands
+
+| Task      | Command                                                    | Notes                       |
+| --------- | ---------------------------------------------------------- | --------------------------- |
+| Build     | `cargo build --all-targets`                                | All targets                 |
+| Tests     | `cargo nextest run`                                        | Full; or `--package client` |
+| Unit only | `cargo nextest run -E 'kind(lib)'`                         | Sandbox-safe; no sockets    |
+| ExtSyms   | `cargo nextest run -E 'binary(extsyms)'`                   | Public API types allowlist  |
+| Lint      | `cargo clippy --all-targets --all-features -- -D warnings` | Strict                      |
+| Format    | `cargo +nightly fmt --all` / `--check`                     | -                           |
+| Security  | `cargo deny check`                                         | Licenses                    |
+| Miri      | `+nightly cargo miri nextest run --package client`         | UB detection                |
+
+CI uses `--release --frozen`. Local commands can omit those flags.
+
+## Workspace Structure
+
+- `common`: gRPC protobuf bindings (`tonic-prost-build`).
+- `client`: Async client with sharding and dispatch.
+- `cmd`: CLI utility (`oxia-cmd`) implementing `get`, `put`, `delete`, `list`, `range`, `notifications`, and `shell`.
+- `oxia-bin-util`: Builds vendored Go Oxia server for testing. Output binary is at `target/oxia/oxia` after build.
+
+## Key Architecture
+
+- **API**: `Client` is a concrete struct, not a trait object, with `put(key, value)` and `put_with_options(...)`. Uses zero-cost abstractions.
+- **Sharding**: XXHASH3 routing; dynamic via `shard.rs`.
+- **Pooling**: `pool.rs` per-shard gRPC; `ArcSwap` caches.
+- **Notifications**: Streaming key changes.
+- **Protos**: Automatically generated from `./ext/oxia/common/proto`. No manual edits are allowed to generated files or protos.
+- **Tests**: Spawn local servers via `client/tests/common.rs`.
+
+## Security & Trust Boundaries
+
+- **Public gRPC API**: Primary entry point for clients (`public_rpc_server.go`). Trust boundary for keys, values, and session management.
+- **Internal Coordination API**: Server-to-server communication (`internal_rpc_server.go`). Critical for cluster integrity (replication, heartbeats).
+- **CLI Arguments**: Entry point for user-supplied configuration (`cmd/src/main.rs`). Boundary for service addresses and timeouts.
+- **Service Discovery**: The client receives node lists from the coordinator (`discovery.rs`). Boundary for potentially untrusted network metadata.
+- **CI/CD Workflows**: Reusable workflows (`rust-build.yml`). Trust boundary for input-driven command execution.
+
+## Concurrency & Synchronization (Hot Path: Lock-free)
+
+1. `ArcSwap::load` to look up active shards/clients.
+2. `RwLock::read` pool (only on misses).
+Guidelines: `ArcSwap` preferred over `RwLock`. Use `tokio::sync` primitives. Do not hold locks across `.await` points.
+
+- **Async Traits**: Use `BoxFuture` desugaring (see `notification.rs`, `address.rs`), not the `async-trait` crate.
+
+## Coding Style
+
+- **Clippy**: Strict workspace Cargo.toml settings must be followed.
+- **Imports**: Prefer unmerged `use` statements (one item per line). Do not merge imports (e.g. avoid `use std::{foo, bar};`).
+- **Docs**: Terse, idiomatic Rust API guidelines; prefer `const fn` when possible.
+- **GitHub**: Submit changes via Draft PRs; push with `--force-with-lease`; always verify clippy and tests locally before pushing. Ignore local `main`.
+
+## Dependencies
+
+- Include minimal features when adding or managing dependencies.
+- Do not add dependencies rejected by `cargo deny`.
+- When making a module `pub`, update `allowed_external_types` in `client/Cargo.toml` for any newly exposed external types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,21 +13,21 @@ This guide outlines rules, architecture, testing frameworks, and style constrain
 
 ## Project Overview
 
-Experimental Rust Oxia client with sharding, gRPC support, and notifications. 
+Experimental Rust Oxia client with sharding, gRPC support, and notifications.
+
 - Workspace crates: `common` (bindings), `client` (async API), `cmd` (CLI `oxia-cmd`), `oxia-bin-util` (server binary compiler).
 
 ## Build & Test Commands
 
-| Task      | Command                                                    | Notes                       |
-| --------- | ---------------------------------------------------------- | --------------------------- |
-| Build     | `cargo build --all-targets`                                | All targets                 |
-| Tests     | `cargo nextest run`                                        | Full; or `--package client` |
-| Unit only | `cargo nextest run -E 'kind(lib)'`                         | Sandbox-safe; no sockets    |
-| ExtSyms   | `cargo nextest run -E 'binary(extsyms)'`                   | Public API types allowlist  |
-| Lint      | `cargo clippy --all-targets --all-features -- -D warnings` | Strict                      |
-| Format    | `cargo +nightly fmt --all` / `--check`                     | -                           |
-| Security  | `cargo deny check`                                         | Licenses                    |
-| Miri      | `+nightly cargo miri nextest run --package client`         | UB detection                |
+| Task      | Command                                            | Notes                       |
+| --------- | -------------------------------------------------- | --------------------------- |
+| Build     | `cargo build --all-targets`                        | All targets                 |
+| Tests     | `cargo nextest run`                                | Full; or `--package client` |
+| Unit only | `cargo nextest run -E 'kind(lib)'`                 | Sandbox-safe; no sockets    |
+| Lint      | `just lint`                                        | Strict                      |
+| Format    | `just fmt`                                         | -                           |
+| Security  | `cargo deny check`                                 | Licenses                    |
+| Miri      | `cargo +nightly miri nextest run --package client` | UB detection                |
 
 CI uses `--release --frozen`. Local commands can omit those flags.
 
@@ -59,7 +59,7 @@ CI uses `--release --frozen`. Local commands can omit those flags.
 
 1. `ArcSwap::load` to look up active shards/clients.
 2. `RwLock::read` pool (only on misses).
-Guidelines: `ArcSwap` preferred over `RwLock`. Use `tokio::sync` primitives. Do not hold locks across `.await` points.
+   Guidelines: `ArcSwap` preferred over `RwLock`. Use `tokio::sync` primitives. Do not hold locks across `.await` points.
 
 - **Async Traits**: Use `BoxFuture` desugaring (see `notification.rs`, `address.rs`), not the `async-trait` crate.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,83 +1,23 @@
-# CLAUDE.md – Project Guidance for Claude Code
+# CLAUDE.md
 
-This CLAUDE.md guides Claude Code (`claude`) for this experimental Rust Oxia client repo. Follow strictly for safe, efficient collaboration. TITLE CLAUDE.md [file:43]
+Refer to the root `AGENTS.md` file for all project architectures, testing frameworks, and style constraints.
 
-## Safety & Workflow Rules (New)
+## Claude Code-Specific Safety & Workflow Rules
+- **Branches**: ALWAYS prefix branches with `claude-` (e.g., `git checkout -b claude-task-name`). Never commit or push directly to `main` or `origin/main`.
+- **Isolation**: Write to `./claude-temp/` first (create if needed: `mkdir claude-temp`). Propose diffs with `/diff`; confirm before main files.
+- **Git Safety**: 
+  - Pre-session: `git stash push -m "pre-claude"`
+  - Stash changes during session: `git stash push`
+  - Do not commit or push without using `/confirm` or getting explicit user approval.
+- **Tokens & Performance**: 
+  - Use `/rewind` (Esc Esc) for undos.
+  - Limit tools (`ENABLE_TOOL_SEARCH=auto:5%`).
+  - Summarize with `/compact`.
+  - Monitor `/cost`.
+- **Efficiency Prompts**:
+  - "Plan in `./claude-temp/`; diff before apply."
+  - "Verify with tests; /cost check."
 
-- **Branches**: ALWAYS prefix `claude-` (e.g., `claude-feature`). Check out new feature branch before edits: `git checkout -b claude-task-name`. Never touch `main`/`origin/main`. [file:43]
-- **Isolation**: Write to `./claude-temp/` first (create if needed: `mkdir claude-temp`). Propose diffs with `/diff`; confirm before main files. Read via `@file.rs` on-demand. [web:35]
-- **Git Safety**: Pre-session: `git stash push -m "pre-claude"`. Stash changes: `git stash push`. No commits/pushes without `/confirm`. Post: `git stash pop` selectively. Block destructives via hooks. [web:33]
-- **Tokens**: Use `/rewind` (Esc Esc) for undos. Limit tools (`ENABLE_TOOL_SEARCH=auto:5%`). Test incrementally; summarize with `/compact`. Monitor `/cost`. [web:10]
-- **Read-Only**: NEVER modify `./ext/oxia/` (vendored Oxia mirror). [file:43]
-- _Work in progress_: Always consider unmerged commits on the current branch
-  - Run `git log --oneline @{u}..` or `git status` at session start if relevant.
-  - Summarize unmerged changes before major tasks.
-
-## Project Overview
-
-Experimental Rust Oxia client: sharding, gRPC, notifications. Workspace: common (bindings), client (async API), cmd (CLI `oxia-cmd`), oxia-bin-util (server binary). [file:43]
-
-## Build & Test Commands
-
-| Task      | Command                                                    | Notes                       |
-| --------- | ---------------------------------------------------------- | --------------------------- |
-| Build     | `cargo build --all-targets`                                | All targets                 |
-| Tests     | `cargo nextest run`                                        | Full; or `--package client` |
-| Unit only | `cargo nextest run -E 'kind(lib)'`                         | Sandbox-safe; no sockets    |
-| ExtSyms   | `cargo nextest run -E 'binary(extsyms)'`                   | Public API types allowlist  |
-| Lint      | `cargo clippy --all-targets --all-features -- -D warnings` | Strict                      |
-| Format    | `cargo +nightly fmt --all` / `--check`                     | -                           |
-| Security  | `cargo deny check`                                         | Licenses                    |
-| Miri      | `+nightly cargo miri nextest run --package client`         | UB detection [file:43]      |
-
-CI uses `--release --frozen`. Local: omit.
-
-## Workspace Structure
-
-- `common`: gRPC protos (tonic-prost-build).
-- `client`: Async client (sharding, dispatch).
-- `cmd`: `oxia-cmd` CLI (get/put/delete/list/range/notifications/shell).
-- `oxia-bin-util`: Builds vendored Go Oxia server for tests. Binary at `target/oxia/oxia` after build. [file:43]
-
-## Key Architecture
-
-- **API**: `Client` struct; `put(key, value)` + `with_options()`. Zero-cost abstractions.
-- **Sharding**: XXHASH3 routing; dynamic via `shard.rs`.
-- **Pooling**: `pool.rs` per-shard gRPC; `ArcSwap` caches.
-- **Notifications**: Streaming key changes.
-- **Protos**: Auto from `./ext/oxia/common/proto`. No manual edits.
-- **Tests**: Spawn servers via `client/tests/common.rs`. [file:43]
-
-## Security & Trust Boundaries
-
-- **Public gRPC API**: Primary entry point for clients (`public_rpc_server.go`). Trust boundary for keys, values, and session management.
-- **Internal Coordination API**: Server-to-server communication (`internal_rpc_server.go`). Critical for cluster integrity (replication, heartbeats).
-- **CLI Arguments**: Entry point for user-supplied configuration (`cmd/src/main.rs`). Boundary for service addresses and timeouts.
-- **Service Discovery**: The client receives node lists from the coordinator (`discovery.rs`). Boundary for potentially untrusted network metadata.
-- **CI/CD Workflows**: Reusable workflows (`rust-build.yml`). Trust boundary for input-driven command execution.
-
-**Concurrency** (Hot Path: Lock-free):
-
-1. `ArcSwap::load` shards/clients.
-2. `RwLock::read` pool (misses).
-   Guidelines: ArcSwap > RwLock; tokio-sync; no locks pre-`.await`. [file:43]
-
-- **Async traits**: Use `BoxFuture` desugaring (see `notification.rs`, `address.rs`), not `async-trait` crate.
-
-## Coding Style
-
-- Clippy: Settings are in workspace Cargo.toml
-- **Imports**: Prefer unmerged `use` statements (one item per line). No `use std::{foo, bar};` merging.
-- Docs: Terse; Rust API guidelines; `const fn`.
-- GitHub: Draft PRs; `--force-with-lease`; tests/clippy pre-push. Ignore local `main`. [file:43]
-
-## Efficiency Prompts
-
-- "Plan in `./claude-temp/`; diff before apply."
-- "Verify with tests; /cost check."
-
-## Dependencies
-
-- Include minimal features when adding or managing dependencies
-- Do not add dependencies rejected by `cargo deny`
-- When making a module `pub`, update `allowed_external_types` in `client/Cargo.toml` for any newly exposed external types
+## Claude Code-Specific Overrides
+- When compacting history with `/compact`, always preserve the core task list.
+- Use subagents for complex research instead of inline exploration loops.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -176,9 +176,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -228,14 +228,14 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 1.3.0",
+ "shlex",
 ]
 
 [[package]]
@@ -257,8 +257,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -339,6 +339,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +361,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -488,7 +509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -646,7 +667,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -792,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -980,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matchers"
@@ -1017,10 +1038,12 @@ dependencies = [
  "itertools",
  "mauricebarnum-oxia-common",
  "nix",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "oxia-bin-util",
  "prost",
  "prost-types",
- "rand",
+ "rand 0.10.1",
  "socket2",
  "tempfile",
  "test-log",
@@ -1049,8 +1072,14 @@ dependencies = [
  "humantime",
  "mauricebarnum-oxia-client",
  "num_cpus",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
  "rustyline",
- "shlex 2.0.1",
+ "serde",
+ "serde_json",
+ "shlex",
  "thiserror",
  "tokio",
  "tracing",
@@ -1094,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1136,7 +1165,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1169,6 +1198,51 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "oxia-bin-util"
@@ -1243,6 +1317,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1348,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
 ]
 
 [[package]]
@@ -1367,13 +1471,42 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1381,6 +1514,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1430,7 +1572,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1488,6 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1530,7 +1673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
@@ -1542,12 +1685,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -1590,7 +1727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1626,7 +1763,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1911,9 +2048,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -1929,9 +2072,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -2085,7 +2228,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2329,6 +2472,26 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Justfile
+++ b/Justfile
@@ -14,4 +14,4 @@ lint: check
     cd client && cargo +nightly-2025-10-18 check-external-types
 
 fmt:
-    cargo fmt --all
+    cargo +nightly fmt --all

--- a/Justfile
+++ b/Justfile
@@ -3,8 +3,18 @@ default: build
 build:
     cargo build --all-targets --all-features
 
+build-all:
+    cargo build --all-targets
+    cargo build --all-targets --features metrics
+    cargo build --all-targets --features go-metrics-compat
+
 test:
+    cargo nextest run --all-features
+
+test-all:
     cargo nextest run
+    cargo nextest run --features metrics
+    cargo nextest run --features go-metrics-compat
 
 check:
     cargo check --all-targets --all-features

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Downsides:
 
 Switching to a trait interface should be doable with minimal changes to both the implementation and the callers. In the "this is an experiment" nature of the current code base, it made more sense to explore the generic decision space ("impl Into<T>"? "impl AsRef<T>"? concrete param? etc.). I'm considering putting in a test that will validate at compile time that the `Client` interface remains close to object safe. I haven't done it yet because I didn't want to deal with the maintenance overhead of the test, but the API is stable enough now that it shouldn't be a problem going forward. Maybe an LLM can generate it for me without making too much of a mess.
 
+## Metrics
+
+The client records semantic latency, size, and request count measurements as OpenTelemetry histogram instruments. Callers that provide their own `MeterProvider` must install SDK views for these instruments to receive `ExponentialHistogram` data points; otherwise the SDK default aggregation may be explicit buckets. The CLI metrics setup in [cmd/src/metrics.rs](cmd/src/metrics.rs) is the canonical example of configuring those views.
+
 # TODO
 
 1. Add robustness for transient errors

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -90,9 +90,9 @@ RUN GH_WORKSPACE="/__w/${REPO_NAME}/${REPO_NAME}" && \
     mkdir -p "${GH_WORKSPACE}" && \
     cp /tmp/recipe.json "${GH_WORKSPACE}/recipe.json" && \
     cd "${GH_WORKSPACE}" && \
-    cargo chef cook --profile ci-debug --all-targets --recipe-path recipe.json && \
-    cargo chef cook --profile ci --all-targets --recipe-path recipe.json && \
-    cargo chef cook --profile ci-test-release --all-targets --recipe-path recipe.json && \
+    cargo chef cook --profile ci-debug --all-targets --features metrics --recipe-path recipe.json && \
+    cargo chef cook --profile ci --all-targets --features metrics --recipe-path recipe.json && \
+    cargo chef cook --profile ci-test-release --all-targets --features metrics --recipe-path recipe.json && \
     cargo fetch --locked && \
     cargo +nightly fetch --locked
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,14 +22,17 @@ xxhash-rust = { version = "0.8.15", default-features = false, features = [
 backon = "1.6.0"
 arc-swap = "1.9"
 tokio-util = "0.7.18"
-bon = { version = "3.9.1", features = ["implied-bounds"] }
+bon = { version = "3.9.2", features = ["implied-bounds"] }
 dashmap = { version = "6", optional = true }
 fastrand = "2.4.1"
 prost = "0.14.4"
 prost-types = "0.14.4"
+opentelemetry = { version = "0.32.0", features = ["metrics"], optional = true }
 
 [features]
 bench-dashmap = ["dep:dashmap"]
+go-metrics-compat = ["metrics"]
+metrics = ["dep:opentelemetry"]
 
 [dev-dependencies]
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros"] }
@@ -42,6 +45,10 @@ tempfile = "3.27.0"
 anyhow = "1.0.102"
 itertools = "0.14.0"
 nix = { version = "0.31", default-features = false, features = ["signal"] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = [
+    "metrics",
+    "testing",
+] }
 
 [[bench]]
 name = "shard_lookup"
@@ -65,4 +72,5 @@ allowed_external_types = [
     "futures_core::stream::Stream",
     "bon::builder_state::IsSet",
     "bon::builder_state::IsUnset",
+    "opentelemetry::metrics::meter::MeterProvider",
 ]

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -20,6 +20,11 @@ use bon::Builder;
 use crate::discovery::IntoServiceDiscovery;
 use crate::discovery::ServiceDiscovery;
 
+#[cfg(feature = "metrics")]
+pub type MeterProviderHandle = Arc<dyn opentelemetry::metrics::MeterProvider + Send + Sync>;
+#[cfg(not(feature = "metrics"))]
+pub type MeterProviderHandle = ();
+
 #[derive(Clone, Copy, Debug)]
 pub struct RetryConfig {
     pub(crate) attempts: usize,
@@ -38,7 +43,7 @@ impl RetryConfig {
     }
 }
 
-#[derive(Builder, Clone, Debug)]
+#[derive(Builder, Clone)]
 #[builder(finish_fn(name = do_build, vis = ""))]
 #[builder(on(String, into))]
 #[builder(state_mod(vis = "pub"))]
@@ -57,6 +62,8 @@ pub struct Config {
     retry: Option<RetryConfig>,
     #[builder(default = false)]
     retry_on_stale_shard_map: bool,
+    #[cfg(feature = "metrics")]
+    meter_provider: Option<MeterProviderHandle>,
 }
 
 impl Config {
@@ -98,6 +105,37 @@ impl Config {
     #[inline]
     pub const fn retry_on_stale_shard_map(&self) -> bool {
         self.retry_on_stale_shard_map
+    }
+
+    #[cfg(feature = "metrics")]
+    #[inline]
+    pub const fn meter_provider(&self) -> Option<&MeterProviderHandle> {
+        self.meter_provider.as_ref()
+    }
+
+    #[cfg(not(feature = "metrics"))]
+    #[inline]
+    #[expect(clippy::unused_self)]
+    pub(crate) const fn meter_provider(&self) -> Option<&MeterProviderHandle> {
+        None
+    }
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Config");
+        debug
+            .field("service_discovery", &"<service discovery>")
+            .field("namespace", &self.namespace)
+            .field("identity", &self.identity)
+            .field("session_timeout", &self.session_timeout)
+            .field("max_parallel_requests", &self.max_parallel_requests)
+            .field("request_timeout", &self.request_timeout)
+            .field("retry", &self.retry)
+            .field("retry_on_stale_shard_map", &self.retry_on_stale_shard_map);
+        #[cfg(feature = "metrics")]
+        debug.field("meter_provider", &self.meter_provider.is_some());
+        debug.finish()
     }
 }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -16,7 +16,9 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Context;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -26,6 +28,7 @@ use futures::stream::StreamExt;
 use futures::stream::TryStreamExt;
 use mauricebarnum_oxia_common::proto as oxia_proto;
 use tonic::transport::Channel;
+use tracing::Instrument;
 
 use crate::notification::NotificationsStream;
 use crate::pool::ChannelPool;
@@ -35,6 +38,7 @@ pub mod batch_get;
 pub mod config;
 pub mod discovery;
 pub mod errors;
+mod metrics;
 mod notification;
 mod pool;
 mod shard;
@@ -44,6 +48,18 @@ pub use errors::*;
 pub use shard::ShardId;
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[inline]
+fn instrument_stream<S>(stream: S, span: tracing::Span) -> impl futures::Stream<Item = S::Item>
+where
+    S: futures::Stream,
+{
+    let mut stream = Box::pin(stream);
+    futures::stream::poll_fn(move |context: &mut Context<'_>| {
+        let _entered = span.enter();
+        Pin::as_mut(&mut stream).poll_next(context)
+    })
+}
 
 #[derive(Clone, Debug)]
 pub struct SecondaryIndex(oxia_proto::SecondaryIndex);
@@ -862,14 +878,17 @@ where
 pub struct Client {
     shard_manager: Option<Arc<shard::Manager>>,
     config: Arc<config::Config>,
+    metrics: metrics::Metrics,
 }
 
 impl Client {
     #[inline]
-    pub const fn new(config: Arc<config::Config>) -> Self {
+    pub fn new(config: Arc<config::Config>) -> Self {
+        let metrics = metrics::Metrics::new(config.meter_provider(), config.namespace());
         Self {
             shard_manager: None,
             config,
+            metrics,
         }
     }
 
@@ -884,11 +903,26 @@ impl Client {
     }
 
     pub async fn connect(&mut self) -> Result<()> {
-        if !self.is_connected() {
-            let sm = shard::Manager::new(&self.config).await?;
-            self.shard_manager = Some(Arc::new(sm));
+        if self.is_connected() {
+            return Ok(());
         }
-        Ok(())
+
+        let span = tracing::info_span!(
+            target: metrics::SCOPE_NAME,
+            "client.connect",
+            "db.system" = metrics::DB_SYSTEM,
+            "db.name" = self.config.namespace(),
+            "error.type" = tracing::field::Empty,
+        );
+        async {
+            let result = shard::Manager::new(&self.config).await.map(|sm| {
+                self.shard_manager = Some(Arc::new(sm));
+            });
+            metrics::record_error_type(&result);
+            result
+        }
+        .instrument(span)
+        .await
     }
 
     #[inline]
@@ -970,56 +1004,82 @@ impl Client {
         self.get_internal(Arc::from(key.into()), options)
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.get",
+        skip(self, key, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::Get.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn get_internal(
         &self,
         key: Arc<str>,
         options: GetOptions,
     ) -> Result<Option<GetResponse>> {
-        // Define the core operation with retry/timeout wrapper
-        let execute_get = |shard: shard::Client, key: Arc<str>, options: GetOptions| async move {
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
-                let key = Arc::clone(&key);
-                let options = options.clone();
-                async move { shard.get(&key, &options).await }
-            })
-            .await
-        };
+        let start = metrics::operation_start();
+        let result = async {
+            // Define the core operation with retry/timeout wrapper
+            let execute_get =
+                |shard: shard::Client, key: Arc<str>, options: GetOptions| async move {
+                    execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                        let shard = shard.clone();
+                        let key = Arc::clone(&key);
+                        let options = options.clone();
+                        async move { shard.get(&key, &options).await }
+                    })
+                    .await
+                };
 
-        // Single shard case: exact match with partition key OR exact match without secondary index
-        let use_single_shard = options.partition_key.is_some()
-            || (options.comparison_type == KeyComparisonType::Equal
-                && options.secondary_index_name.is_none());
+            // Single shard case: exact match with partition key OR exact match without secondary index
+            let use_single_shard = options.partition_key.is_some()
+                || (options.comparison_type == KeyComparisonType::Equal
+                    && options.secondary_index_name.is_none());
 
-        if use_single_shard {
-            let selector = options.partition_key.as_deref().unwrap_or(&key);
-            let shard = self.get_shard(selector)?;
-            return execute_get(shard, key, options).await;
-        }
+            if use_single_shard {
+                let selector = options.partition_key.as_deref().unwrap_or(&key);
+                let shard = self.get_shard(selector)?;
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                return execute_get(shard, key, options).await;
+            }
 
-        // Multi-shard case: query all shards and select the best response
-        let max_parallel = match self.config.max_parallel_requests() {
-            0 => usize::MAX,
-            n => n,
-        };
+            // Multi-shard case: query all shards and select the best response
+            let max_parallel = match self.config.max_parallel_requests() {
+                0 => usize::MAX,
+                n => n,
+            };
 
-        let best_response = futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
-            .map(|shard| execute_get(shard, Arc::clone(&key), options.clone()))
-            .buffer_unordered(max_parallel)
-            .try_fold(None, |best, response| async {
-                Ok(match response {
-                    Some(candidate) => Some(match best {
-                        None => candidate,
-                        Some(prev) => {
-                            util::select_response(Some(prev), candidate, options.comparison_type)
-                        }
-                    }),
-                    None => best,
+            futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
+                .map(|shard| execute_get(shard, Arc::clone(&key), options.clone()))
+                .buffer_unordered(max_parallel)
+                .try_fold(None, |best, response| async {
+                    Ok(match response {
+                        Some(candidate) => Some(match best {
+                            None => candidate,
+                            Some(prev) => {
+                                util::select_response(Some(prev), candidate, options.comparison_type)
+                            }
+                        }),
+                        None => best,
+                    })
                 })
-            })
-            .await?;
-
-        Ok(best_response)
+                .await
+        }
+        .await;
+        metrics::record_operation_result_with_size(
+            &self.metrics,
+            metrics::Operation::Get,
+            metrics::get_result_kind,
+            metrics::get_response_size,
+            start,
+            &result,
+        );
+        result
     }
 
     /// `batch_get` request multiple keys, minimizing requests to the backend
@@ -1035,52 +1095,68 @@ impl Client {
         use futures::future::Either::Left;
         use futures::future::Either::Right;
 
-        let shard_manager = self.get_shard_manager()?;
-        let (batch_get_futures, failures) = batch_get::prepare_requests(req, &shard_manager);
+        let span = tracing::info_span!(
+            target: metrics::SCOPE_NAME,
+            "db.operation.batch_get",
+            "db.system" = metrics::DB_SYSTEM,
+            "db.name" = self.config.namespace(),
+            "db.operation" = metrics::Operation::BatchGet.as_str(),
+            "error.type" = tracing::field::Empty,
+        );
+        let (start, final_stream) = {
+            let span: &tracing::Span = &span;
+            span.in_scope(|| {
+                let start = metrics::operation_start();
+                let shard_manager = match self.get_shard_manager() {
+                    Ok(manager) => manager,
+                    Err(error) => {
+                        let result = Err(error);
+                        metrics::record_operation_result(
+                            &self.metrics,
+                            metrics::Operation::BatchGet,
+                            metrics::result_kind,
+                            start,
+                            &result,
+                        );
+                        return result;
+                    }
+                };
+                let (batch_get_futures, failures) =
+                    batch_get::prepare_requests(req, &shard_manager);
 
-        // Send the request to all of the shards in parallel.  This will block until the initial
-        // backend calls return either a stream or an error.  A remote error will be demuxed into
-        // per-key errors, see shard::Client::batch_get()
-        let batch_get_stream = if batch_get_futures.is_empty() {
-            None
-        } else {
-            Some(
-                futures::stream::iter(batch_get_futures)
-                    .buffer_unordered(self.config.max_parallel_requests())
-                    .flatten_unordered(None)
-                    .boxed(),
-            )
-        };
+                let batch_get_stream = if batch_get_futures.is_empty() {
+                    None
+                } else {
+                    Some(
+                        futures::stream::iter(batch_get_futures)
+                            .buffer_unordered(self.config.max_parallel_requests())
+                            .flatten_unordered(None)
+                            .boxed(),
+                    )
+                };
 
-        let failures_stream = if failures.is_empty() {
-            None
-        } else {
-            Some(futures::stream::iter(failures))
-        };
+                let failures_stream = if failures.is_empty() {
+                    None
+                } else {
+                    Some(futures::stream::iter(failures))
+                };
 
-        // Finally, return a stream that will collect results from each shard as they become
-        // available.  Per-shard ordering is defined by the Oxia server (as of this writing,
-        // they should be in the same order).  The ordering of responses between shards and the early failures
-        // already collected is unspecified.
-        //
-        // All of this syntatic mess lets us return precisely the stream we need without boxing it.
-        // The only overhead is reading it, which hopefully will be done just this once.
+                let final_stream = match (batch_get_stream, failures_stream) {
+                    (Some(b), None) => Left(b),
+                    (Some(b), Some(f)) => Right(Left(Left(futures::stream::select(b, f)))),
+                    (None, Some(f)) => Right(Left(Right(f))),
+                    (None, None) => Right(Right(futures::stream::empty())),
+                };
+                Ok((start, final_stream))
+            })
+        }?;
+        let final_stream = instrument_stream(final_stream, span);
 
-        let final_stream = match (batch_get_stream, failures_stream) {
-            // Requests, no early failures
-            (Some(b), None) => Left(b),
-
-            // Requests and early failures
-            (Some(b), Some(f)) => Right(Left(Left(futures::stream::select(b, f)))),
-
-            // All failures
-            (None, Some(f)) => Right(Left(Right(f))),
-
-            // Empty requests? Should be rare
-            (None, None) => Right(Right(futures::stream::empty())),
-        };
-
-        Ok(final_stream)
+        Ok(metrics::record_batch_get_stream(
+            self.metrics.clone(),
+            start,
+            final_stream,
+        ))
     }
 
     #[inline]
@@ -1102,22 +1178,50 @@ impl Client {
         self.put_internal(Arc::from(key.into()), value.into(), options)
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.put",
+        skip(self, key, value, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::Put.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn put_internal(
         &self,
         key: Arc<str>,
         value: Bytes,
         options: PutOptions,
     ) -> Result<PutResponse> {
-        let selector = options.partition_key.as_deref().unwrap_or(&key);
-        let shard = self.get_shard(selector)?;
-        execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-            let shard = shard.clone();
-            let key = Arc::clone(&key);
-            let value = value.clone();
-            let options = options.clone();
-            async move { shard.put(&key, value, &options).await }
-        })
-        .await
+        let value_size = value.len() as u64;
+        let start = metrics::operation_start();
+        let result = async {
+            let selector = options.partition_key.as_deref().unwrap_or(&key);
+            let shard = self.get_shard(selector)?;
+            tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                let shard = shard.clone();
+                let key = Arc::clone(&key);
+                let value = value.clone();
+                let options = options.clone();
+                async move { shard.put(&key, value, &options).await }
+            })
+            .await
+        }
+        .await;
+        metrics::record_operation_result_with_size(
+            &self.metrics,
+            metrics::Operation::Put,
+            metrics::result_kind,
+            |_| value_size,
+            start,
+            &result,
+        );
+        result
     }
 
     #[inline]
@@ -1134,16 +1238,42 @@ impl Client {
         self.delete_internal(Arc::from(key.into()), options)
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.delete",
+        skip(self, key, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::Delete.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn delete_internal(&self, key: Arc<str>, options: DeleteOptions) -> Result<()> {
-        let selector = options.partition_key.as_deref().unwrap_or(&key);
-        let shard = self.get_shard(selector)?;
-        execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-            let shard = shard.clone();
-            let key = Arc::clone(&key);
-            let options = options.clone();
-            async move { shard.delete(&key, &options).await }
-        })
-        .await
+        let start = metrics::operation_start();
+        let result = async {
+            let selector = options.partition_key.as_deref().unwrap_or(&key);
+            let shard = self.get_shard(selector)?;
+            tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                let shard = shard.clone();
+                let key = Arc::clone(&key);
+                let options = options.clone();
+                async move { shard.delete(&key, &options).await }
+            })
+            .await
+        }
+        .await;
+        metrics::record_operation_result(
+            &self.metrics,
+            metrics::Operation::Delete,
+            metrics::result_kind,
+            start,
+            &result,
+        );
+        result
     }
 
     #[inline]
@@ -1173,69 +1303,95 @@ impl Client {
         )
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.delete_range",
+        skip(self, start_inclusive, end_exclusive, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::DeleteRange.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn delete_range_internal(
         &self,
         start_inclusive: Arc<str>,
         end_exclusive: Arc<str>,
         options: DeleteRangeOptions,
     ) -> Result<()> {
-        let do_delete_range = |shard: shard::Client,
-                               start: Arc<str>,
-                               end: Arc<str>,
-                               options: DeleteRangeOptions| async move {
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
-                let start = Arc::clone(&start);
-                let end = Arc::clone(&end);
-                let options = options.clone();
-                async move { shard.delete_range(&start, &end, &options).await }
-            })
-            .await
-        };
-
-        if let Some(shard) = {
-            if let Some(pk) = options.partition_key.as_deref() {
-                Some(self.get_shard(pk)?)
-            } else if let Some(id) = options.shard {
-                Some(self.get_shard_by_id(id.into())?)
-            } else {
-                None
-            }
-        } {
-            return do_delete_range(shard, start_inclusive, end_exclusive, options).await;
-        }
-
-        let n = match self.config.max_parallel_requests() {
-            0 => usize::MAX,
-            n => n,
-        };
-
-        let mut result_stream =
-            futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
-                .map(|shard| {
-                    do_delete_range(
-                        shard,
-                        Arc::clone(&start_inclusive),
-                        Arc::clone(&end_exclusive),
-                        options.clone(),
-                    )
+        let start = metrics::operation_start();
+        let result = async {
+            let do_delete_range = |shard: shard::Client,
+                                   start: Arc<str>,
+                                   end: Arc<str>,
+                                   options: DeleteRangeOptions| async move {
+                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                    let shard = shard.clone();
+                    let start = Arc::clone(&start);
+                    let end = Arc::clone(&end);
+                    let options = options.clone();
+                    async move { shard.delete_range(&start, &end, &options).await }
                 })
-                .buffer_unordered(n);
+                .await
+            };
 
-        let mut errs = Vec::new();
-        while let Some(shard_result) = result_stream.next().await {
-            match shard_result {
-                Err(Error::ShardError(e)) => errs.push(e),
-                Err(_) => return shard_result,
-                Ok(()) => (),
+            if let Some(shard) = {
+                if let Some(pk) = options.partition_key.as_deref() {
+                    Some(self.get_shard(pk)?)
+                } else if let Some(id) = options.shard {
+                    Some(self.get_shard_by_id(id.into())?)
+                } else {
+                    None
+                }
+            } {
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                return do_delete_range(shard, start_inclusive, end_exclusive, options).await;
             }
-        }
 
-        if !errs.is_empty() {
-            return Err(Error::MultipleShardError(errs.into()));
-        }
+            let n = match self.config.max_parallel_requests() {
+                0 => usize::MAX,
+                n => n,
+            };
 
-        Ok(())
+            let mut result_stream =
+                futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
+                    .map(|shard| {
+                        do_delete_range(
+                            shard,
+                            Arc::clone(&start_inclusive),
+                            Arc::clone(&end_exclusive),
+                            options.clone(),
+                        )
+                    })
+                    .buffer_unordered(n);
+
+            let mut errs = Vec::new();
+            while let Some(shard_result) = result_stream.next().await {
+                match shard_result {
+                    Err(Error::ShardError(e)) => errs.push(e),
+                    Err(_) => return shard_result,
+                    Ok(()) => (),
+                }
+            }
+
+            if !errs.is_empty() {
+                return Err(Error::MultipleShardError(errs.into()));
+            }
+
+            Ok(())
+        }
+        .await;
+        metrics::record_operation_result(
+            &self.metrics,
+            metrics::Operation::DeleteRange,
+            metrics::result_kind,
+            start,
+            &result,
+        );
+        result
     }
 
     #[inline]
@@ -1261,64 +1417,90 @@ impl Client {
         )
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.list",
+        skip(self, start_inclusive, end_exclusive, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::List.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn list_internal(
         &self,
         start_inclusive: Arc<str>,
         end_exclusive: Arc<str>,
         options: ListOptions,
     ) -> Result<ListResponse> {
-        let do_list = |shard: shard::Client,
-                       start: Arc<str>,
-                       end: Arc<str>,
-                       options: ListOptions| async move {
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
-                let start = Arc::clone(&start);
-                let end = Arc::clone(&end);
-                let options = options.clone();
-                async move { shard.list(&start, &end, &options).await }
-            })
-            .await
-        };
-
-        if let Some(pk) = options.partition_key.as_deref() {
-            let shard = self.get_shard(pk)?;
-            return do_list(shard, start_inclusive, end_exclusive, options).await;
-        }
-
-        let n = match self.config.max_parallel_requests() {
-            0 => usize::MAX,
-            n => n,
-        };
-
-        let mut result_stream =
-            futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
-                .map(|shard| {
-                    do_list(
-                        shard,
-                        Arc::clone(&start_inclusive),
-                        Arc::clone(&end_exclusive),
-                        options.clone(),
-                    )
+        let start = metrics::operation_start();
+        let result = async {
+            let do_list = |shard: shard::Client,
+                           start: Arc<str>,
+                           end: Arc<str>,
+                           options: ListOptions| async move {
+                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                    let shard = shard.clone();
+                    let start = Arc::clone(&start);
+                    let end = Arc::clone(&end);
+                    let options = options.clone();
+                    async move { shard.list(&start, &end, &options).await }
                 })
-                .buffer_unordered(n);
+                .await
+            };
 
-        let mut response = ListResponse::default();
-        while let Some(shard_result) = result_stream.next().await {
-            if let Ok(shard_response) = shard_result {
-                response.merge(shard_response);
-            } else if options.partial_ok {
-                response.partial = true;
-            } else {
-                return shard_result;
+            if let Some(pk) = options.partition_key.as_deref() {
+                let shard = self.get_shard(pk)?;
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                return do_list(shard, start_inclusive, end_exclusive, options).await;
             }
-        }
 
-        if options.sort {
-            response.sort();
-        }
+            let n = match self.config.max_parallel_requests() {
+                0 => usize::MAX,
+                n => n,
+            };
 
-        Ok(response)
+            let mut result_stream =
+                futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
+                    .map(|shard| {
+                        do_list(
+                            shard,
+                            Arc::clone(&start_inclusive),
+                            Arc::clone(&end_exclusive),
+                            options.clone(),
+                        )
+                    })
+                    .buffer_unordered(n);
+
+            let mut response = ListResponse::default();
+            while let Some(shard_result) = result_stream.next().await {
+                if let Ok(shard_response) = shard_result {
+                    response.merge(shard_response);
+                } else if options.partial_ok {
+                    response.partial = true;
+                } else {
+                    return shard_result;
+                }
+            }
+
+            if options.sort {
+                response.sort();
+            }
+
+            Ok(response)
+        }
+        .await;
+        metrics::record_operation_result(
+            &self.metrics,
+            metrics::Operation::List,
+            metrics::result_kind,
+            start,
+            &result,
+        );
+        result
     }
 
     #[inline]
@@ -1344,64 +1526,91 @@ impl Client {
         )
     }
 
+    #[allow(clippy::large_futures)]
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.range_scan",
+        skip(self, start_inclusive, end_exclusive, options),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::RangeScan.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
     async fn range_scan_internal(
         &self,
         start_inclusive: Arc<str>,
         end_exclusive: Arc<str>,
         options: RangeScanOptions,
     ) -> Result<RangeScanResponse> {
-        let do_range_scan = |shard: shard::Client,
-                             start: Arc<str>,
-                             end: Arc<str>,
-                             options: RangeScanOptions| async move {
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
-                let start = Arc::clone(&start);
-                let end = Arc::clone(&end);
-                let options = options.clone();
-                async move { shard.range_scan(&start, &end, &options).await }
-            })
-            .await
-        };
-
-        if let Some(pk) = options.partition_key.as_deref() {
-            let shard = self.get_shard(pk)?;
-            return do_range_scan(shard, start_inclusive, end_exclusive, options).await;
-        }
-
-        let n = match self.config.max_parallel_requests() {
-            0 => usize::MAX,
-            n => n,
-        };
-
-        let mut result_stream =
-            futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
-                .map(|shard| {
-                    do_range_scan(
-                        shard,
-                        Arc::clone(&start_inclusive),
-                        Arc::clone(&end_exclusive),
-                        options.clone(),
-                    )
+        let start = metrics::operation_start();
+        let result = async {
+            let do_range_scan = |shard: shard::Client,
+                                 start: Arc<str>,
+                                 end: Arc<str>,
+                                 options: RangeScanOptions| async move {
+                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
+                    let shard = shard.clone();
+                    let start = Arc::clone(&start);
+                    let end = Arc::clone(&end);
+                    let options = options.clone();
+                    async move { shard.range_scan(&start, &end, &options).await }
                 })
-                .buffer_unordered(n);
+                .await
+            };
 
-        let mut response = RangeScanResponse::default();
-        while let Some(shard_result) = result_stream.next().await {
-            if let Ok(shard_response) = shard_result {
-                response.merge(shard_response);
-            } else if options.partial_ok {
-                response.partial = true;
-            } else {
-                return shard_result;
+            if let Some(pk) = options.partition_key.as_deref() {
+                let shard = self.get_shard(pk)?;
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                return do_range_scan(shard, start_inclusive, end_exclusive, options).await;
             }
-        }
 
-        if options.sort {
-            response.sort();
-        }
+            let n = match self.config.max_parallel_requests() {
+                0 => usize::MAX,
+                n => n,
+            };
 
-        Ok(response)
+            let mut result_stream =
+                futures::stream::iter(self.get_shard_manager()?.get_shard_clients())
+                    .map(|shard| {
+                        do_range_scan(
+                            shard,
+                            Arc::clone(&start_inclusive),
+                            Arc::clone(&end_exclusive),
+                            options.clone(),
+                        )
+                    })
+                    .buffer_unordered(n);
+
+            let mut response = RangeScanResponse::default();
+            while let Some(shard_result) = result_stream.next().await {
+                if let Ok(shard_response) = shard_result {
+                    response.merge(shard_response);
+                } else if options.partial_ok {
+                    response.partial = true;
+                } else {
+                    return shard_result;
+                }
+            }
+
+            if options.sort {
+                response.sort();
+            }
+
+            Ok(response)
+        }
+        .await;
+        metrics::record_operation_result_with_size(
+            &self.metrics,
+            metrics::Operation::RangeScan,
+            metrics::result_kind,
+            metrics::range_scan_response_size,
+            start,
+            &result,
+        );
+        result
     }
 
     /// Create a notifications stream with default options.

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -1,0 +1,862 @@
+// Copyright 2025-2026 Maurice S. Barnum
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::redundant_pub_crate)]
+
+#[cfg(feature = "metrics")]
+use std::time::Instant;
+
+use crate::Error;
+use crate::GetResponse;
+use crate::RangeScanResponse;
+use crate::errors::OxiaError;
+
+pub(crate) const SCOPE_NAME: &str = "mauricebarnum_oxia_client";
+pub(crate) const DB_SYSTEM: &str = "oxia";
+
+#[cfg(feature = "metrics")]
+pub(crate) type BatchStart = Instant;
+#[cfg(not(feature = "metrics"))]
+#[derive(Clone, Copy)]
+pub(crate) struct BatchStart;
+#[cfg(feature = "metrics")]
+pub(crate) type BatchExecDuration = std::time::Duration;
+#[cfg(not(feature = "metrics"))]
+#[derive(Copy, Clone)]
+pub(crate) struct BatchExecDuration;
+#[cfg(feature = "metrics")]
+pub(crate) type OperationStart = Instant;
+#[cfg(not(feature = "metrics"))]
+#[derive(Copy, Clone)]
+pub(crate) struct OperationStart;
+
+#[cfg(all(test, feature = "metrics"))]
+pub(crate) const HISTOGRAM_NAMES: &[&str] = &[
+    names::OP_DURATION,
+    names::OP_SIZE,
+    names::BATCH_TOTAL,
+    names::BATCH_EXEC,
+    names::BATCH_SIZE,
+    names::BATCH_REQUEST_COUNT,
+];
+
+#[cfg(feature = "metrics")]
+pub(crate) mod names {
+    pub(crate) const OP_DURATION: &str = "db.client.operation.duration";
+    pub(crate) const OP_SIZE: &str = "db.client.operation.size";
+    pub(crate) const BATCH_TOTAL: &str = "db.client.batch.duration";
+    pub(crate) const BATCH_EXEC: &str = "db.client.batch.exec_duration";
+    pub(crate) const BATCH_SIZE: &str = "db.client.batch.size";
+    pub(crate) const BATCH_REQUEST_COUNT: &str = "db.client.batch.request_count";
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Operation {
+    Get,
+    Put,
+    Delete,
+    DeleteRange,
+    List,
+    RangeScan,
+    BatchGet,
+}
+
+impl Operation {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Get => "get",
+            Self::Put => "put",
+            Self::Delete => "delete",
+            Self::DeleteRange => "delete_range",
+            Self::List => "list",
+            Self::RangeScan => "range_scan",
+            Self::BatchGet => "batch_get",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResultKind {
+    Success,
+    Failure,
+}
+
+impl ResultKind {
+    #[cfg(feature = "metrics")]
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failure => "failure",
+        }
+    }
+}
+
+pub(crate) const fn result_kind<T>(result: &crate::Result<T>) -> ResultKind {
+    match result {
+        Ok(_) => ResultKind::Success,
+        Err(_) => ResultKind::Failure,
+    }
+}
+
+pub(crate) const fn get_result_kind(result: &crate::Result<Option<GetResponse>>) -> ResultKind {
+    match result {
+        Ok(_) | Err(Error::Oxia(OxiaError::KeyNotFound)) => ResultKind::Success,
+        Err(_) => ResultKind::Failure,
+    }
+}
+
+pub(crate) fn get_response_size(result: &crate::Result<Option<GetResponse>>) -> u64 {
+    result
+        .as_ref()
+        .ok()
+        .and_then(Option::as_ref)
+        .and_then(|response| response.value.as_ref())
+        .map_or(0, |value| value.len() as u64)
+}
+
+pub(crate) fn range_scan_response_size(result: &crate::Result<RangeScanResponse>) -> u64 {
+    result.as_ref().map_or(0, |response| {
+        response
+            .records
+            .iter()
+            .map(|record| record.value.as_ref().map_or(0, bytes::Bytes::len) as u64)
+            .sum()
+    })
+}
+
+pub(crate) fn record_error_type<T>(result: &crate::Result<T>) {
+    if let Err(error) = result {
+        tracing::Span::current().record("error.type", error.to_string());
+    }
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn operation_start() -> OperationStart {
+    Instant::now()
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) const fn operation_start() -> OperationStart {
+    OperationStart
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn record_operation_result<T, C>(
+    metrics: &Metrics,
+    operation: Operation,
+    classify: C,
+    start: OperationStart,
+    result: &crate::Result<T>,
+) where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+{
+    metrics.record_operation(operation, classify(result), start.elapsed());
+    record_error_type(result);
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) fn record_operation_result<T, C>(
+    _metrics: &Metrics,
+    _operation: Operation,
+    _classify: C,
+    _start: OperationStart,
+    result: &crate::Result<T>,
+) where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+{
+    record_error_type(result);
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn record_operation_result_with_size<T, C, S>(
+    metrics: &Metrics,
+    operation: Operation,
+    classify: C,
+    size: S,
+    start: OperationStart,
+    result: &crate::Result<T>,
+) where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+    S: FnOnce(&crate::Result<T>) -> u64,
+{
+    let result_kind = classify(result);
+    metrics.record_operation(operation, result_kind, start.elapsed());
+    metrics.record_operation_size(operation, result_kind, size(result));
+    record_error_type(result);
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn record_batch_get_stream<S>(
+    metrics: Metrics,
+    start: OperationStart,
+    stream: S,
+) -> impl futures::Stream<Item = crate::batch_get::ResponseItem>
+where
+    S: futures::Stream<Item = crate::batch_get::ResponseItem>,
+{
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
+    use futures::StreamExt as _;
+
+    struct Completion {
+        failed: Arc<AtomicBool>,
+        metrics: Metrics,
+        recorded: bool,
+        start: OperationStart,
+    }
+
+    impl Completion {
+        fn record(&mut self, completed: bool) {
+            if self.recorded {
+                return;
+            }
+
+            let result = if completed && !self.failed.load(Ordering::Relaxed) {
+                ResultKind::Success
+            } else {
+                ResultKind::Failure
+            };
+            self.metrics
+                .record_operation(Operation::BatchGet, result, self.start.elapsed());
+            self.recorded = true;
+        }
+    }
+
+    impl Drop for Completion {
+        fn drop(&mut self) {
+            self.record(false);
+        }
+    }
+
+    let failed = Arc::new(AtomicBool::new(false));
+    let observed_failed = Arc::clone(&failed);
+    let mut completion = Completion {
+        failed,
+        metrics,
+        recorded: false,
+        start,
+    };
+    stream
+        .inspect(move |item| {
+            if item.response.is_err() {
+                observed_failed.store(true, Ordering::Relaxed);
+            }
+        })
+        .map(Some)
+        .chain(futures::stream::once(futures::future::lazy(move |_| {
+            completion.record(true);
+            None
+        })))
+        .filter_map(futures::future::ready)
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) const fn record_batch_get_stream<S>(_: Metrics, _: OperationStart, stream: S) -> S {
+    stream
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) fn record_operation_result_with_size<T, C, S>(
+    _metrics: &Metrics,
+    _operation: Operation,
+    _classify: C,
+    _size: S,
+    _start: OperationStart,
+    result: &crate::Result<T>,
+) where
+    C: FnOnce(&crate::Result<T>) -> ResultKind,
+    S: FnOnce(&crate::Result<T>) -> u64,
+{
+    record_error_type(result);
+}
+
+#[cfg(feature = "metrics")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_batch(
+    metrics: &Metrics,
+    operation: Operation,
+    result: ResultKind,
+    total_start: BatchStart,
+    exec_duration: BatchExecDuration,
+    value_size: u64,
+    request_count: u64,
+) {
+    metrics.record_batch(
+        operation,
+        result,
+        total_start.elapsed(),
+        exec_duration,
+        value_size,
+        request_count,
+    );
+}
+
+#[cfg(not(feature = "metrics"))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) const fn record_batch(
+    _metrics: &Metrics,
+    _operation: Operation,
+    _result: ResultKind,
+    _total_start: BatchStart,
+    _exec_duration: BatchExecDuration,
+    _value_size: u64,
+    _request_count: u64,
+) {
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn batch_start() -> Instant {
+    Instant::now()
+}
+
+#[cfg(feature = "metrics")]
+pub(crate) fn batch_exec_duration(start: Instant) -> std::time::Duration {
+    start.elapsed()
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) const fn batch_start() -> BatchStart {
+    BatchStart
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) const fn batch_exec_duration(_: BatchStart) -> BatchExecDuration {
+    BatchExecDuration
+}
+
+#[cfg(feature = "metrics")]
+mod imp {
+    use opentelemetry::KeyValue;
+    use opentelemetry::global;
+    #[cfg(feature = "go-metrics-compat")]
+    use opentelemetry::metrics::Counter;
+    use opentelemetry::metrics::Histogram;
+
+    use super::DB_SYSTEM;
+    use super::Operation;
+    use super::ResultKind;
+    use super::SCOPE_NAME;
+    use super::names;
+
+    #[cfg(feature = "go-metrics-compat")]
+    mod compat_names {
+        pub(super) const OP_DURATION_SUM: &str = "oxia_client_op_sum";
+        pub(super) const OP_DURATION_COUNT: &str = "oxia_client_op_count";
+        pub(super) const BATCH_TOTAL_SUM: &str = "oxia_client_batch_total_sum";
+        pub(super) const BATCH_TOTAL_COUNT: &str = "oxia_client_batch_total_count";
+        pub(super) const BATCH_EXEC_SUM: &str = "oxia_client_batch_exec_sum";
+        pub(super) const BATCH_EXEC_COUNT: &str = "oxia_client_batch_exec_count";
+    }
+
+    pub(crate) type MeterProviderHandle = crate::config::MeterProviderHandle;
+
+    #[derive(Clone)]
+    pub(crate) struct Metrics {
+        namespace: KeyValue,
+        op_duration: Histogram<f64>,
+        #[cfg(feature = "go-metrics-compat")]
+        compat_op_duration: Timer,
+        op_size: Histogram<u64>,
+        batch_total_duration: Histogram<f64>,
+        #[cfg(feature = "go-metrics-compat")]
+        compat_batch_total_duration: Timer,
+        batch_exec_duration: Histogram<f64>,
+        #[cfg(feature = "go-metrics-compat")]
+        compat_batch_exec_duration: Timer,
+        batch_size: Histogram<u64>,
+        batch_request_count: Histogram<u64>,
+    }
+
+    impl std::fmt::Debug for Metrics {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("Metrics").finish_non_exhaustive()
+        }
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    #[derive(Clone, Debug)]
+    struct Timer {
+        sum: Counter<f64>,
+        count: Counter<u64>,
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    impl Timer {
+        fn new(
+            meter: &opentelemetry::metrics::Meter,
+            sum: &'static str,
+            count: &'static str,
+        ) -> Self {
+            Self {
+                sum: meter.f64_counter(sum).with_unit("ms").build(),
+                count: meter.u64_counter(count).with_unit("1").build(),
+            }
+        }
+
+        fn record(&self, duration: std::time::Duration, attrs: &[KeyValue]) {
+            self.sum.add(duration.as_secs_f64() * 1_000.0, attrs);
+            self.count.add(1, attrs);
+        }
+    }
+
+    impl Metrics {
+        pub(crate) fn new(provider: Option<&MeterProviderHandle>, namespace: &str) -> Self {
+            let provider = provider.cloned().unwrap_or_else(global::meter_provider);
+            let meter = provider.meter(SCOPE_NAME);
+
+            Self {
+                namespace: KeyValue::new("db.name", std::sync::Arc::<str>::from(namespace)),
+                op_duration: meter
+                    .f64_histogram(names::OP_DURATION)
+                    .with_unit("s")
+                    .build(),
+                #[cfg(feature = "go-metrics-compat")]
+                compat_op_duration: Timer::new(
+                    &meter,
+                    compat_names::OP_DURATION_SUM,
+                    compat_names::OP_DURATION_COUNT,
+                ),
+                op_size: meter.u64_histogram(names::OP_SIZE).with_unit("By").build(),
+                batch_total_duration: meter
+                    .f64_histogram(names::BATCH_TOTAL)
+                    .with_unit("s")
+                    .build(),
+                #[cfg(feature = "go-metrics-compat")]
+                compat_batch_total_duration: Timer::new(
+                    &meter,
+                    compat_names::BATCH_TOTAL_SUM,
+                    compat_names::BATCH_TOTAL_COUNT,
+                ),
+                batch_exec_duration: meter
+                    .f64_histogram(names::BATCH_EXEC)
+                    .with_unit("s")
+                    .build(),
+                #[cfg(feature = "go-metrics-compat")]
+                compat_batch_exec_duration: Timer::new(
+                    &meter,
+                    compat_names::BATCH_EXEC_SUM,
+                    compat_names::BATCH_EXEC_COUNT,
+                ),
+                batch_size: meter
+                    .u64_histogram(names::BATCH_SIZE)
+                    .with_unit("By")
+                    .build(),
+                batch_request_count: meter
+                    .u64_histogram(names::BATCH_REQUEST_COUNT)
+                    .with_unit("1")
+                    .build(),
+            }
+        }
+
+        pub(crate) fn record_operation(
+            &self,
+            operation: Operation,
+            result: ResultKind,
+            duration: std::time::Duration,
+        ) {
+            let attrs = self.attrs(operation, result);
+            record_timer(&self.op_duration, duration, &attrs);
+            #[cfg(feature = "go-metrics-compat")]
+            self.compat_op_duration.record(duration, &attrs);
+        }
+
+        pub(crate) fn record_operation_size(
+            &self,
+            operation: Operation,
+            result: ResultKind,
+            size: u64,
+        ) {
+            self.op_size.record(size, &self.attrs(operation, result));
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        pub(crate) fn record_batch(
+            &self,
+            operation: Operation,
+            result: ResultKind,
+            total_duration: std::time::Duration,
+            exec_duration: std::time::Duration,
+            value_size: u64,
+            request_count: u64,
+        ) {
+            let attrs = self.attrs(operation, result);
+            record_timer(&self.batch_total_duration, total_duration, &attrs);
+            record_timer(&self.batch_exec_duration, exec_duration, &attrs);
+            #[cfg(feature = "go-metrics-compat")]
+            {
+                self.compat_batch_total_duration
+                    .record(total_duration, &attrs);
+                self.compat_batch_exec_duration
+                    .record(exec_duration, &attrs);
+            }
+            self.batch_size.record(value_size, &attrs);
+            self.batch_request_count.record(request_count, &attrs);
+        }
+
+        fn attrs(&self, operation: Operation, result: ResultKind) -> [KeyValue; 4] {
+            [
+                KeyValue::new("db.system", DB_SYSTEM),
+                self.namespace.clone(),
+                KeyValue::new("db.operation", operation.as_str()),
+                KeyValue::new("result", result.as_str()),
+            ]
+        }
+    }
+
+    fn record_timer(timer: &Histogram<f64>, duration: std::time::Duration, attrs: &[KeyValue]) {
+        timer.record(duration.as_secs_f64(), attrs);
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+mod imp {
+    pub(crate) type MeterProviderHandle = ();
+
+    #[derive(Clone, Debug)]
+    pub(crate) struct Metrics;
+
+    impl Metrics {
+        pub(crate) const fn new(_provider: Option<&MeterProviderHandle>, _namespace: &str) -> Self {
+            Self
+        }
+    }
+}
+
+pub(crate) use imp::Metrics;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_not_found_get_is_success_for_metrics() {
+        let result = Err(Error::Oxia(OxiaError::KeyNotFound));
+        assert_eq!(get_result_kind(&result), ResultKind::Success);
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod sdk_tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use opentelemetry_sdk::metrics::Aggregation;
+    use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+    use opentelemetry_sdk::metrics::InMemoryMetricExporterBuilder;
+    use opentelemetry_sdk::metrics::Instrument;
+    use opentelemetry_sdk::metrics::InstrumentKind;
+    use opentelemetry_sdk::metrics::PeriodicReader;
+    use opentelemetry_sdk::metrics::SdkMeterProvider;
+    use opentelemetry_sdk::metrics::Stream;
+    use opentelemetry_sdk::metrics::Temporality;
+    use opentelemetry_sdk::metrics::data;
+    use opentelemetry_sdk::metrics::data::ResourceMetrics;
+
+    use super::*;
+
+    const EXPONENTIAL_HISTOGRAM_MAX_SIZE: u32 = 160;
+    const EXPONENTIAL_HISTOGRAM_MAX_SCALE: i8 = 20;
+
+    #[test]
+    fn semantic_metrics_use_exponential_histograms() {
+        let (exporter, provider, metrics) = setup_metrics();
+
+        metrics.record_operation(
+            Operation::Get,
+            ResultKind::Success,
+            Duration::from_millis(250),
+        );
+        metrics.record_operation_size(Operation::Get, ResultKind::Success, 42);
+        metrics.record_batch(
+            Operation::Put,
+            ResultKind::Success,
+            Duration::from_secs(2),
+            Duration::from_millis(500),
+            128,
+            3,
+        );
+        metrics.record_operation_size(Operation::Get, ResultKind::Success, 0);
+
+        let rm = collect(&provider, &exporter);
+
+        assert_exponential_f64(&rm, names::OP_DURATION, "s", 1, 0.25, true);
+        assert_exponential_u64(&rm, names::OP_SIZE, "By", 2, 42, true, true);
+        assert_exponential_f64(&rm, names::BATCH_TOTAL, "s", 1, 2.0, true);
+        assert_exponential_f64(&rm, names::BATCH_EXEC, "s", 1, 0.5, true);
+        assert_exponential_u64(&rm, names::BATCH_SIZE, "By", 1, 128, true, false);
+        assert_exponential_u64(&rm, names::BATCH_REQUEST_COUNT, "1", 1, 3, true, false);
+    }
+
+    #[tokio::test]
+    async fn batch_get_operation_records_stream_failure_on_completion() {
+        use futures::StreamExt as _;
+
+        let (exporter, provider, metrics) = setup_metrics();
+        let stream = record_batch_get_stream(
+            metrics,
+            operation_start(),
+            futures::stream::iter([crate::batch_get::ResponseItem::failed(
+                "key",
+                Error::Cancelled,
+            )]),
+        );
+
+        assert_eq!(stream.collect::<Vec<_>>().await.len(), 1);
+        let rm = collect(&provider, &exporter);
+        let histogram = exponential_f64(&rm, names::OP_DURATION, "s");
+        let result = histogram
+            .data_points()
+            .next()
+            .expect("histogram data point")
+            .attributes()
+            .find(|attribute| attribute.key.as_str() == "result");
+        assert_eq!(
+            result.map(|attribute| attribute.value.to_string()),
+            Some("failure".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_get_operation_records_failure_when_stream_is_dropped() {
+        let (exporter, provider, metrics) = setup_metrics();
+        let stream = record_batch_get_stream(
+            metrics,
+            operation_start(),
+            futures::stream::iter([crate::batch_get::ResponseItem::failed(
+                "key",
+                Error::Cancelled,
+            )]),
+        );
+
+        drop(stream);
+        let rm = collect(&provider, &exporter);
+        let histogram = exponential_f64(&rm, names::OP_DURATION, "s");
+        let result = histogram
+            .data_points()
+            .next()
+            .expect("histogram data point")
+            .attributes()
+            .find(|attribute| attribute.key.as_str() == "result");
+        assert_eq!(
+            result.map(|attribute| attribute.value.to_string()),
+            Some("failure".to_owned())
+        );
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    #[test]
+    fn go_metrics_compat_adds_only_latency_sum_count_metrics() {
+        let (exporter, provider, metrics) = setup_metrics();
+
+        metrics.record_operation(
+            Operation::Get,
+            ResultKind::Success,
+            Duration::from_millis(250),
+        );
+        metrics.record_operation_size(Operation::Get, ResultKind::Success, 42);
+        metrics.record_batch(
+            Operation::Put,
+            ResultKind::Success,
+            Duration::from_secs(2),
+            Duration::from_millis(500),
+            128,
+            3,
+        );
+
+        let rm = collect(&provider, &exporter);
+
+        assert_exponential_f64(&rm, names::OP_DURATION, "s", 1, 0.25, true);
+        assert_sum_f64(&rm, "oxia_client_op_sum", "ms", 250.0);
+        assert_sum_u64(&rm, "oxia_client_op_count", "1", 1);
+        assert_sum_f64(&rm, "oxia_client_batch_total_sum", "ms", 2_000.0);
+        assert_sum_u64(&rm, "oxia_client_batch_total_count", "1", 1);
+        assert_sum_f64(&rm, "oxia_client_batch_exec_sum", "ms", 500.0);
+        assert_sum_u64(&rm, "oxia_client_batch_exec_count", "1", 1);
+        assert_metric_absent(&rm, "oxia_client_op_value");
+        assert_metric_absent(&rm, "oxia_client_batch_value");
+        assert_metric_absent(&rm, "oxia_client_batch_request");
+    }
+
+    fn setup_metrics() -> (InMemoryMetricExporter, SdkMeterProvider, Metrics) {
+        let exporter = InMemoryMetricExporterBuilder::new()
+            .with_temporality(Temporality::Cumulative)
+            .build();
+        let reader = PeriodicReader::builder(exporter.clone()).build();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_view(exponential_histogram_view)
+            .build();
+        let provider_handle: crate::config::MeterProviderHandle = Arc::new(provider.clone());
+        let metrics = Metrics::new(Some(&provider_handle), "default");
+        (exporter, provider, metrics)
+    }
+
+    fn exponential_histogram_view(instrument: &Instrument) -> Option<Stream> {
+        (instrument.kind() == InstrumentKind::Histogram
+            && HISTOGRAM_NAMES.contains(&instrument.name()))
+        .then(|| {
+            Stream::builder()
+                .with_aggregation(Aggregation::Base2ExponentialHistogram {
+                    max_size: EXPONENTIAL_HISTOGRAM_MAX_SIZE,
+                    max_scale: EXPONENTIAL_HISTOGRAM_MAX_SCALE,
+                    record_min_max: false,
+                })
+                .build()
+                .expect("valid exponential histogram view")
+        })
+    }
+
+    fn collect(provider: &SdkMeterProvider, exporter: &InMemoryMetricExporter) -> ResourceMetrics {
+        provider.force_flush().expect("metrics collection succeeds");
+        exporter
+            .get_finished_metrics()
+            .expect("metrics export succeeds")
+            .pop()
+            .expect("metrics were exported")
+    }
+
+    fn assert_exponential_f64(
+        rm: &ResourceMetrics,
+        name: &str,
+        unit: &str,
+        count: usize,
+        sum: f64,
+        has_positive_bucket: bool,
+    ) {
+        let histogram = exponential_f64(rm, name, unit);
+        assert_eq!(Temporality::Cumulative, histogram.temporality());
+        let mut points = histogram.data_points();
+        let point = points.next().expect("histogram data point");
+        assert!(points.next().is_none());
+        assert_eq!(count, point.count());
+        assert!((point.sum() - sum).abs() < f64::EPSILON);
+        assert_eq!(None, point.min());
+        assert_eq!(None, point.max());
+        assert_eq!(0, point.zero_count());
+        assert_eq!(
+            has_positive_bucket,
+            point.positive_bucket().counts().any(|count| count > 0)
+        );
+    }
+
+    fn assert_exponential_u64(
+        rm: &ResourceMetrics,
+        name: &str,
+        unit: &str,
+        count: usize,
+        sum: u64,
+        has_positive_bucket: bool,
+        has_zero: bool,
+    ) {
+        let histogram = exponential_u64(rm, name, unit);
+        assert_eq!(Temporality::Cumulative, histogram.temporality());
+        let mut points = histogram.data_points();
+        let point = points.next().expect("histogram data point");
+        assert!(points.next().is_none());
+        assert_eq!(count, point.count());
+        assert_eq!(sum, point.sum());
+        assert_eq!(None, point.min());
+        assert_eq!(None, point.max());
+        assert_eq!(u64::from(has_zero), point.zero_count());
+        assert_eq!(
+            has_positive_bucket,
+            point.positive_bucket().counts().any(|count| count > 0)
+        );
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn assert_sum_f64(rm: &ResourceMetrics, name: &str, unit: &str, value: f64) {
+        let sum = sum_f64(rm, name, unit);
+        let mut points = sum.data_points();
+        let point = points.next().expect("sum data point");
+        assert!(points.next().is_none());
+        assert!((point.value() - value).abs() < f64::EPSILON);
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn assert_sum_u64(rm: &ResourceMetrics, name: &str, unit: &str, value: u64) {
+        let sum = sum_u64(rm, name, unit);
+        let mut points = sum.data_points();
+        let point = points.next().expect("sum data point");
+        assert!(points.next().is_none());
+        assert_eq!(value, point.value());
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn assert_metric_absent(rm: &ResourceMetrics, name: &str) {
+        assert!(
+            find_metric(rm, name).is_none(),
+            "metric {name} should not be exported"
+        );
+    }
+
+    fn checked_metric<'a>(
+        rm: &'a ResourceMetrics,
+        name: &str,
+        unit: &str,
+    ) -> &'a opentelemetry_sdk::metrics::data::Metric {
+        let metric = find_metric(rm, name).unwrap_or_else(|| panic!("metric {name} is exported"));
+        assert_eq!(unit, metric.unit());
+        metric
+    }
+
+    fn find_metric<'a>(
+        rm: &'a ResourceMetrics,
+        name: &str,
+    ) -> Option<&'a opentelemetry_sdk::metrics::data::Metric> {
+        rm.scope_metrics()
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .find(|metric| metric.name() == name)
+    }
+
+    fn exponential_f64<'a>(
+        rm: &'a ResourceMetrics,
+        name: &str,
+        unit: &str,
+    ) -> &'a data::ExponentialHistogram<f64> {
+        match checked_metric(rm, name, unit).data() {
+            data::AggregatedMetrics::F64(data::MetricData::ExponentialHistogram(value)) => value,
+            _ => panic!("metric {name} has expected data type"),
+        }
+    }
+
+    fn exponential_u64<'a>(
+        rm: &'a ResourceMetrics,
+        name: &str,
+        unit: &str,
+    ) -> &'a data::ExponentialHistogram<u64> {
+        match checked_metric(rm, name, unit).data() {
+            data::AggregatedMetrics::U64(data::MetricData::ExponentialHistogram(value)) => value,
+            _ => panic!("metric {name} has expected data type"),
+        }
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn sum_f64<'a>(rm: &'a ResourceMetrics, name: &str, unit: &str) -> &'a data::Sum<f64> {
+        match checked_metric(rm, name, unit).data() {
+            data::AggregatedMetrics::F64(data::MetricData::Sum(value)) => value,
+            _ => panic!("metric {name} has expected data type"),
+        }
+    }
+
+    #[cfg(feature = "go-metrics-compat")]
+    fn sum_u64<'a>(rm: &'a ResourceMetrics, name: &str, unit: &str) -> &'a data::Sum<u64> {
+        match checked_metric(rm, name, unit).data() {
+            data::AggregatedMetrics::U64(data::MetricData::Sum(value)) => value,
+            _ => panic!("metric {name} has expected data type"),
+        }
+    }
+}

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -62,6 +62,7 @@ use crate::SecondaryIndex;
 use crate::batch_get;
 use crate::config;
 use crate::create_grpc_client;
+use crate::metrics;
 use crate::pool::ChannelPool;
 
 #[repr(transparent)]
@@ -128,6 +129,14 @@ fn get_response_as_result(r: oxia_proto::GetResponse) -> Result<Option<GetRespon
         Ok(Status::KeyNotFound) => Ok(None),
         _ => Err(OxiaError::from(r.status).into()),
     }
+}
+
+#[cfg(feature = "metrics")]
+fn get_response_is_success(r: &oxia_proto::GetResponse) -> bool {
+    matches!(
+        oxia_proto::Status::try_from(r.status),
+        Ok(oxia_proto::Status::Ok | oxia_proto::Status::KeyNotFound)
+    )
 }
 
 const DIRECT_ID_SLOTS: u64 = 20;
@@ -289,6 +298,7 @@ fn apply_leader_hint_to_directory(leaders: &LeaderDirectory, hint: &crate::Leade
 #[derive(Debug)]
 struct ClientData {
     config: Arc<config::Config>,
+    metrics: metrics::Metrics,
     channel_pool: ChannelPool,
     shard_id: ShardId,
     /// Shared reference to leader directory - enables dynamic leader lookup.
@@ -302,7 +312,7 @@ struct ClientData {
 }
 
 impl ClientData {
-    const fn new(
+    fn new(
         config: Arc<config::Config>,
         channel_pool: ChannelPool,
         shard_id: ShardId,
@@ -310,8 +320,10 @@ impl ClientData {
         meta: tonic::metadata::MetadataMap,
         cancel_token: CancellationToken,
     ) -> Self {
+        let metrics = metrics::Metrics::new(config.meter_provider(), config.namespace());
         Self {
             config,
+            metrics,
             channel_pool,
             shard_id,
             leaders,
@@ -457,6 +469,20 @@ fn check_delete_range_response(r: &oxia_proto::WriteResponse) -> Option<Error> {
         return Some(OxiaError::from(d.status).into());
     }
     None
+}
+
+fn check_write_operation_response(
+    response: &oxia_proto::WriteResponse,
+    operation: metrics::Operation,
+) -> Option<Error> {
+    match operation {
+        metrics::Operation::Put => check_put_response(response),
+        metrics::Operation::Delete => check_delete_response(response),
+        metrics::Operation::DeleteRange => check_delete_range_response(response),
+        _ => Some(Error::Custom(format!(
+            "invalid write metrics operation: {operation:?}"
+        ))),
+    }
 }
 
 #[inline]
@@ -740,13 +766,16 @@ impl Client {
     async fn process_write(
         &self,
         write_req: oxia_proto::WriteRequest,
+        metrics_op: metrics::Operation,
     ) -> Result<oxia_proto::WriteResponse> {
         let data = &self.data;
+        let total_start = metrics::batch_start();
 
         let write_req = oxia_proto::WriteRequest {
             shard: Some(data.shard_id.0),
             ..write_req
         };
+        let (value_size, request_count) = write_metrics(&write_req, metrics_op);
 
         // Create a channel for the write stream with a buffer of 1 (only sending one request)
         let (tx, rx) = tokio::sync::mpsc::channel(1);
@@ -763,33 +792,53 @@ impl Client {
         let req = self.create_request(write_stream);
 
         // Get response stream with better error handling
-        let mut resp_stream = self
+        let exec_start = metrics::batch_start();
+        let rpc_result = self
             .rpc(|mut grpc| async move { grpc.write_stream(req).await })
-            .await?
-            .into_inner();
+            .await;
+        let (result, exec_duration) = match rpc_result {
+            Err(err) => (Err(err), metrics::batch_exec_duration(exec_start)),
+            Ok(response) => {
+                let mut resp_stream = response.into_inner();
 
-        // Get first response
-        let write_response = match resp_stream.next().await {
-            Some(Ok(response)) => response,
-            Some(Err(err)) => return Err(err.into()),
-            None => {
-                return Err(Error::Custom(
-                    "Server returned no write response".to_string(),
-                ));
+                // Server execution and response delivery happen while polling the stream.
+                let first_response = resp_stream.next().await;
+                let exec_duration = metrics::batch_exec_duration(exec_start);
+                let result = match first_response {
+                    Some(Ok(response)) => {
+                        // Close the stream by dropping the sender
+                        drop(tx);
+
+                        // Verify we received only one response
+                        if let Some(additional_response) = resp_stream.next().await {
+                            Err(Error::Custom(format!(
+                                "Expected exactly one response, but got additional response: {additional_response:?}"
+                            )))
+                        } else {
+                            Ok(response)
+                        }
+                    }
+                    Some(Err(err)) => Err(err.into()),
+                    None => Err(Error::Custom(
+                        "Server returned no write response".to_string(),
+                    )),
+                };
+                (result, exec_duration)
             }
         };
-
-        // Close the stream by dropping the sender
-        drop(tx);
-
-        // Verify we received only one response
-        if let Some(response) = resp_stream.next().await {
-            return Err(Error::Custom(format!(
-                "Expected exactly one response, but got additional response: {response:?}"
-            )));
-        }
-
-        Ok(write_response)
+        let result = result.and_then(|response| {
+            check_write_operation_response(&response, metrics_op).map_or_else(|| Ok(response), Err)
+        });
+        metrics::record_batch(
+            &data.metrics,
+            metrics_op,
+            metrics::result_kind(&result),
+            total_start,
+            exec_duration,
+            value_size,
+            request_count,
+        );
+        result
     }
 
     /// Retrieves a key with the given options
@@ -831,10 +880,13 @@ impl Client {
         })?)
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn demux_stream(
         context: Arc<ClientData>,
         keys: Vec<Arc<str>>,
         read_response: Result<tonic::Response<Streaming<oxia_proto::ReadResponse>>>,
+        total_start: metrics::BatchStart,
+        exec_start: metrics::BatchStart,
     ) -> impl Stream<Item = batch_get::ResponseItem> {
         enum State {
             Demuxing {
@@ -849,24 +901,70 @@ impl Client {
         }
 
         let keys_iter = keys.into_iter();
-        let state = match read_response {
+        let (result_kind, value_size, request_count, state) = match read_response {
             Ok(s) => match s.into_inner().next().await {
-                Some(Ok(rr)) => State::Demuxing {
-                    context,
-                    keys_iter,
-                    gets_iter: rr.gets.into_iter(),
-                },
-                Some(Err(status)) => State::Failing {
-                    keys_iter,
-                    err: status.into(),
-                },
-                None => State::Failing {
-                    keys_iter,
-                    err: no_response_error(context.get_leader().as_deref(), context.shard_id),
-                },
+                Some(Ok(rr)) => {
+                    let (result_kind, value_size, request_count) =
+                        read_metrics(&rr, keys_iter.len());
+                    (
+                        result_kind,
+                        value_size,
+                        request_count,
+                        State::Demuxing {
+                            context: Arc::clone(&context),
+                            keys_iter,
+                            gets_iter: rr.gets.into_iter(),
+                        },
+                    )
+                }
+                Some(Err(status)) => {
+                    let request_count = keys_iter.len() as u64;
+                    (
+                        metrics::ResultKind::Failure,
+                        0,
+                        request_count,
+                        State::Failing {
+                            keys_iter,
+                            err: status.into(),
+                        },
+                    )
+                }
+                None => {
+                    let request_count = keys_iter.len() as u64;
+                    (
+                        metrics::ResultKind::Failure,
+                        0,
+                        request_count,
+                        State::Failing {
+                            keys_iter,
+                            err: no_response_error(
+                                context.get_leader().as_deref(),
+                                context.shard_id,
+                            ),
+                        },
+                    )
+                }
             },
-            Err(err) => State::Failing { keys_iter, err },
+            Err(err) => {
+                let request_count = keys_iter.len() as u64;
+                (
+                    metrics::ResultKind::Failure,
+                    0,
+                    request_count,
+                    State::Failing { keys_iter, err },
+                )
+            }
         };
+        let exec_duration = metrics::batch_exec_duration(exec_start);
+        metrics::record_batch(
+            &context.metrics,
+            metrics::Operation::Get,
+            result_kind,
+            total_start,
+            exec_duration,
+            value_size,
+            request_count,
+        );
 
         futures::stream::unfold(state, move |mut state| async move {
             loop {
@@ -919,6 +1017,7 @@ impl Client {
         &self,
         batch_req: batch_get::Request,
     ) -> impl Stream<Item = batch_get::ResponseItem> + use<> {
+        let total_start = metrics::batch_start();
         let opts = match batch_req.opts {
             Some(o) => o.into(),
             None => GetOptions::default(),
@@ -935,6 +1034,7 @@ impl Client {
             gets,
         };
 
+        let exec_start = metrics::batch_start();
         let read_result = self
             .rpc(|mut grpc| {
                 let req = read_req.clone();
@@ -945,13 +1045,29 @@ impl Client {
         let read_result = match read_result {
             Err(Error::OxiaRpc(OxiaRpcError::NodeIsNotLeader { hint: Some(hint) })) => {
                 self.apply_leader_hint(&hint);
-                self.rpc(|mut grpc| async move { grpc.read(read_req).await })
-                    .await
+                let retry_result = self
+                    .rpc(|mut grpc| async move { grpc.read(read_req).await })
+                    .await;
+                return Self::demux_stream(
+                    Arc::clone(&self.data),
+                    batch_req.keys,
+                    retry_result,
+                    total_start,
+                    exec_start,
+                )
+                .await;
             }
             other => other,
         };
 
-        Self::demux_stream(Arc::clone(&self.data), batch_req.keys, read_result).await
+        Self::demux_stream(
+            Arc::clone(&self.data),
+            batch_req.keys,
+            read_result,
+            total_start,
+            exec_start,
+        )
+        .await
     }
 
     /// Puts a value with the given options
@@ -968,11 +1084,7 @@ impl Client {
         };
 
         let req = self.make_put_req(session_id, options, key, value);
-        let rsp = self.process_write(req).await?;
-
-        if let Some(e) = check_put_response(&rsp) {
-            return Err(e);
-        }
+        let rsp = self.process_write(req, metrics::Operation::Put).await?;
 
         let p = rsp.puts.into_iter().next().ok_or_else(|| {
             Error::Custom("expected one PutResponse in write response but got none".to_string())
@@ -983,12 +1095,7 @@ impl Client {
     /// Deletes a key with the given options
     pub(crate) async fn delete(&self, key: &str, options: &DeleteOptions) -> Result<()> {
         let req = self.make_delete_req(options, key);
-        let rsp = self.process_write(req).await?;
-
-        if let Some(e) = check_delete_response(&rsp) {
-            return Err(e);
-        }
-
+        self.process_write(req, metrics::Operation::Delete).await?;
         Ok(())
     }
 
@@ -1000,9 +1107,8 @@ impl Client {
         options: &DeleteRangeOptions,
     ) -> impl Future<Output = Result<()>> {
         let req = self.make_delete_range_req(options, start_inclusive, end_exclusive);
-        self.process_write(req).map(|r| {
-            r.and_then(|rsp| check_delete_range_response(&rsp).map_or_else(|| Ok(()), Err))
-        })
+        self.process_write(req, metrics::Operation::DeleteRange)
+            .map(|result| result.map(|_| ()))
     }
 
     /// Lists keys in the given range with options
@@ -1102,6 +1208,66 @@ impl Client {
             .await?;
         Ok(NotificationsStream::from_proto(rsp.into_inner()))
     }
+}
+
+#[cfg(feature = "metrics")]
+fn write_metrics(request: &oxia_proto::WriteRequest, metrics_op: metrics::Operation) -> (u64, u64) {
+    match metrics_op {
+        metrics::Operation::Put => debug_assert!(
+            !request.puts.is_empty()
+                && request.deletes.is_empty()
+                && request.delete_ranges.is_empty(),
+            "expected metrics::Operation::Put"
+        ),
+        metrics::Operation::Delete => debug_assert!(
+            request.puts.is_empty()
+                && !request.deletes.is_empty()
+                && request.delete_ranges.is_empty(),
+            "expected metrics::Operation::Delete"
+        ),
+        metrics::Operation::DeleteRange => debug_assert!(
+            request.puts.is_empty()
+                && request.deletes.is_empty()
+                && !request.delete_ranges.is_empty(),
+            "expected metrics::Operation::DeleteRange"
+        ),
+        _ => debug_assert!(false, "invalid op"),
+    }
+
+    let value_size = request.puts.iter().map(|put| put.value.len() as u64).sum();
+    let request_count =
+        (request.puts.len() + request.deletes.len() + request.delete_ranges.len()) as u64;
+    (value_size, request_count)
+}
+#[cfg(not(feature = "metrics"))]
+#[inline]
+const fn write_metrics(_: &oxia_proto::WriteRequest, _: metrics::Operation) -> (u64, u64) {
+    (0, 0)
+}
+
+#[cfg(feature = "metrics")]
+fn read_metrics(
+    response: &oxia_proto::ReadResponse,
+    expected_count: usize,
+) -> (metrics::ResultKind, u64, u64) {
+    let value_size = response
+        .gets
+        .iter()
+        .map(|get| get.value.as_ref().map_or(0, bytes::Bytes::len) as u64)
+        .sum();
+    let result = if response.gets.len() == expected_count
+        && response.gets.iter().all(get_response_is_success)
+    {
+        metrics::ResultKind::Success
+    } else {
+        metrics::ResultKind::Failure
+    };
+    (result, value_size, expected_count as u64)
+}
+#[cfg(not(feature = "metrics"))]
+#[inline]
+const fn read_metrics(_: &oxia_proto::ReadResponse, _: usize) -> (metrics::ResultKind, u64, u64) {
+    (metrics::ResultKind::Success, 0, 0)
 }
 
 /// Trait for a shardfmapping strategy.
@@ -1848,6 +2014,64 @@ mod tests {
     fn make_shard_id(x: u64) -> ShardId {
         #[allow(clippy::cast_possible_wrap)]
         (x as i64).into()
+    }
+
+    #[test]
+    fn write_operation_validation_rejects_oxia_failure() {
+        let response = oxia_proto::WriteResponse {
+            puts: vec![oxia_proto::PutResponse {
+                status: 2,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert!(check_write_operation_response(&response, metrics::Operation::Put).is_some());
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn read_metrics_rejects_per_key_failure() {
+        let response = oxia_proto::ReadResponse {
+            gets: vec![oxia_proto::GetResponse {
+                status: 2,
+                ..Default::default()
+            }],
+        };
+
+        let (result, _, request_count) = read_metrics(&response, 1);
+        assert_eq!(result, metrics::ResultKind::Failure);
+        assert_eq!(request_count, 1);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn read_metrics_rejects_short_response() {
+        let response = oxia_proto::ReadResponse {
+            gets: vec![oxia_proto::GetResponse {
+                status: 0,
+                ..Default::default()
+            }],
+        };
+
+        let (result, _, request_count) = read_metrics(&response, 2);
+        assert_eq!(result, metrics::ResultKind::Failure);
+        assert_eq!(request_count, 2);
+    }
+
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn read_metrics_accepts_key_not_found() {
+        let response = oxia_proto::ReadResponse {
+            gets: vec![oxia_proto::GetResponse {
+                status: 1,
+                ..Default::default()
+            }],
+        };
+
+        let (result, _, request_count) = read_metrics(&response, 1);
+        assert_eq!(result, metrics::ResultKind::Success);
+        assert_eq!(request_count, 1);
     }
 
     #[test]

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition.workspace = true
 license = "Apache-2.0"
 
+[features]
+default = ["otlp-json-compat"]
+otlp-json-compat = []
+
 [[bin]]
 name = "oxia-cmd"
 path = "src/main.rs"
@@ -18,8 +22,20 @@ clap_complete = "4.6.5"
 futures = "0.3.32"
 hex = "0.4.3"
 humantime = "2.3.0"
-mauricebarnum-oxia-client = { path = "../client" }
+mauricebarnum-oxia-client = { path = "../client", features = ["metrics"] }
 num_cpus = "1.17.0"
+opentelemetry = { version = "0.32.0", default-features = false }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = [
+    "metrics",
+] }
+opentelemetry-proto = { version = "0.32.0", default-features = false, features = [
+    "gen-tonic-messages",
+    "metrics",
+    "with-serde",
+] }
+prost = "0.14.4"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
 rustyline = "18.0.0"
 shlex = "2.0.1"
 thiserror = "2.0.18"
@@ -35,3 +51,9 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = [
+    "metrics",
+    "testing",
+] }

--- a/cmd/src/context.rs
+++ b/cmd/src/context.rs
@@ -31,13 +31,14 @@ pub struct Context {
 }
 
 impl Context {
-    pub(super) fn new(cli: &crate::Cli) -> Self {
+    pub(super) fn new(cli: &crate::Cli, metrics: Option<&crate::metrics::MetricsOutput>) -> Self {
         let config = config::Config::builder()
             .service_addr(cli.service_address.clone())
             .max_parallel_requests(cli.max_parallel_requests)
             .session_timeout(cli.session_timeout)
             .request_timeout(cli.request_timeout)
             .retry_on_stale_shard_map(cli.retry_on_stale_shard_map)
+            .maybe_meter_provider(metrics.map(crate::metrics::MetricsOutput::meter_provider))
             .build();
 
         let client = Client::new(config);

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::Parser;
+use clap::ValueEnum;
 use mauricebarnum_oxia_client as client_lib;
 
 mod commands;
@@ -26,6 +28,9 @@ use context::Context;
 
 mod log;
 use log::LogArgs;
+
+mod metrics;
+use metrics::MetricsOutput;
 
 mod utils;
 
@@ -52,6 +57,28 @@ pub struct Cli {
 
     #[arg(long, default_value_t = false)]
     retry_on_stale_shard_map: bool,
+
+    #[arg(
+        long,
+        value_enum,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "text",
+        help = "Export collected metrics",
+        long_help = "Export collected metrics. Machine-readable output should use a dedicated file.\n\nFormats:\n  text       Human-readable diagnostic output\n  otlp-json  Canonical OTLP/JSON ExportMetricsServiceRequest\n  otlp-pb    Binary OTLP protobuf ExportMetricsServiceRequest"
+    )]
+    metrics: Option<MetricsFormat>,
+
+    /// Metrics destination: stderr by default, stdout for '-', or a file path.
+    #[arg(long, requires = "metrics")]
+    metrics_output: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum MetricsFormat {
+    Text,
+    OtlpJson,
+    OtlpPb,
 }
 
 #[tokio::main]
@@ -59,6 +86,74 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     cli.log.setup("off")?;
 
-    let ctx = Context::new(&cli);
-    cli.command.run(ctx).await
+    let metrics = cli
+        .metrics
+        .map(|format| MetricsOutput::new(format, cli.metrics_output.as_deref()))
+        .transpose()?;
+    let ctx = Context::new(&cli, metrics.as_ref());
+    let result = cli.command.run(ctx).await;
+
+    let export_result = if let Some(metrics) = metrics {
+        metrics.export()
+    } else {
+        Ok(())
+    };
+
+    match (result, export_result) {
+        (Ok(()), export) => export,
+        (Err(command_error), Ok(())) => Err(command_error),
+        (Err(command_error), Err(export_error)) => {
+            eprintln!("failed to export metrics: {export_error:#}");
+            Err(command_error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory as _;
+    use clap::Parser as _;
+
+    use super::*;
+
+    #[test]
+    fn parses_metrics_formats() {
+        for (argument, expected) in [
+            ("--metrics", MetricsFormat::Text),
+            ("--metrics=text", MetricsFormat::Text),
+            ("--metrics=otlp-json", MetricsFormat::OtlpJson),
+            ("--metrics=otlp-pb", MetricsFormat::OtlpPb),
+        ] {
+            let cli = Cli::try_parse_from(["oxia-cmd", argument, "get", "key"])
+                .expect("valid metrics argument");
+            assert_eq!(cli.metrics, Some(expected));
+        }
+    }
+
+    #[test]
+    fn metrics_help_describes_formats() {
+        let help = Cli::command().render_long_help().to_string();
+        assert!(help.contains("text       Human-readable diagnostic output"));
+        assert!(help.contains("otlp-json  Canonical OTLP/JSON ExportMetricsServiceRequest"));
+        assert!(help.contains("otlp-pb    Binary OTLP protobuf ExportMetricsServiceRequest"));
+    }
+
+    #[test]
+    fn metrics_value_requires_equals() {
+        let cli = Cli::try_parse_from(["oxia-cmd", "--metrics", "get", "key"])
+            .expect("subcommand is not consumed as a metrics format");
+        assert_eq!(cli.metrics, Some(MetricsFormat::Text));
+    }
+
+    #[test]
+    fn rejects_invalid_metrics_format() {
+        assert!(Cli::try_parse_from(["oxia-cmd", "--metrics=yaml", "get", "key"]).is_err());
+        assert!(Cli::try_parse_from(["oxia-cmd", "--metrics=json", "get", "key"]).is_err());
+        assert!(Cli::try_parse_from(["oxia-cmd", "--metrics=om2", "get", "key"]).is_err());
+    }
+
+    #[test]
+    fn metrics_output_requires_metrics() {
+        assert!(Cli::try_parse_from(["oxia-cmd", "--metrics-output", "-", "get", "key"]).is_err());
+    }
 }

--- a/cmd/src/metrics.rs
+++ b/cmd/src/metrics.rs
@@ -1,0 +1,625 @@
+// Copyright 2026 Maurice S. Barnum
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+use std::fs::File;
+use std::io;
+use std::io::Write as _;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use anyhow::Context as _;
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::error::OTelSdkError;
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::metrics::Aggregation;
+use opentelemetry_sdk::metrics::Instrument;
+use opentelemetry_sdk::metrics::InstrumentKind;
+use opentelemetry_sdk::metrics::PeriodicReader;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::Stream;
+use opentelemetry_sdk::metrics::Temporality;
+use opentelemetry_sdk::metrics::data;
+use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+
+use crate::MetricsFormat;
+
+mod otlp;
+
+const EXPONENTIAL_HISTOGRAM_MAX_SIZE: u32 = 160;
+const EXPONENTIAL_HISTOGRAM_MAX_SCALE: i8 = 20;
+
+const HISTOGRAM_NAMES: &[&str] = &[
+    "db.client.operation.duration",
+    "db.client.operation.size",
+    "db.client.batch.duration",
+    "db.client.batch.exec_duration",
+    "db.client.batch.size",
+    "db.client.batch.request_count",
+];
+
+#[derive(Debug)]
+pub struct MetricsOutput {
+    provider: SdkMeterProvider,
+    exporter: OutputExporter,
+}
+
+#[derive(Debug)]
+enum MetricsWriter {
+    Stderr,
+    Stdout,
+    File(File),
+}
+
+impl MetricsOutput {
+    pub fn new(format: MetricsFormat, output: Option<&Path>) -> anyhow::Result<Self> {
+        let writer = match output {
+            None => MetricsWriter::Stderr,
+            Some(path) if path == Path::new("-") => MetricsWriter::Stdout,
+            Some(path) => MetricsWriter::File(
+                File::create(path)
+                    .with_context(|| format!("failed to open metrics output {}", path.display()))?,
+            ),
+        };
+        let exporter = OutputExporter::new(format, writer)?;
+        let reader = PeriodicReader::builder(exporter.clone()).build();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_view(exponential_histogram_view)
+            .build();
+        Ok(Self { provider, exporter })
+    }
+
+    pub fn meter_provider(&self) -> crate::client_lib::config::MeterProviderHandle {
+        Arc::new(self.provider.clone())
+    }
+
+    pub fn export(self) -> anyhow::Result<()> {
+        let shutdown_result = self
+            .provider
+            .shutdown()
+            .context("failed to shut down metrics provider");
+        if let Some(error) = self.exporter.error()? {
+            anyhow::bail!("failed to write metrics: {error}");
+        }
+        shutdown_result
+    }
+}
+
+#[derive(Clone, Debug)]
+struct OutputExporter {
+    format: MetricsFormat,
+    state: Arc<Mutex<OutputState>>,
+}
+
+#[derive(Debug)]
+struct OutputState {
+    error: Option<String>,
+    pending: Option<Vec<u8>>,
+    writer: MetricsWriter,
+}
+
+impl OutputExporter {
+    fn new(format: MetricsFormat, writer: MetricsWriter) -> io::Result<Self> {
+        let pending = Some(format_output(format, &ResourceMetrics::default())?);
+        Ok(Self {
+            format,
+            state: Arc::new(Mutex::new(OutputState {
+                error: None,
+                pending,
+                writer,
+            })),
+        })
+    }
+
+    fn update(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
+        match format_output(self.format, metrics) {
+            Ok(output) => {
+                self.state
+                    .lock()
+                    .map_err(|error| lock_error(&error))?
+                    .pending = Some(output);
+                Ok(())
+            }
+            Err(error) => {
+                let message = error.to_string();
+                self.state.lock().map_err(|error| lock_error(&error))?.error =
+                    Some(message.clone());
+                Err(OTelSdkError::InternalFailure(message))
+            }
+        }
+    }
+
+    fn error(&self) -> anyhow::Result<Option<String>> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|error| anyhow::anyhow!("metrics output lock poisoned: {error}"))?
+            .error
+            .clone())
+    }
+}
+
+impl PushMetricExporter for OutputExporter {
+    fn export(
+        &self,
+        metrics: &ResourceMetrics,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+        std::future::ready(self.update(metrics))
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: std::time::Duration) -> OTelSdkResult {
+        let mut state = self.state.lock().map_err(|error| lock_error(&error))?;
+        if let Some(output) = state.pending.take()
+            && let Err(error) = state.writer.write_all(&output)
+        {
+            let message = error.to_string();
+            state.error = Some(message.clone());
+            drop(state);
+            return Err(OTelSdkError::InternalFailure(message));
+        }
+        drop(state);
+        Ok(())
+    }
+
+    fn temporality(&self) -> Temporality {
+        Temporality::Cumulative
+    }
+}
+
+impl MetricsWriter {
+    fn write_all(&mut self, output: &[u8]) -> io::Result<()> {
+        match self {
+            Self::Stderr => io::stderr().lock().write_all(output),
+            Self::Stdout => io::stdout().lock().write_all(output),
+            Self::File(file) => file.write_all(output),
+        }
+    }
+}
+
+fn format_output(format: MetricsFormat, metrics: &ResourceMetrics) -> io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    match format {
+        MetricsFormat::Text => format_metrics(&mut output, metrics)?,
+        MetricsFormat::OtlpJson => otlp::format_json(&mut output, metrics)?,
+        MetricsFormat::OtlpPb => otlp::format_protobuf(&mut output, metrics)?,
+    }
+    Ok(output)
+}
+
+fn lock_error<T>(error: &std::sync::PoisonError<T>) -> OTelSdkError {
+    OTelSdkError::InternalFailure(format!("metrics output lock poisoned: {error}"))
+}
+
+fn format_metrics(writer: &mut dyn io::Write, metrics: &ResourceMetrics) -> io::Result<()> {
+    writeln!(writer, "Metrics")?;
+    writeln!(writer, "Resource")?;
+    if let Some(schema_url) = metrics.resource().schema_url() {
+        writeln!(writer, "\tResource SchemaUrl: {schema_url:?}")?;
+    }
+    for (key, value) in metrics.resource() {
+        writeln!(writer, "\t ->  {key}={value:?}")?;
+    }
+
+    for (scope_index, scope_metrics) in metrics.scope_metrics().enumerate() {
+        writeln!(writer, "\tInstrumentation Scope #{scope_index}")?;
+        writeln!(
+            writer,
+            "\t\tName         : {}",
+            scope_metrics.scope().name()
+        )?;
+        if let Some(version) = scope_metrics.scope().version() {
+            writeln!(writer, "\t\tVersion      : {version:?}")?;
+        }
+        if let Some(schema_url) = scope_metrics.scope().schema_url() {
+            writeln!(writer, "\t\tSchemaUrl    : {schema_url:?}")?;
+        }
+        for (index, attribute) in scope_metrics.scope().attributes().enumerate() {
+            if index == 0 {
+                writeln!(writer, "\t\tScope Attributes:")?;
+            }
+            writeln!(writer, "\t\t\t ->  {}: {}", attribute.key, attribute.value)?;
+        }
+
+        for (metric_index, metric) in scope_metrics.metrics().enumerate() {
+            writeln!(writer, "Metric #{metric_index}")?;
+            writeln!(writer, "\t\tName         : {}", metric.name())?;
+            writeln!(writer, "\t\tDescription  : {}", metric.description())?;
+            writeln!(writer, "\t\tUnit         : {}", metric.unit())?;
+            format_aggregation(writer, metric.data(), metric.unit())?;
+        }
+    }
+    Ok(())
+}
+
+fn format_aggregation(
+    writer: &mut dyn io::Write,
+    aggregation: &data::AggregatedMetrics,
+    unit: &str,
+) -> io::Result<()> {
+    match aggregation {
+        data::AggregatedMetrics::U64(value) => format_metric_data(writer, value, unit),
+        data::AggregatedMetrics::I64(value) => format_metric_data(writer, value, unit),
+        data::AggregatedMetrics::F64(value) => format_metric_data(writer, value, unit),
+    }
+}
+
+fn format_metric_data<T: Copy + Debug>(
+    writer: &mut dyn io::Write,
+    data: &data::MetricData<T>,
+    unit: &str,
+) -> io::Result<()> {
+    match data {
+        data::MetricData::Gauge(value) => {
+            writeln!(writer, "\t\tType         : Gauge")?;
+            format_gauge(writer, value)
+        }
+        data::MetricData::Sum(value) => {
+            writeln!(writer, "\t\tType         : Sum")?;
+            format_sum(writer, value)
+        }
+        data::MetricData::Histogram(value) => {
+            writeln!(writer, "\t\tType         : Histogram")?;
+            format_histogram(writer, value)
+        }
+        data::MetricData::ExponentialHistogram(value) => {
+            writeln!(writer, "\t\tType         : Exponential Histogram")?;
+            format_exponential_histogram(writer, value, unit)
+        }
+    }
+}
+
+fn format_sum<T: Copy + Debug>(writer: &mut dyn io::Write, sum: &data::Sum<T>) -> io::Result<()> {
+    writeln!(writer, "\t\tSum DataPoints")?;
+    writeln!(writer, "\t\tMonotonic    : {}", sum.is_monotonic())?;
+    format_temporality(writer, sum.temporality())?;
+    format_time(writer, "StartTime", sum.start_time())?;
+    format_time(writer, "EndTime", sum.time())?;
+    format_sum_data_points(writer, sum.data_points())
+}
+
+fn format_gauge<T: Copy + Debug>(
+    writer: &mut dyn io::Write,
+    gauge: &data::Gauge<T>,
+) -> io::Result<()> {
+    writeln!(writer, "\t\tGauge DataPoints")?;
+    if let Some(start_time) = gauge.start_time() {
+        format_time(writer, "StartTime", start_time)?;
+    }
+    format_time(writer, "EndTime", gauge.time())?;
+    format_gauge_data_points(writer, gauge.data_points())
+}
+
+fn format_histogram<T: Copy + Debug>(
+    writer: &mut dyn io::Write,
+    histogram: &data::Histogram<T>,
+) -> io::Result<()> {
+    format_temporality(writer, histogram.temporality())?;
+    format_time(writer, "StartTime", histogram.start_time())?;
+    format_time(writer, "EndTime", histogram.time())?;
+    writeln!(writer, "\t\tHistogram DataPoints")?;
+    for (index, point) in histogram.data_points().enumerate() {
+        writeln!(writer, "\t\tDataPoint #{index}")?;
+        writeln!(writer, "\t\t\tCount        : {}", point.count())?;
+        writeln!(writer, "\t\t\tSum          : {:?}", point.sum())?;
+        if let Some(min) = point.min() {
+            writeln!(writer, "\t\t\tMin          : {min:?}")?;
+        }
+        if let Some(max) = point.max() {
+            writeln!(writer, "\t\t\tMax          : {max:?}")?;
+        }
+        format_attributes(writer, point.attributes())?;
+    }
+    Ok(())
+}
+
+fn format_exponential_histogram<T: Copy + Debug>(
+    writer: &mut dyn io::Write,
+    histogram: &data::ExponentialHistogram<T>,
+    unit: &str,
+) -> io::Result<()> {
+    format_temporality(writer, histogram.temporality())?;
+    format_time(writer, "StartTime", histogram.start_time())?;
+    format_time(writer, "EndTime", histogram.time())?;
+    writeln!(writer, "\t\tExponential Histogram DataPoints")?;
+    for (index, point) in histogram.data_points().enumerate() {
+        writeln!(writer, "\t\tDataPoint #{index}")?;
+        writeln!(writer, "\t\t\tCount        : {}", point.count())?;
+        writeln!(writer, "\t\t\tSum          : {:?}", point.sum())?;
+        if let Some(min) = point.min() {
+            writeln!(writer, "\t\t\tMin          : {min:?}")?;
+        }
+        if let Some(max) = point.max() {
+            writeln!(writer, "\t\t\tMax          : {max:?}")?;
+        }
+        let base = exponential_base(point.scale());
+        writeln!(writer, "\t\t\tScale        : {}", point.scale())?;
+        writeln!(writer, "\t\t\tBase         : {base:.12}")?;
+        writeln!(writer, "\t\t\tZeroCount    : {}", point.zero_count())?;
+        writeln!(
+            writer,
+            "\t\t\tZeroThreshold: {:.12e}",
+            point.zero_threshold()
+        )?;
+        format_attributes(writer, point.attributes())?;
+        format_exponential_buckets(writer, point, unit, base)?;
+    }
+    Ok(())
+}
+
+fn format_exponential_buckets<T>(
+    writer: &mut dyn io::Write,
+    point: &data::ExponentialHistogramDataPoint<T>,
+    unit: &str,
+    base: f64,
+) -> io::Result<()> {
+    writeln!(writer, "\t\t\tBuckets      :")?;
+    for (position, count) in point.negative_bucket().counts().enumerate() {
+        if count == 0 {
+            continue;
+        }
+        let index = bucket_index(point.negative_bucket().offset(), position)?;
+        let lower = -base.powi(index + 1);
+        let upper = -base.powi(index);
+        format_bucket(writer, '[', lower, upper, ')', count, unit)?;
+    }
+    if point.zero_count() > 0 {
+        format_bucket(
+            writer,
+            '[',
+            -point.zero_threshold(),
+            point.zero_threshold(),
+            ']',
+            point.zero_count(),
+            unit,
+        )?;
+    }
+    for (position, count) in point.positive_bucket().counts().enumerate() {
+        if count == 0 {
+            continue;
+        }
+        let index = bucket_index(point.positive_bucket().offset(), position)?;
+        let lower = base.powi(index);
+        let upper = base.powi(index + 1);
+        format_bucket(writer, '(', lower, upper, ']', count, unit)?;
+    }
+    Ok(())
+}
+
+fn format_bucket(
+    writer: &mut dyn io::Write,
+    left: char,
+    lower: f64,
+    upper: f64,
+    right: char,
+    count: u64,
+    unit: &str,
+) -> io::Result<()> {
+    if unit.is_empty() {
+        writeln!(
+            writer,
+            "\t\t\t\t{left}{lower:.12e}, {upper:.12e}{right}: {count}"
+        )
+    } else {
+        writeln!(
+            writer,
+            "\t\t\t\t{left}{lower:.12e}, {upper:.12e}{right} {unit}: {count}"
+        )
+    }
+}
+
+fn bucket_index(offset: i32, position: usize) -> io::Result<i32> {
+    let position = i32::try_from(position).map_err(io::Error::other)?;
+    offset.checked_add(position).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "exponential histogram bucket index overflow",
+        )
+    })
+}
+
+fn exponential_base(scale: i8) -> f64 {
+    2.0_f64.powi(-i32::from(scale)).exp2()
+}
+
+fn format_temporality(writer: &mut dyn io::Write, temporality: Temporality) -> io::Result<()> {
+    let name = match temporality {
+        Temporality::Cumulative => "Cumulative",
+        Temporality::Delta => "Delta",
+        other => return writeln!(writer, "\t\tTemporality  : {other:?}"),
+    };
+    writeln!(writer, "\t\tTemporality  : {name}")
+}
+
+fn format_gauge_data_points<'a, T: Copy + Debug + 'a>(
+    writer: &mut dyn io::Write,
+    data_points: impl Iterator<Item = &'a data::GaugeDataPoint<T>>,
+) -> io::Result<()> {
+    for (index, point) in data_points.enumerate() {
+        writeln!(writer, "\t\tDataPoint #{index}")?;
+        writeln!(writer, "\t\t\tValue        : {:?}", point.value())?;
+        format_attributes(writer, point.attributes())?;
+    }
+    Ok(())
+}
+
+fn format_sum_data_points<'a, T: Copy + Debug + 'a>(
+    writer: &mut dyn io::Write,
+    data_points: impl Iterator<Item = &'a data::SumDataPoint<T>>,
+) -> io::Result<()> {
+    for (index, point) in data_points.enumerate() {
+        writeln!(writer, "\t\tDataPoint #{index}")?;
+        writeln!(writer, "\t\t\tValue        : {:?}", point.value())?;
+        format_attributes(writer, point.attributes())?;
+    }
+    Ok(())
+}
+
+fn format_time(writer: &mut dyn io::Write, label: &str, time: SystemTime) -> io::Result<()> {
+    writeln!(
+        writer,
+        "\t\t\t{label:<13}: {}",
+        humantime::format_rfc3339_micros(time)
+    )
+}
+
+fn format_attributes<'a>(
+    writer: &mut dyn io::Write,
+    attributes: impl Iterator<Item = &'a KeyValue>,
+) -> io::Result<()> {
+    writeln!(writer, "\t\t\tAttributes   :")?;
+    for attribute in attributes {
+        writeln!(
+            writer,
+            "\t\t\t\t ->  {}: {}",
+            attribute.key, attribute.value
+        )?;
+    }
+    Ok(())
+}
+
+fn exponential_histogram_view(instrument: &Instrument) -> Option<Stream> {
+    (instrument.kind() == InstrumentKind::Histogram && HISTOGRAM_NAMES.contains(&instrument.name()))
+        .then(|| {
+            Stream::builder()
+                .with_aggregation(Aggregation::Base2ExponentialHistogram {
+                    max_size: EXPONENTIAL_HISTOGRAM_MAX_SIZE,
+                    max_scale: EXPONENTIAL_HISTOGRAM_MAX_SCALE,
+                    record_min_max: false,
+                })
+                .build()
+                .expect("valid exponential histogram view")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use opentelemetry::metrics::MeterProvider as _;
+
+    use super::*;
+
+    #[test]
+    fn selects_default_stderr_and_explicit_stdout() {
+        let stderr = MetricsOutput::new(MetricsFormat::Text, None).expect("stderr opens");
+        assert!(matches!(
+            stderr.exporter.state.lock().unwrap().writer,
+            MetricsWriter::Stderr
+        ));
+
+        let stdout = MetricsOutput::new(MetricsFormat::OtlpJson, Some(Path::new("-")))
+            .expect("stdout opens");
+        assert!(matches!(
+            stdout.exporter.state.lock().unwrap().writer,
+            MetricsWriter::Stdout
+        ));
+
+        stderr.exporter.state.lock().unwrap().pending = None;
+        stdout.exporter.state.lock().unwrap().pending = None;
+    }
+
+    #[test]
+    fn opens_and_truncates_metrics_file_immediately() {
+        let path = std::env::temp_dir().join(format!(
+            "oxia-cmd-metrics-output-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        fs::write(&path, b"existing data").expect("test file is writable");
+
+        let output = MetricsOutput::new(MetricsFormat::OtlpPb, Some(&path))
+            .expect("metrics output file opens");
+        assert!(matches!(
+            output.exporter.state.lock().unwrap().writer,
+            MetricsWriter::File(_)
+        ));
+        assert_eq!(fs::metadata(&path).unwrap().len(), 0);
+
+        drop(output);
+        fs::remove_file(path).expect("test file is removable");
+    }
+
+    #[test]
+    fn reports_metrics_file_open_failure_immediately() {
+        let path = std::env::temp_dir()
+            .join("oxia-cmd-missing-directory")
+            .join("metrics.out");
+        let error = MetricsOutput::new(MetricsFormat::Text, Some(&path))
+            .expect_err("missing parent directory must fail");
+        assert!(error.to_string().contains("failed to open metrics output"));
+    }
+
+    #[test]
+    fn formats_populated_exponential_histogram_buckets() {
+        let (output, path) = file_output(MetricsFormat::Text);
+        let histogram = output
+            .provider
+            .meter("test.scope")
+            .f64_histogram("db.client.operation.duration")
+            .with_unit("s")
+            .build();
+        for value in [-4.0, -1.0, 0.0, 0.0, 1.0, 4.0] {
+            histogram.record(value, &[KeyValue::new("result", "success")]);
+        }
+        output.export().expect("metrics export succeeds");
+        let output = fs::read_to_string(&path).expect("metrics output is readable");
+        fs::remove_file(path).expect("test file is removable");
+
+        assert!(output.contains("Type         : Exponential Histogram"));
+        assert!(output.contains("Count        : 6"));
+        assert!(output.contains("Sum          : 0.0"));
+        assert!(output.contains("ZeroCount    : 2"));
+        assert!(output.contains("Buckets      :"));
+        assert!(output.contains(" s: 1"));
+        assert!(output.contains(" ->  result: success"));
+    }
+
+    #[test]
+    fn formats_u64_exponential_histogram_without_empty_zero_bucket() {
+        let (output, path) = file_output(MetricsFormat::Text);
+        output
+            .provider
+            .meter("test.scope")
+            .u64_histogram("db.client.operation.size")
+            .with_unit("By")
+            .build()
+            .record(3, &[]);
+        output.export().expect("metrics export succeeds");
+        let output = fs::read_to_string(&path).expect("metrics output is readable");
+        fs::remove_file(path).expect("test file is removable");
+
+        assert!(output.contains("Temporality  : Cumulative"));
+        assert!(output.contains("Sum          : 3"));
+        assert!(output.contains(" By: 1"));
+        assert!(!output.contains("[0.000000000000e0, 0.000000000000e0]"));
+    }
+
+    fn file_output(format: MetricsFormat) -> (MetricsOutput, std::path::PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "oxia-cmd-metrics-format-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        let output = MetricsOutput::new(format, Some(&path)).expect("metrics output file opens");
+        (output, path)
+    }
+}

--- a/cmd/src/metrics/otlp.rs
+++ b/cmd/src/metrics/otlp.rs
@@ -1,0 +1,265 @@
+// Copyright 2026 Maurice S. Barnum
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_sdk::metrics::data;
+use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use prost::Message as _;
+
+pub(super) fn format_json(writer: &mut dyn io::Write, metrics: &ResourceMetrics) -> io::Result<()> {
+    let request = export_request(metrics)?;
+
+    #[cfg(feature = "otlp-json-compat")]
+    let request = compatibility_json(&request)?;
+
+    serde_json::to_writer(&mut *writer, &request).map_err(io::Error::other)?;
+    writeln!(writer)
+}
+
+pub(super) fn format_protobuf(
+    writer: &mut dyn io::Write,
+    metrics: &ResourceMetrics,
+) -> io::Result<()> {
+    writer.write_all(&export_request(metrics)?.encode_to_vec())
+}
+
+fn export_request(metrics: &ResourceMetrics) -> io::Result<ExportMetricsServiceRequest> {
+    validate_metrics(metrics)?;
+    Ok(ExportMetricsServiceRequest::from(metrics))
+}
+
+fn validate_metrics(metrics: &ResourceMetrics) -> io::Result<()> {
+    for scope in metrics.scope_metrics() {
+        for metric in scope.metrics() {
+            if let data::AggregatedMetrics::U64(value) = metric.data() {
+                validate_u64_metric(metric.name(), value)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_u64_metric(name: &str, metric: &data::MetricData<u64>) -> io::Result<()> {
+    match metric {
+        data::MetricData::Gauge(value) => {
+            for point in value.data_points() {
+                validate_otlp_int(name, point.value())?;
+                validate_exemplars(name, point.exemplars())?;
+            }
+        }
+        data::MetricData::Sum(value) => {
+            for point in value.data_points() {
+                validate_otlp_int(name, point.value())?;
+                validate_exemplars(name, point.exemplars())?;
+            }
+        }
+        data::MetricData::Histogram(value) => {
+            for point in value.data_points() {
+                validate_exemplars(name, point.exemplars())?;
+            }
+        }
+        data::MetricData::ExponentialHistogram(value) => {
+            for point in value.data_points() {
+                validate_exemplars(name, point.exemplars())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_exemplars<'a>(
+    name: &str,
+    exemplars: impl Iterator<Item = &'a data::Exemplar<u64>>,
+) -> io::Result<()> {
+    for exemplar in exemplars {
+        validate_otlp_int(name, exemplar.value)?;
+    }
+    Ok(())
+}
+
+fn validate_otlp_int(name: &str, value: u64) -> io::Result<()> {
+    i64::try_from(value).map(|_| ()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("metric {name} value {value} exceeds OTLP int64 range"),
+        )
+    })
+}
+
+#[cfg(feature = "otlp-json-compat")]
+fn compatibility_json(request: &ExportMetricsServiceRequest) -> io::Result<serde_json::Value> {
+    let mut value = serde_json::to_value(request).map_err(io::Error::other)?;
+    normalize_otlp_json(&mut value);
+    Ok(value)
+}
+
+#[cfg(feature = "otlp-json-compat")]
+fn normalize_otlp_json(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                normalize_otlp_json(value);
+            }
+        }
+        serde_json::Value::Object(fields) => {
+            for (name, value) in fields {
+                if matches!(
+                    name.as_str(),
+                    "asInt"
+                        | "bucketCounts"
+                        | "count"
+                        | "startTimeUnixNano"
+                        | "timeUnixNano"
+                        | "zeroCount"
+                ) {
+                    stringify_integer(value);
+                }
+                normalize_otlp_json(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(feature = "otlp-json-compat")]
+fn stringify_integer(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                stringify_integer(value);
+            }
+        }
+        serde_json::Value::Number(number) if number.is_i64() || number.is_u64() => {
+            *value = serde_json::Value::String(number.to_string());
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::metrics::MeterProvider as _;
+    use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+    use opentelemetry_sdk::metrics::PeriodicReader;
+    use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+    use super::*;
+
+    // This passes with the compatibility feature. Without that feature, it
+    // passes only when the upstream SDK emits canonical OTLP JSON by itself.
+    #[test]
+    fn emits_canonical_otlp_json() {
+        let (_provider, metrics) = test_metrics(42);
+        let mut output = Vec::new();
+        format_json(&mut output, &metrics).expect("JSON formatting succeeds");
+        assert_eq!(output.last(), Some(&b'\n'));
+
+        let document: serde_json::Value =
+            serde_json::from_slice(&output).expect("valid JSON document");
+        assert_canonical_otlp_json(&document);
+    }
+
+    #[test]
+    fn rejects_unsigned_values_outside_otlp_int64_range() {
+        let (_provider, metrics) = test_metrics(u64::MAX);
+        let error = format_json(&mut Vec::new(), &metrics).expect_err("value is rejected");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("exceeds OTLP int64 range"));
+    }
+
+    #[test]
+    fn emits_otlp_protobuf() {
+        let (_provider, metrics) = test_metrics(42);
+        let mut output = Vec::new();
+        format_protobuf(&mut output, &metrics).expect("protobuf formatting succeeds");
+
+        let request = ExportMetricsServiceRequest::decode(output.as_slice())
+            .expect("valid ExportMetricsServiceRequest protobuf");
+        assert_eq!(request.resource_metrics.len(), 1);
+        assert_eq!(request.resource_metrics[0].scope_metrics.len(), 1);
+        assert_eq!(
+            request.resource_metrics[0].scope_metrics[0].metrics.len(),
+            2
+        );
+    }
+
+    #[test]
+    fn protobuf_rejects_unsigned_values_outside_otlp_int64_range() {
+        let (_provider, metrics) = test_metrics(u64::MAX);
+        let error = format_protobuf(&mut Vec::new(), &metrics).expect_err("value is rejected");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("exceeds OTLP int64 range"));
+    }
+
+    fn assert_canonical_otlp_json(document: &serde_json::Value) {
+        let resource_metrics = &document["resourceMetrics"][0];
+        assert_eq!(
+            resource_metrics["scopeMetrics"][0]["scope"]["name"],
+            "test.scope"
+        );
+
+        let metrics = resource_metrics["scopeMetrics"][0]["metrics"]
+            .as_array()
+            .expect("metrics array");
+        let sum = &metrics
+            .iter()
+            .find(|metric| metric["name"] == "requests.total")
+            .expect("sum metric")["sum"];
+        assert_eq!(sum["aggregationTemporality"], 2);
+        assert_eq!(sum["dataPoints"][0]["asInt"], "42");
+        assert!(sum["dataPoints"][0]["startTimeUnixNano"].is_string());
+        assert!(sum["dataPoints"][0]["timeUnixNano"].is_string());
+
+        let histogram = &metrics
+            .iter()
+            .find(|metric| metric["name"] == "request.duration")
+            .expect("histogram metric")["histogram"]["dataPoints"][0];
+        assert_eq!(histogram["count"], "3");
+        assert_eq!(
+            histogram["bucketCounts"],
+            serde_json::json!(["1", "1", "1"])
+        );
+    }
+
+    fn test_metrics(sum_value: u64) -> (SdkMeterProvider, ResourceMetrics) {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone()).build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("test.scope");
+        meter
+            .u64_counter("requests.total")
+            .with_description("request count")
+            .with_unit("1")
+            .build()
+            .add(sum_value, &[]);
+        let histogram = meter
+            .f64_histogram("request.duration")
+            .with_description("duration")
+            .with_unit("s")
+            .with_boundaries(vec![0.1, 1.0])
+            .build();
+        for value in [0.01, 0.5, 2.0] {
+            histogram.record(value, &[]);
+        }
+        provider.force_flush().expect("metrics collection succeeds");
+        let metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics export succeeds")
+            .pop()
+            .expect("metrics were exported");
+        (provider, metrics)
+    }
+}

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -1,0 +1,99 @@
+# Client Instrumentation
+
+The Oxia client emits tracing spans unconditionally. OpenTelemetry metrics are
+compiled in with the `metrics` feature; `go-metrics-compat` enables `metrics`
+and adds counters compatible with the Go client's timer-style metric names.
+
+Both spans and metrics use the instrumentation scope
+`mauricebarnum_oxia_client`. The client creates instruments from the
+`MeterProvider` supplied to `Config`, or from the OpenTelemetry global meter
+provider when none is supplied. The application owns provider configuration,
+readers, exporters, views, flushing, and shutdown. In particular, applications
+that require exponential histograms must install views for the histogram
+instruments. The CLI setup in `cmd/src/metrics.rs` is an example.
+
+## Spans
+
+All spans are emitted at `INFO` level. Keys, values, and range bounds are not
+recorded.
+
+| Span name | Description |
+| --- | --- |
+| `client.connect` | Connects the client and initializes shard management. |
+| `db.operation.get` | Executes a logical get, including shard selection, retries, and any multi-shard fan-out. |
+| `db.operation.batch_get` | Produces and consumes a logical batch-get stream across its shard requests. |
+| `db.operation.put` | Executes a logical put, including shard selection and retries. |
+| `db.operation.delete` | Executes a logical single-key delete, including shard selection and retries. |
+| `db.operation.delete_range` | Executes a logical range delete, including any multi-shard fan-out. |
+| `db.operation.list` | Executes a logical key listing, including any multi-shard fan-out. |
+| `db.operation.range_scan` | Executes a logical record scan, including any multi-shard fan-out. |
+
+Operation spans have the following fields:
+
+| Field | Description |
+| --- | --- |
+| `db.system` | Always `oxia`. |
+| `db.name` | Configured Oxia namespace. |
+| `db.operation` | One of `get`, `batch_get`, `put`, `delete`, `delete_range`, `list`, or `range_scan`. |
+| `db.oxia.shard_id` | Selected shard ID for a single-shard operation; absent for multi-shard operations and `batch_get`. |
+| `error.type` | Display form of the returned error; absent on success. |
+
+`client.connect` records `db.system`, `db.name`, and `error.type`, but does not
+record `db.operation` or a shard ID. A `batch_get` span remains attached while
+the returned stream is polled. Its operation-duration metric is successful
+only when the stream reaches completion without an item error; an item error
+or dropping the stream before completion records failure. Stream item errors
+affect that metric classification but do not populate the span's `error.type`;
+only an error returned while constructing the stream does so.
+
+## Metrics
+
+Every metric data point has these attributes:
+
+| Attribute | Values |
+| --- | --- |
+| `db.system` | `oxia` |
+| `db.name` | Configured Oxia namespace |
+| `db.operation` | `get`, `batch_get`, `put`, `delete`, `delete_range`, `list`, or `range_scan` |
+| `result` | `success` or `failure` |
+
+| Metric | Instrument | Unit | Description |
+| --- | --- | --- | --- |
+| `db.client.operation.duration` | `f64` histogram | `s` | End-to-end logical client operation duration, including routing, retries, fan-out, and result processing. |
+| `db.client.operation.size` | `u64` histogram | `By` | Value bytes for logical `get`, `put`, and `range_scan` operations. |
+| `db.client.batch.duration` | `f64` histogram | `s` | Total per-shard batch duration from request preparation through response validation. |
+| `db.client.batch.exec_duration` | `f64` histogram | `s` | Per-shard RPC execution duration from dispatch through receipt of the first streamed response. |
+| `db.client.batch.size` | `u64` histogram | `By` | Sum of value bytes in a per-shard batch. |
+| `db.client.batch.request_count` | `u64` histogram | `1` | Number of requests represented by a per-shard batch. |
+
+Operation duration is recorded for every logical database operation.
+Operation size is recorded only for `get`, `put`, and `range_scan`: `get` uses
+the returned value length, `put` uses the submitted value length even when the
+operation fails, and `range_scan` sums returned value lengths. Empty and
+missing values contribute zero bytes.
+
+Batch metrics describe the internal per-shard read or write batch, not the
+logical top-level operation. Batch reads are emitted by `batch_get` shard
+requests with `db.operation=get`; batch writes are emitted for `put`, `delete`,
+and `delete_range`. Write batch size counts put value bytes, so delete batches
+record zero bytes. A get result of key-not-found is considered successful. A
+batch read is successful only when the response count matches the requested
+key count and every per-key response is successful, including key-not-found.
+
+## Go Compatibility Metrics
+
+The `go-metrics-compat` feature records timer sums in milliseconds and event
+counts alongside the semantic histograms. These counters have the same four
+attributes as the semantic metrics.
+
+| Metric | Instrument | Unit | Description |
+| --- | --- | --- | --- |
+| `oxia_client_op_sum` | `f64` counter | `ms` | Sum of logical operation durations. |
+| `oxia_client_op_count` | `u64` counter | `1` | Number of logical operation duration samples. |
+| `oxia_client_batch_total_sum` | `f64` counter | `ms` | Sum of total per-shard batch durations. |
+| `oxia_client_batch_total_count` | `u64` counter | `1` | Number of total per-shard batch duration samples. |
+| `oxia_client_batch_exec_sum` | `f64` counter | `ms` | Sum of per-shard batch execution durations. |
+| `oxia_client_batch_exec_count` | `u64` counter | `1` | Number of per-shard batch execution duration samples. |
+
+The compatibility feature does not add equivalents for operation size, batch
+size, or batch request count.


### PR DESCRIPTION
Add client operation tracing spans, opt-in metrics collection
Instrument client connection and logical get, batch-get, put, delete,
delete-range, list, and range-scan operations with INFO tracing spans.
Record the Oxia system and namespace, operation name, selected
single-shard ID, and returned error type without exposing keys, values,
or range bounds.

Add the opt-in metrics feature and Config support for a caller-provided
OpenTelemetry MeterProvider, falling back to the global provider. Record
operation duration for every logical database operation and value size
for get, put, and range-scan results, with bounded operation and result
attributes.

Record per-shard read and write batch total duration, RPC execution
duration through the first streamed response, value bytes, and request
count. Classify key-not-found reads as successful, validate batch
response counts and per-key results, and record batch-get stream failure
on item errors or early drop.

Add go-metrics-compat timer sum/count counters in milliseconds, while
retaining the semantic histogram instruments. Extend oxia-cmd with
caller-owned SDK setup, exponential-histogram views, and text,
OTLP/JSON, and OTLP/Protobuf export formats.

See docs/instrumentation.md for details

Created with assistance from OpenAI Codex (GPT-5.5).