### PR TITLE
Refactor client retry timeout helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ CI uses `--release --frozen`. Local commands can omit those flags.
 - **API**: `Client` is a concrete struct, not a trait object, with `put(key, value)` and `put_with_options(...)`. Uses zero-cost abstractions.
 - **Sharding**: XXHASH3 routing; dynamic via `shard.rs`.
 - **Pooling**: `pool.rs` per-shard gRPC; `ArcSwap` caches.
+- **Retry/Timeouts**: `lib.rs::execute_with_retry` owns client-level retry orchestration. Keep the first attempt explicit, preserve stale-shard-map retry handling, and use `util::with_retry_timeout` for transient retries. Use `Client::execute_on_shard` for per-shard client operations instead of open-coding retry wrappers in public method internals.
 - **Notifications**: Streaming key changes.
 - **Protos**: Automatically generated from `./ext/oxia/common/proto`. No manual edits are allowed to generated files or protos.
 - **Tests**: Spawn local servers via `client/tests/common.rs`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ CI uses `--release --frozen`. Local commands can omit those flags.
 - **Clippy**: Strict workspace Cargo.toml settings must be followed.
 - **Imports**: Prefer unmerged `use` statements (one item per line). Do not merge imports (e.g. avoid `use std::{foo, bar};`).
 - **Docs**: Terse, idiomatic Rust API guidelines; prefer `const fn` when possible.
+- **Formatting**: Use `just fmt`, or run `rustfmt` with nightly; stable `cargo fmt` does not honor the repository's unstable import formatting settings.
 - **GitHub**: Submit changes via Draft PRs; push with `--force-with-lease`; always verify clippy and tests locally before pushing. Ignore local `main`.
 
 ## Dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ CI uses `--release --frozen`. Local commands can omit those flags.
 - **Imports**: Prefer unmerged `use` statements (one item per line). Do not merge imports (e.g. avoid `use std::{foo, bar};`).
 - **Docs**: Terse, idiomatic Rust API guidelines; prefer `const fn` when possible.
 - **Formatting**: Use `just fmt`, or run `rustfmt` with nightly; stable `cargo fmt` does not honor the repository's unstable import formatting settings.
