### PR TITLE
ci: fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,6 +6,11 @@ on:
     - cron: "0 2 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   renovate:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -28,6 +28,10 @@ on:
         default: ""
         type: string
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   CARGO_TERM_COLOR: always
   SCCACHE_DIR: "/tmp/sccache"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/mauricebarnum/oxia-rust/security/code-scanning/3](https://github.com/mauricebarnum/oxia-rust/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/rust.yml` so all jobs in this workflow (including the reusable-workflow job) run with least-privilege token scopes by default.

Best single fix here: insert at workflow root (after `name:` and before `on:`) a minimal read-only token scope:
- `permissions:`
  - `contents: read`

This is the safest baseline for CI workflows that primarily read repository contents. It documents security intent and prevents accidental privilege expansion if repo/org defaults change later. No imports, methods, or other definitions are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
