### PR TITLE
Bake CI profile artifacts into build image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,13 +5,27 @@ on:
     branches: ["main"]
     paths:
       - "build/Dockerfile"
-      - ".github/workflows/docker-image.yml"
-  pull_request:
-    paths:
-      - ".github/workflows/docker-image.yml"
-      - "build/Dockerfile"
+      - "build/Dockerfile.dockerignore"
+      - "build/cargo-config.toml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "*/Cargo.toml"
       - "ext/oxia.version"
       - "ext/oxia/**"
+      - ".github/workflows/docker-image.yml"
+      - ".github/workflows/rust-build.yml"
+  pull_request:
+    paths:
+      - "build/Dockerfile"
+      - "build/Dockerfile.dockerignore"
+      - "build/cargo-config.toml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "*/Cargo.toml"
+      - "ext/oxia.version"
+      - "ext/oxia/**"
+      - ".github/workflows/docker-image.yml"
+      - ".github/workflows/rust-build.yml"
   workflow_dispatch:
   schedule:
     - cron: "13 3 6 * *" # monthly
@@ -63,6 +77,7 @@ jobs:
     with:
       image: ghcr.io/${{ github.repository }}/rust-build:sha-${{ github.sha }}
       build_mode: ci
+      diagnose_build_fingerprints: true
     secrets: inherit
 
   tag-latest:

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       build_mode:
-        description: "Build mode: auto, ci, ci-debug, ci-test-release, or debug"
+        description: "Build mode: auto, ci, ci-debug, or debug"
         required: false
         default: "auto"
         type: string
@@ -75,10 +75,6 @@ jobs:
             echo "CARGO_PROFILE=ci-debug" >> $GITHUB_ENV
             echo "RELEASE_FLAG=--profile ci-debug" >> $GITHUB_ENV
             echo "NEXTEST_FLAG=--cargo-profile ci-debug" >> $GITHUB_ENV
-          elif [ "$BUILD_MODE" = "ci-test-release" ]; then
-            echo "CARGO_PROFILE=ci-test-release" >> $GITHUB_ENV
-            echo "RELEASE_FLAG=--profile ci-test-release" >> $GITHUB_ENV
-            echo "NEXTEST_FLAG=--cargo-profile ci-test-release" >> $GITHUB_ENV
           elif [ "$EVENT" = "pull_request" ]; then
             # Auto mode: ci-debug for PRs
             echo "CARGO_PROFILE=ci-debug" >> $GITHUB_ENV
@@ -140,7 +136,6 @@ jobs:
         run: cargo nextest run $NEXTEST_FLAG --frozen --features metrics --no-fail-fast --verbose
 
       - name: doc-test
-        if: env.CARGO_PROFILE == 'ci-test-release'
         run: cargo test --doc $RELEASE_FLAG --frozen --verbose
 
       - name: miri-client

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: ""
         type: string
+      diagnose_build_fingerprints:
+        description: "Emit Cargo fingerprint diagnostics for the cargo build step"
+        required: false
+        default: false
+        type: boolean
       caller_event_name:
         description: "Event name from caller (used for auto build_mode PR detection)"
         required: false
@@ -53,14 +58,55 @@ jobs:
       - name: checkout
         uses: actions/checkout@v7
 