+- **Commit messages**: Wrap descriptive text at 72 characters
 - **GitHub**: Submit changes via Draft PRs; push with `--force-with-lease`; always verify clippy and tests locally before pushing. Ignore local `main`.
 
 ## Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -509,7 +509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -916,11 +916,11 @@ dependencies = [
 
 [[package]]
 name = "is_executable"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1138,7 +1138,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1581,7 +1581,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1608,7 +1608,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1736,7 +1736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1772,7 +1772,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1849,7 +1849,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2237,7 +2237,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2301,86 +2301,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,7 +1044,7 @@ dependencies = [
  "futures",
  "getrandom 0.4.2",
  "http",
- "itertools",
+ "itertools 0.15.0",
  "mauricebarnum-oxia-common",
  "nix",
  "opentelemetry",
@@ -1382,7 +1391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -1403,7 +1412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -43,7 +43,7 @@ test-log = { version = "0.2.21", features = ["trace", "color"] }
 oxia-bin-util = { path = "../oxia-bin-util" }
 tempfile = "3.27.0"
 anyhow = "1.0.102"
-itertools = "0.14.0"
+itertools = "0.15.0"
 nix = { version = "0.31", default-features = false, features = ["signal"] }
 opentelemetry_sdk = { version = "0.32.1", default-features = false, features = [
     "metrics",

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -20,8 +20,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
 use std::time::Duration;
-use std::time::Instant;
 
+use backon::FibonacciBuilder;
+use backon::Retryable;
 use bon::Builder;
 use bytes::Bytes;
 use futures::stream::StreamExt;
@@ -745,18 +746,23 @@ const fn extract_leader_hint(e: &Error) -> Option<&LeaderHint> {
     }
 }
 
-fn remaining_timeout(
-    request_timeout: Option<Duration>,
-    start: Option<Instant>,
-) -> Option<Duration> {
-    request_timeout
-        .zip(start)
-        .map(|(timeout, started)| timeout.saturating_sub(started.elapsed()))
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RetrySafety {
+    Idempotent,
+    NonIdempotent,
+}
+
+impl RetrySafety {
+    #[inline]
+    fn should_retry(self, error: &Error) -> bool {
+        error.is_retryable() || matches!((self, error), (Self::Idempotent, Error::RequestTimeout))
+    }
 }
 
 pub(crate) async fn execute_with_retry<F, Fut, R>(
     config: &Arc<config::Config>,
     shard_manager: Option<&Arc<shard::Manager>>,
+    retry_safety: RetrySafety,
     op: F,
 ) -> Result<R>
 where
@@ -765,47 +771,49 @@ where
     F: Fn() -> Fut + Send + Sync,
 {
     let timeout = config.request_timeout();
-    let retry_config = config.retry();
-    let start = if (retry_config.is_some() || config.retry_on_stale_shard_map())
-        && timeout.unwrap_or_default() > Duration::ZERO
-    {
-        Some(Instant::now())
-    } else {
-        None
-    };
+    util::with_timeout(timeout, async {
+        let result = op().await;
 
-    let result = util::with_timeout(timeout, op()).await;
+        // Happy path: call just worked
+        if result.is_ok() {
+            return result;
+        }
 
-    // Happy path: call just worked
-    if result.is_ok() {
-        return result;
-    }
+        // Something went wrong.  We'll enter the retry path now if we're confident that
+        // the operation can be retried safely.  Unconditional writes, for example,
+        // shouldn't be retried upon a timeout since we don't know if the previous write
+        // was applied or not.
+        if let Err(ref error) = result
+            && !retry_safety.should_retry(error)
+        {
+            return result;
+        }
 
-    // Or... our time budget was consumed, and we're done
-    if matches!(&result, Err(Error::RequestTimeout)) {
-        return result;
-    }
+        // Stale shard map: refresh and retry before falling through to transient retry
+        if config.retry_on_stale_shard_map()
+            && let Some(sm) = shard_manager
+            && let Err(ref e) = result
+            && e.is_wrong_leader()
+        {
+            let hint = extract_leader_hint(e).cloned();
+            return stale_shard_map_retry(config, sm, hint, &op).await;
+        }
 
-    // Stale shard map: refresh and retry before falling through to transient retry
-    if config.retry_on_stale_shard_map()
-        && let Some(sm) = shard_manager
-        && let Err(ref e) = result
-        && e.is_wrong_leader()
-    {
-        let hint = extract_leader_hint(e).cloned();
-        return stale_shard_map_retry(config, sm, start, hint, &op).await;
-    }
+        let Some(retry_config) = config.retry() else {
+            return result;
+        };
 
-    // Or... no retries are requested
-    if retry_config.is_none() {
-        return result;
-    }
+        let backoff = FibonacciBuilder::default()
+            .with_min_delay(retry_config.initial_delay)
+            .with_max_delay(retry_config.max_delay)
+            .with_max_times(retry_config.attempts)
+            .with_jitter();
 
-    // Account for the time we've used so far for the next round of retries
-    let timeout = remaining_timeout(timeout, start);
-
-    let retry_op = move || op();
-    util::with_timeout(timeout, util::with_retry(retry_config, retry_op)).await
+        op.retry(backoff)
+            .when(|e: &Error| retry_safety.should_retry(e))
+            .await
+    })
+    .await
 }
 
 /// Retry loop for stale shard map (wrong leader) errors.
@@ -815,11 +823,10 @@ where
 /// from the retry result, or fall back to the slow path when no hint is available.
 ///
 /// Each slow-path iteration: capture epoch → trigger refresh → wait for update → retry op.
-/// Bounded by retry attempts (or 1 if no retry config) and the overall request timeout.
+/// Bounded by retry attempts (or 1 if no retry config) and the outer request timeout.
 async fn stale_shard_map_retry<F, Fut, R>(
     config: &Arc<config::Config>,
     shard_manager: &Arc<shard::Manager>,
-    start: Option<Instant>,
     initial_hint: Option<LeaderHint>,
     op: F,
 ) -> Result<R>
@@ -829,17 +836,14 @@ where
     F: Fn() -> Fut + Send + Sync,
 {
     let max_attempts = config.retry().map_or(1, |r| r.attempts);
-    let request_timeout = config.request_timeout();
+    let wait_timeout = config
+        .request_timeout()
+        .filter(|timeout| *timeout > Duration::ZERO)
+        .unwrap_or(Duration::from_secs(30));
 
     let mut hint = initial_hint;
 
     for _ in 0..max_attempts {
-        // Check remaining time budget
-        let remaining = remaining_timeout(request_timeout, start);
-        if matches!(remaining, Some(left) if left.is_zero()) {
-            return Err(Error::RequestTimeout);
-        }
-
         if let Some(ref h) = hint {
             // Fast path: leader hint known — apply immediately without waiting
             // apply_leader_hint also calls trigger_refresh internally
@@ -849,14 +853,10 @@ where
             let epoch = shard_manager.epoch();
             shard_manager.trigger_refresh();
 
-            // Wait for the shard map to update, using remaining timeout or a reasonable default
-            let wait_timeout = remaining.unwrap_or(Duration::from_secs(30));
             shard_manager.wait_for_update(epoch, wait_timeout).await?;
         }
 
-        // Retry the operation with remaining timeout
-        let remaining = remaining_timeout(request_timeout, start);
-        let result = util::with_timeout(remaining, op()).await;
+        let result = op().await;
 
         #[allow(clippy::match_same_arms)]
         match &result {
@@ -870,8 +870,7 @@ where
     }
 
     // Final attempt after exhausting retry budget
-    let remaining = remaining_timeout(request_timeout, start);
-    util::with_timeout(remaining, op()).await
+    op().await
 }
 
 #[derive(Clone, Debug)]
@@ -990,6 +989,26 @@ impl Client {
         self.get_shard_manager()?.get_client_by_shard_id(id)
     }
 
+    async fn execute_on_shard<F, Fut, R>(
+        &self,
+        shard: shard::Client,
+        retry_safety: RetrySafety,
+        op: F,
+    ) -> Result<R>
+    where
+        Fut: Future<Output = Result<R>> + Send,
+        R: Send,
+        F: Fn(shard::Client) -> Fut + Send + Sync,
+    {
+        execute_with_retry(
+            &self.config,
+            self.shard_manager.as_ref(),
+            retry_safety,
+            move || op(shard.clone()),
+        )
+        .await
+    }
+
     #[inline]
     pub fn get(&self, k: impl Into<String>) -> impl Future<Output = Result<Option<GetResponse>>> {
         self.get_with_options(k, GetOptions::default())
@@ -1024,17 +1043,13 @@ impl Client {
     ) -> Result<Option<GetResponse>> {
         let start = metrics::operation_start();
         let result = async {
-            // Define the core operation with retry/timeout wrapper
-            let execute_get =
-                |shard: shard::Client, key: Arc<str>, options: GetOptions| async move {
-                    execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                        let shard = shard.clone();
-                        let key = Arc::clone(&key);
-                        let options = options.clone();
-                        async move { shard.get(&key, &options).await }
-                    })
-                    .await
-                };
+            let execute_get = |shard, key: Arc<str>, options: GetOptions| {
+                self.execute_on_shard(shard, RetrySafety::Idempotent, move |shard| {
+                    let key = Arc::clone(&key);
+                    let options = options.clone();
+                    async move { shard.get(&key, &options).await }
+                })
+            };
 
             // Single shard case: exact match with partition key OR exact match without secondary index
             let use_single_shard = options.partition_key.is_some()
@@ -1045,7 +1060,7 @@ impl Client {
                 let selector = options.partition_key.as_deref().unwrap_or(&key);
                 let shard = self.get_shard(selector)?;
                 tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
-                return execute_get(shard, key, options).await;
+                return execute_get(shard, Arc::clone(&key), options.clone()).await;
             }
 
             // Multi-shard case: query all shards and select the best response
@@ -1061,9 +1076,11 @@ impl Client {
                     Ok(match response {
                         Some(candidate) => Some(match best {
                             None => candidate,
-                            Some(prev) => {
-                                util::select_response(Some(prev), candidate, options.comparison_type)
-                            }
+                            Some(prev) => util::select_response(
+                                Some(prev),
+                                candidate,
+                                options.comparison_type,
+                            ),
                         }),
                         None => best,
                     })
@@ -1203,8 +1220,9 @@ impl Client {
             let selector = options.partition_key.as_deref().unwrap_or(&key);
             let shard = self.get_shard(selector)?;
             tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
+            // TODO: inspect PutOptions and retry timeouts when the request is provably
+            // idempotent, such as a put constrained by an expected version.
+            self.execute_on_shard(shard, RetrySafety::NonIdempotent, move |shard| {
                 let key = Arc::clone(&key);
                 let value = value.clone();
                 let options = options.clone();
@@ -1257,8 +1275,9 @@ impl Client {
             let selector = options.partition_key.as_deref().unwrap_or(&key);
             let shard = self.get_shard(selector)?;
             tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
-            execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                let shard = shard.clone();
+            // TODO: inspect DeleteOptions and retry timeouts when the request is provably
+            // idempotent, such as a delete constrained by an expected version.
+            self.execute_on_shard(shard, RetrySafety::NonIdempotent, move |shard| {
                 let key = Arc::clone(&key);
                 let options = options.clone();
                 async move { shard.delete(&key, &options).await }
@@ -1324,18 +1343,18 @@ impl Client {
     ) -> Result<()> {
         let start = metrics::operation_start();
         let result = async {
-            let do_delete_range = |shard: shard::Client,
-                                   start: Arc<str>,
-                                   end: Arc<str>,
-                                   options: DeleteRangeOptions| async move {
-                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                    let shard = shard.clone();
-                    let start = Arc::clone(&start);
-                    let end = Arc::clone(&end);
+            // TODO: inspect DeleteRangeOptions and retry timeouts when the request is
+            // provably idempotent.
+            let do_delete_range = |shard,
+                                   start_inclusive: Arc<str>,
+                                   end_exclusive: Arc<str>,
+                                   options: DeleteRangeOptions| {
+                self.execute_on_shard(shard, RetrySafety::NonIdempotent, move |shard| {
+                    let start = Arc::clone(&start_inclusive);
+                    let end = Arc::clone(&end_exclusive);
                     let options = options.clone();
                     async move { shard.delete_range(&start, &end, &options).await }
                 })
-                .await
             };
 
             if let Some(shard) = {
@@ -1348,7 +1367,13 @@ impl Client {
                 }
             } {
                 tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
-                return do_delete_range(shard, start_inclusive, end_exclusive, options).await;
+                return do_delete_range(
+                    shard,
+                    Arc::clone(&start_inclusive),
+                    Arc::clone(&end_exclusive),
+                    options.clone(),
+                )
+                .await;
             }
 
             let n = match self.config.max_parallel_requests() {
@@ -1438,24 +1463,28 @@ impl Client {
     ) -> Result<ListResponse> {
         let start = metrics::operation_start();
         let result = async {
-            let do_list = |shard: shard::Client,
-                           start: Arc<str>,
-                           end: Arc<str>,
-                           options: ListOptions| async move {
-                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                    let shard = shard.clone();
-                    let start = Arc::clone(&start);
-                    let end = Arc::clone(&end);
+            let do_list = |shard,
+                           start_inclusive: Arc<str>,
+                           end_exclusive: Arc<str>,
+                           options: ListOptions| {
+                self.execute_on_shard(shard, RetrySafety::Idempotent, move |shard| {
+                    let start = Arc::clone(&start_inclusive);
+                    let end = Arc::clone(&end_exclusive);
                     let options = options.clone();
                     async move { shard.list(&start, &end, &options).await }
                 })
-                .await
             };
 
             if let Some(pk) = options.partition_key.as_deref() {
                 let shard = self.get_shard(pk)?;
                 tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
-                return do_list(shard, start_inclusive, end_exclusive, options).await;
+                return do_list(
+                    shard,
+                    Arc::clone(&start_inclusive),
+                    Arc::clone(&end_exclusive),
+                    options.clone(),
+                )
+                .await;
             }
 
             let n = match self.config.max_parallel_requests() {
@@ -1547,24 +1576,28 @@ impl Client {
     ) -> Result<RangeScanResponse> {
         let start = metrics::operation_start();
         let result = async {
-            let do_range_scan = |shard: shard::Client,
-                                 start: Arc<str>,
-                                 end: Arc<str>,
-                                 options: RangeScanOptions| async move {
-                execute_with_retry(&self.config, self.shard_manager.as_ref(), move || {
-                    let shard = shard.clone();
-                    let start = Arc::clone(&start);
-                    let end = Arc::clone(&end);
+            let do_range_scan = |shard,
+                                 start_inclusive: Arc<str>,
+                                 end_exclusive: Arc<str>,
+                                 options: RangeScanOptions| {
+                self.execute_on_shard(shard, RetrySafety::Idempotent, move |shard| {
+                    let start = Arc::clone(&start_inclusive);
+                    let end = Arc::clone(&end_exclusive);
                     let options = options.clone();
                     async move { shard.range_scan(&start, &end, &options).await }
                 })
-                .await
             };
 
             if let Some(pk) = options.partition_key.as_deref() {
                 let shard = self.get_shard(pk)?;
                 tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
-                return do_range_scan(shard, start_inclusive, end_exclusive, options).await;
+                return do_range_scan(
+                    shard,
+                    Arc::clone(&start_inclusive),
+                    Arc::clone(&end_exclusive),
+                    options.clone(),
+                )
+                .await;
             }
 
             let n = match self.config.max_parallel_requests() {
@@ -1634,7 +1667,158 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+
     use super::*;
+
+    const RETRIES: usize = 3;
+    const EXPECTED_RETRYABLE_CALLS: usize = RETRIES + 2;
+    const EXPECTED_IDEMPOTENT_TIMEOUT_CALLS: usize = RETRIES + 2;
+
+    #[test_log::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn execute_with_retry_retries_retryable_errors() -> Result<()> {
+        let config = config::Config::builder()
+            .service_addr("localhost:1234")
+            .retry(config::RetryConfig::new(RETRIES, Duration::from_millis(1)))
+            .build();
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let result = execute_with_retry(&config, None, RetrySafety::NonIdempotent, {
+            let count = Arc::clone(&count);
+            move || {
+                let count = Arc::clone(&count);
+                async move {
+                    count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Err::<(), _>(Error::Io(
+                        io::Error::new(io::ErrorKind::ConnectionReset, "").into(),
+                    ))
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            EXPECTED_RETRYABLE_CALLS,
+            count.load(std::sync::atomic::Ordering::Relaxed)
+        );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn execute_with_retry_retries_request_timeout_for_idempotent_ops() -> Result<()> {
+        let config = config::Config::builder()
+            .service_addr("localhost:1234")
+            .retry(config::RetryConfig::new(RETRIES, Duration::from_millis(1)))
+            .build();
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let result = execute_with_retry(&config, None, RetrySafety::Idempotent, {
+            let count = Arc::clone(&count);
+            move || {
+                let count = Arc::clone(&count);
+                async move {
+                    count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Err::<(), _>(Error::RequestTimeout)
+                }
+            }
+        })
+        .await;
+
+        assert!(matches!(result, Err(Error::RequestTimeout)));
+        assert_eq!(
+            EXPECTED_IDEMPOTENT_TIMEOUT_CALLS,
+            count.load(std::sync::atomic::Ordering::Relaxed)
+        );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn execute_with_retry_does_not_retry_request_timeout_for_non_idempotent_ops() -> Result<()>
+    {
+        let config = config::Config::builder()
+            .service_addr("localhost:1234")
+            .retry(config::RetryConfig::new(3, Duration::from_millis(1)))
+            .build();
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let result = execute_with_retry(&config, None, RetrySafety::NonIdempotent, {
+            let count = Arc::clone(&count);
+            move || {
+                let count = Arc::clone(&count);
+                async move {
+                    count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Err::<(), _>(Error::RequestTimeout)
+                }
+            }
+        })
+        .await;
+
+        assert!(matches!(result, Err(Error::RequestTimeout)));
+        assert_eq!(1, count.load(std::sync::atomic::Ordering::Relaxed));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn execute_with_retry_without_retry_config_runs_once() -> Result<()> {
+        let config = config::Config::builder()
+            .service_addr("localhost:1234")
+            .build();
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let result = execute_with_retry(&config, None, RetrySafety::NonIdempotent, {
+            let count = Arc::clone(&count);
+            move || {
+                let count = Arc::clone(&count);
+                async move {
+                    count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Err::<(), _>(Error::Io(
+                        io::Error::new(io::ErrorKind::ConnectionReset, "").into(),
+                    ))
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(1, count.load(std::sync::atomic::Ordering::Relaxed));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    #[cfg_attr(miri, ignore)]
+    async fn execute_with_retry_timeout_bounds_retry_sequence() -> Result<()> {
+        let config = config::Config::builder()
+            .service_addr("localhost:1234")
+            .retry(config::RetryConfig::new(3, Duration::from_millis(50)))
+            .request_timeout(Duration::from_millis(10))
+            .build();
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let result = execute_with_retry(&config, None, RetrySafety::Idempotent, {
+            let count = Arc::clone(&count);
+            move || {
+                let count = Arc::clone(&count);
+                async move {
+                    count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    Err::<(), _>(Error::Io(
+                        io::Error::new(io::ErrorKind::ConnectionReset, "").into(),
+                    ))
+                }
+            }
+        })
+        .await;
+
+        assert!(matches!(result, Err(Error::RequestTimeout)));
+        assert_eq!(2, count.load(std::sync::atomic::Ordering::Relaxed));
+        Ok(())
+    }
 
     #[test]
     fn test_validate_dest() {

--- a/client/src/notification.rs
+++ b/client/src/notification.rs
@@ -233,10 +233,15 @@ impl NotificationsStream {
                     let config = Arc::clone(&config);
                     let offset = offsets.get(id);
                     async move {
-                        let r = crate::execute_with_retry(&config, None, move || {
-                            let client = client.clone();
-                            async move { client.get_notifications(offset).await }
-                        })
+                        let r = crate::execute_with_retry(
+                            &config,
+                            None,
+                            crate::RetrySafety::Idempotent,
+                            move || {
+                                let client = client.clone();
+                                async move { client.get_notifications(offset).await }
+                            },
+                        )
                         .await;
                         let s = StreamNotifyClose::new(match r {
                             Ok(s) => s.boxed(),
@@ -325,10 +330,15 @@ impl NotificationsStream {
                 Err(e) => return (id, Err(e)),
             };
 
-            let result = crate::execute_with_retry(&config, None, move || {
-                let client = client.clone();
-                async move { client.get_notifications(offset).await }
-            })
+            let result = crate::execute_with_retry(
+                &config,
+                None,
+                crate::RetrySafety::Idempotent,
+                move || {
+                    let client = client.clone();
+                    async move { client.get_notifications(offset).await }
+                },
+            )
             .await;
 
             match result {

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -1145,20 +1145,19 @@ impl Client {
 
     /// Gets a list with timeout handling
     #[allow(dead_code)]
-    pub(crate) async fn list_with_timeout(
+    async fn list_with_timeout(
         &self,
         start_inclusive: &str,
         end_exclusive: &str,
         opts: &ListOptions,
         timeout: Duration,
     ) -> Result<ListResponse> {
-        // Apply timeout to the list operation
-        match tokio::time::timeout(timeout, self.list(start_inclusive, end_exclusive, opts)).await {
-            Ok(result) => result,
-            Err(_) => Err(Error::Custom(format!(
-                "List request timed out after {timeout:?}"
-            ))),
-        }
+        // Experimental placeholder for shard-local timeout handling.
+        crate::util::with_timeout(
+            Some(timeout),
+            self.list(start_inclusive, end_exclusive, opts),
+        )
+        .await
     }
 
     /// Scans for records in the given range with options

--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -16,12 +16,8 @@ use std::cmp::Ordering;
 use std::future::Future;
 use std::time::Duration;
 
-use backon::FibonacciBuilder;
-use backon::Retryable;
-
 use crate::Error;
 use crate::Result;
-use crate::config;
 
 pub async fn with_timeout<T, Fut>(timeout: Option<Duration>, fut: Fut) -> Result<T>
 where
@@ -32,27 +28,6 @@ where
             .await
             .map_err(|_| Error::RequestTimeout)?,
         _ => fut.await,
-    }
-}
-
-pub async fn with_retry<T, F, Fut>(retry_config: Option<config::RetryConfig>, mut f: F) -> Result<T>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Result<T>>,
-{
-    match retry_config {
-        Some(rc) => {
-            let backoff = FibonacciBuilder::default()
-                .with_min_delay(rc.initial_delay)
-                .with_max_delay(rc.max_delay)
-                .with_max_times(rc.attempts)
-                .with_jitter();
-            (|| f())
-                .retry(&backoff)
-                .when(|e: &Error| e.is_retryable())
-                .await
-        }
-        None => f().await,
     }
 }
 
@@ -159,14 +134,10 @@ pub fn select_response(
 #[allow(clippy::too_many_lines)]
 mod tests {
     use std::cmp::Ordering;
-    use std::io;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicUsize;
 
     use itertools::Itertools;
 
     use super::*;
-    use crate::config::RetryConfig;
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
@@ -181,42 +152,6 @@ mod tests {
             Err(Error::RequestTimeout) => Ok(()),
             _ => Err(Error::Custom(format!("unexpected result {r:?}"))),
         }
-    }
-
-    #[test_log::test(tokio::test)]
-    #[cfg_attr(miri, ignore)]
-    #[allow(clippy::items_after_statements)]
-    async fn test_with_retry() -> Result<()> {
-        const RETRIES: usize = 3;
-        const EXPECTED: usize = RETRIES + 2;
-
-        let retry = Some(RetryConfig::new(RETRIES, Duration::from_millis(1)));
-        let count = Arc::new(AtomicUsize::new(0));
-
-        let funcs = [
-            || -> Result<()> {
-                Err(Error::Io(
-                    io::Error::new(io::ErrorKind::ConnectionReset, "").into(),
-                ))
-            },
-            || -> Result<()> { Err(Error::RequestTimeout) },
-        ];
-        for f in funcs {
-            let r = with_retry(retry, {
-                let count = Arc::clone(&count);
-                move || {
-                    let count = Arc::clone(&count);
-                    async move {
-                        count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        f()
-                    }
-                }
-            })
-            .await;
-            assert!(r.is_err());
-        }
-        assert_eq!(EXPECTED, count.load(std::sync::atomic::Ordering::Relaxed));
-        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
- **chore(deps): update rust crate itertools to 0.15.0**
- **Refactor client retry timeout helpers**
- **tell agents to format with nightly**
- **tell agents to keep commit message lines shorter**
