### PR TITLE
Reuse the prebuilt Miri sysroot

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -126,6 +126,7 @@ ENV CARGO_HOME=${CARGO_HOME} \
     RUSTFLAGS="${RUSTFLAGS}" \
     RUSTC_WRAPPER="sccache" \
     CARGO_TARGET_DIR=${HOME}/deps/target \
+    MIRI_SYSROOT=${HOME}/.cache/miri \
     RUST_VERSION_EXTERNAL_TYPES="${RUST_VERSION_EXTERNAL_TYPES}" \
     XDG_CACHE_HOME="${HOME}/.cache" \
     PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
## Summary

- point cargo-miri at the sysroot baked into the build image
- retain the existing single target-aware workspace clean
- prevent validation-time sysroot setup from disturbing warmed target artifacts

## Local verification

- target-only workspace clean removed 187 path-sensitive workspace artifacts
- stale source and build-script injection tests were both detected after target-only cleanup
- full ARM Miri run passed: 35 passed, 6 skipped
- full final-image build completed all build stages; local Docker import then failed with an unrelated `unexpected EOF` and the OrbStack socket became unavailable
- `just fmt` and `git diff --check` passed

## Supersedes

Supersedes #289 with the minimal one-line change.

Created with assistance from OpenAI Codex.