+      - name: normalize-workspace-path
+        run: |
+          repo_name="${GITHUB_REPOSITORY##*/}"
+          workflow_workspace="/__w/${repo_name}/${repo_name}"
+          if [ -z "$repo_name" ] || [ "$workflow_workspace" = "/__w//" ]; then
+            echo "Unable to determine GitHub workspace path" >&2
+            exit 1
+          fi
+          if [ "$PWD" != "$workflow_workspace" ]; then
+            mkdir -p "$(dirname "$workflow_workspace")"
+            rm -rf "$workflow_workspace"
+            mkdir -p "$workflow_workspace"
+            cp -a "$PWD/." "$workflow_workspace/"
+          fi
+          echo "WORKFLOW_WORKSPACE=$workflow_workspace" >> "$GITHUB_ENV"
+
+      - name: normalize-build-script-mtimes
+        run: |
+          cd "$WORKFLOW_WORKSPACE"
+          manifest=/root/deps/build-rs.sha256
+          if [ ! -f "$manifest" ]; then
+            exit 0
+          fi
+
+          # Cargo fingerprints compare build script source mtimes against the
+          # baked target artifacts. A fresh checkout gives unchanged build.rs
+          # files newer mtimes, so backdate only files that match the image.
+          while read -r expected path; do
+            path=${path#./}
+            if [ ! -f "$path" ]; then
+              continue
+            fi
+            actual=$(sha256sum "$path" | cut -d ' ' -f1)
+            if [ "$actual" = "$expected" ]; then
+              touch -d '@1' "$path"
+            fi
+          done < "$manifest"
+
       - name: cargo-deny
-        run: cargo deny check
+        run: |
+          cd "$WORKFLOW_WORKSPACE"
+          cargo deny check
 
       - name: set-build-profile
         env:
           BUILD_MODE_INPUT: ${{ inputs.build_mode }}
           EVENT_INPUT: ${{ inputs.caller_event_name || github.event_name }}
         run: |
+          cd "$WORKFLOW_WORKSPACE"
           BUILD_MODE="$BUILD_MODE_INPUT"
           EVENT="$EVENT_INPUT"
           if [ "$BUILD_MODE" = "ci" ]; then
@@ -89,7 +135,9 @@ jobs:
           echo "Build mode: $BUILD_MODE, Event: $EVENT, Profile: $CARGO_PROFILE"
 
       - name: Compute rustc hash
-        run: echo "RUSTC_HASH=$(rustc --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        run: |
+          cd "$WORKFLOW_WORKSPACE"
+          echo "RUSTC_HASH=$(rustc --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
 
       - name: enable-sccache
         uses: actions/cache@v5
@@ -110,6 +158,7 @@ jobs:
       - name: detect-vendored-build
         id: vendored
         run: |
+          cd "$WORKFLOW_WORKSPACE"
           vendored=false
           if [ -f .cargo/config.toml ] && grep -q 'vendored-sources' .cargo/config.toml; then
             vendored=true
@@ -119,38 +168,47 @@ jobs:
       - name: fetch-dependencies
         if: steps.vendored.outputs.vendored == 'false'
         run: |
+          cd "$WORKFLOW_WORKSPACE"
           cargo update --dry-run --verbose # update crate index
           cargo fetch --locked   # fetch dependencies: last network dependency
 
       - name: build
-        run: cargo build $RELEASE_FLAG --frozen --all-targets --features metrics
+        env:
+          CARGO_LOG: ${{ inputs.diagnose_build_fingerprints && 'cargo::core::compiler::fingerprint=info' || '' }}
+        run: |
+          cd "$WORKFLOW_WORKSPACE"
+          cargo build $RELEASE_FLAG --frozen --all-targets --features metrics
 
       - name: clippy
-        run: cargo clippy $RELEASE_FLAG --no-deps --frozen --all-targets --features metrics -- -D warnings
+        run: |
+          cd "$WORKFLOW_WORKSPACE"
+          cargo clippy $RELEASE_FLAG --no-deps --frozen --all-targets --features metrics -- -D warnings
 
       - name: check-external-types
-        run: cd client && cargo +"$RUST_VERSION_EXTERNAL_TYPES" check-external-types --all-features
+        run: |
+          cd "$WORKFLOW_WORKSPACE/client"
+          cargo +"$RUST_VERSION_EXTERNAL_TYPES" check-external-types --all-features
 
       - name: test
         timeout-minutes: 15 # release builds may be slower
-        run: cargo nextest run $NEXTEST_FLAG --frozen --features metrics --no-fail-fast --verbose
+        run: |
+          cd "$WORKFLOW_WORKSPACE"
+          cargo nextest run $NEXTEST_FLAG --frozen --features metrics --no-fail-fast --verbose
 
       - name: doc-test
-        run: cargo test --doc $RELEASE_FLAG --frozen --verbose
+        run: |
+          cd "$WORKFLOW_WORKSPACE"
+          cargo test --doc $RELEASE_FLAG --frozen --verbose
 
       - name: miri-client
         run: |
-          repo_name="${GITHUB_REPOSITORY##*/}"
-          workflow_workspace="/__w/${repo_name}/${repo_name}"
-          if [ "$PWD" != "$workflow_workspace" ]; then
-            mkdir -p "$(dirname "$workflow_workspace")"
-            ln -sfnT "$PWD" "$workflow_workspace"
-            cd "$workflow_workspace"
-          fi
+          cd "$WORKFLOW_WORKSPACE"
           unset RUSTC_WRAPPER
           cargo +nightly miri nextest run --package mauricebarnum-oxia-client --features metrics --frozen
         env:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation
 
       - name: show-sccache-stats
-        run: sccache --show-stats || true
+        run: |
+          cd "$WORKFLOW_WORKSPACE"
+          sccache --show-stats || true

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: enable-miri-cache
         uses: actions/cache@v5
         with:
-          path: /home/runner/deps/target/miri
+          path: /root/deps/target/miri
           key: miri-${{ runner.os }}-${{ env.RUSTC_HASH }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             miri-${{ runner.os }}-${{ env.RUSTC_HASH }}-
@@ -145,6 +145,13 @@ jobs:
 
       - name: miri-client
         run: |
+          repo_name="${GITHUB_REPOSITORY##*/}"
+          workflow_workspace="/__w/${repo_name}/${repo_name}"
+          if [ "$PWD" != "$workflow_workspace" ]; then
+            mkdir -p "$(dirname "$workflow_workspace")"
+            ln -sfnT "$PWD" "$workflow_workspace"
+            cd "$workflow_workspace"
+          fi
           unset RUSTC_WRAPPER
           cargo +nightly miri nextest run --package mauricebarnum-oxia-client --features metrics --frozen
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,8 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 # both contexts.  Concretely:
 #   - [profile.ci-debug] here must exactly match [profile.ci-debug] in Cargo.toml.
 #   - [profile.ci] here must exactly match [profile.ci] in Cargo.toml.
-#   - [profile.ci-test-release] here must exactly match [profile.ci-test-release] in Cargo.toml.
 #   - [profile.release] here must exactly match [profile.release] in Cargo.toml
-#     (because [profile.ci] and [profile.ci-test-release] inherit from it).
+#     (because [profile.ci] inherits from it).
 # Update both files together whenever you change a profile.
 
 # Goal: Fast compiles, but fast enough runtime to not be frustrated.
@@ -90,15 +89,3 @@ opt-level = 2              # Good optimization, faster compile than 3
 debug-assertions = true    # Catch bugs in CI
 overflow-checks = true     # Catch arithmetic bugs
 strip = "none"
-
-# Test-release: Full optimizations plus assertions for catching release-only bugs.
-# Must match workspace Cargo.toml
-[profile.ci-test-release]
-inherits = "release"
-debug = true            # Full debug info for accurate backtraces
-debug-assertions = true # Keep assertions enabled (critical for bug catching)
-overflow-checks = true  # Keep overflow checks
-lto = false             # LTO too slow for CI, optimizations not needed for tests
-codegen-units = 256     # Fast compilation
-incremental = false     # Enable sccache
-strip = "none"          # Keep symbols

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -103,7 +103,6 @@ RUN GH_WORKSPACE="/__w/${REPO_NAME}/${REPO_NAME}" && \
     cd "${GH_WORKSPACE}" && \
     cargo chef cook --profile ci-debug --all-targets --features metrics --recipe-path recipe.json && \
     cargo chef cook --profile ci --all-targets --features metrics --recipe-path recipe.json && \
-    cargo chef cook --profile ci-test-release --all-targets --features metrics --recipe-path recipe.json && \
     cargo fetch --locked && \
     cargo +nightly fetch --locked
 
@@ -145,7 +144,6 @@ COPY . /__w/${REPO_NAME}/${REPO_NAME}
 RUN cd /__w/${REPO_NAME}/${REPO_NAME} && \
     cargo build --profile ci-debug --all-targets --features metrics --frozen && \
     cargo build --profile ci --all-targets --features metrics --frozen && \
-    cargo build --profile ci-test-release --all-targets --features metrics --frozen && \
     rm -rf /__w/${REPO_NAME}/${REPO_NAME}
 
 WORKDIR ${HOME}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,7 @@ ARG HOME=/root
 ARG RUST_VERSION=1.96.0
 ARG RUST_VERSION_EXTERNAL_TYPES=nightly-2026-03-20
 ARG GO_VERSION=1.26.4
+ARG SCCACHE_DIR=/tmp/sccache
 
 # ===== 1. Pull Official Images =====
 FROM rust:${RUST_VERSION} AS rust-official
@@ -75,6 +76,7 @@ ARG REPO_NAME=oxia-rust
 ARG CARGO_HOME
 ARG RUSTUP_HOME
 ARG HOME
+ARG SCCACHE_DIR
 
 WORKDIR ${HOME}
 
@@ -87,6 +89,8 @@ ENV CARGO_HOME=${CARGO_HOME} \
     RUSTUP_HOME=${RUSTUP_HOME} \
     CARGO_TARGET_DIR=${HOME}/deps/target \
     RUSTC_WRAPPER=sccache \
+    SCCACHE_DIR=${SCCACHE_DIR} \
+    OXIA_BIN=${CARGO_HOME}/bin/oxia \
     PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:$PATH
 
 COPY build/cargo-config.toml ${CARGO_HOME}/config.toml
@@ -118,10 +122,15 @@ ARG CARGO_HOME
 ARG RUSTUP_HOME
 ARG RUST_VERSION_EXTERNAL_TYPES
 ARG HOME
+ARG REPO_NAME=oxia-rust
+ARG SCCACHE_DIR
 
 ENV CARGO_HOME=${CARGO_HOME} \
     RUSTUP_HOME=${RUSTUP_HOME} \
     CARGO_TARGET_DIR=${HOME}/deps/target \
+    RUSTC_WRAPPER=sccache \
+    SCCACHE_DIR=${SCCACHE_DIR} \
+    OXIA_BIN=${CARGO_HOME}/bin/oxia \
     RUST_VERSION_EXTERNAL_TYPES="${RUST_VERSION_EXTERNAL_TYPES}" \
     PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -131,5 +140,12 @@ COPY --from=rust-cooker ${RUSTUP_HOME} ${RUSTUP_HOME}
 COPY --from=rust-cooker ${HOME}/deps ${HOME}/deps
 COPY --from=go-official /usr/local/go /usr/local/go
 COPY --from=go-builder /tmp/oxia ${CARGO_HOME}/bin/oxia
+
+COPY . /__w/${REPO_NAME}/${REPO_NAME}
+RUN cd /__w/${REPO_NAME}/${REPO_NAME} && \
+    cargo build --profile ci-debug --all-targets --features metrics --frozen && \
+    cargo build --profile ci --all-targets --features metrics --frozen && \
+    cargo build --profile ci-test-release --all-targets --features metrics --frozen && \
+    rm -rf /__w/${REPO_NAME}/${REPO_NAME}
 
 WORKDIR ${HOME}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -142,8 +142,14 @@ COPY --from=go-builder /tmp/oxia ${CARGO_HOME}/bin/oxia
 
 COPY . /__w/${REPO_NAME}/${REPO_NAME}
 RUN cd /__w/${REPO_NAME}/${REPO_NAME} && \
+    find . -name build.rs -type f -print0 | sort -z | xargs -0 sha256sum > "${HOME}/deps/build-rs.sha256" && \
     cargo build --profile ci-debug --all-targets --features metrics --frozen && \
+    cargo clippy --profile ci-debug --no-deps --all-targets --features metrics --frozen -- -D warnings && \
     cargo build --profile ci --all-targets --features metrics --frozen && \
+    cargo clippy --profile ci --no-deps --all-targets --features metrics --frozen -- -D warnings && \
+    cd client && \
+    cargo +"${RUST_VERSION_EXTERNAL_TYPES}" check-external-types --all-features && \
+    cd .. && \
     unset RUSTC_WRAPPER && \
     MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" \
     cargo +nightly miri nextest run --package mauricebarnum-oxia-client --features metrics --frozen && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -144,6 +144,9 @@ COPY . /__w/${REPO_NAME}/${REPO_NAME}
 RUN cd /__w/${REPO_NAME}/${REPO_NAME} && \
     cargo build --profile ci-debug --all-targets --features metrics --frozen && \
     cargo build --profile ci --all-targets --features metrics --frozen && \
+    unset RUSTC_WRAPPER && \
+    MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation" \
+    cargo +nightly miri nextest run --package mauricebarnum-oxia-client --features metrics --frozen && \
     rm -rf /__w/${REPO_NAME}/${REPO_NAME}
 
 WORKDIR ${HOME}

--- a/build/Dockerfile.dockerignore
+++ b/build/Dockerfile.dockerignore
@@ -1,12 +1,21 @@
 # Ignore everything by default
 **
 
-# Allow Cargo manifests (sufficient for cargo-chef prepare; no source stubs needed)
+# Allow Cargo manifests for cargo-chef prepare
 !**/Cargo.toml
 !Cargo.lock
 
 # Allow build files (Dockerfile and any supporting scripts in build/)
 !build/**
 
-# Include oxia go source tree
+# Include source needed to prebuild the real Rust workspace graph
+!common/**
+!client/**
+!cmd/**
+!oxia-bin-util/**
+
+# Include vendored proto and Go source trees
+!ext/
+!ext/*.version
 !ext/oxia/**
+!ext/google-protos/**

--- a/build/cargo-config.toml
+++ b/build/cargo-config.toml
@@ -9,9 +9,8 @@
 # both contexts.  Concretely:
 #   - [profile.ci-debug] here must exactly match [profile.ci-debug] in Cargo.toml.
 #   - [profile.ci] here must exactly match [profile.ci] in Cargo.toml.
-#   - [profile.ci-test-release] here must exactly match [profile.ci-test-release] in Cargo.toml.
 #   - [profile.release] here must exactly match [profile.release] in Cargo.toml
-#     (because [profile.ci] and [profile.ci-test-release] inherit from it).
+#     (because [profile.ci] inherits from it).
 # Update both files together whenever you change a profile.
 
 # Goal: Fast compiles, but fast enough runtime to not be frustrated.
@@ -62,15 +61,3 @@ opt-level = 2              # Good optimization, faster compile than 3
 debug-assertions = true    # Catch bugs in CI
 overflow-checks = true     # Catch arithmetic bugs
 strip = "none"
-
-# Test-release: Full optimizations plus assertions for catching release-only bugs.
-# Must match workspace Cargo.toml
-[profile.ci-test-release]
-inherits = "release"
-debug = true            # Full debug info for accurate backtraces
-debug-assertions = true # Keep assertions enabled (critical for bug catching)
-overflow-checks = true  # Keep overflow checks
-lto = false             # LTO too slow for CI, optimizations not needed for tests
-codegen-units = 256     # Fast compilation
-incremental = false     # Enable sccache
-strip = "none"          # Keep symbols


### PR DESCRIPTION
Prebuild the real workspace targets for ci-debug, ci, and ci-test-release in the final image stage so fresh containers can reuse /root/deps/target artifacts.

Keep the image entrypoint unset and align Cargo cache-related environment with the reusable Rust workflow.

Created with assistance from OpenAI Codex (GPT-5.5).
