### PR TITLE
sequence updates

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -71,6 +71,7 @@ allowed_external_types = [
     "tonic::status::Status",
     "tonic::transport::error::Error",
     "futures_core::future::BoxFuture",
+    "futures_core::stream::BoxStream",
     "futures_core::stream::Stream",
     "bon::builder_state::IsSet",
     "bon::builder_state::IsUnset",

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -25,6 +25,7 @@ use backon::FibonacciBuilder;
 use backon::Retryable;
 use bon::Builder;
 use bytes::Bytes;
+use futures_core::stream::BoxStream;
 use futures_util::stream::StreamExt;
 use futures_util::stream::TryStreamExt;
 use mauricebarnum_oxia_common::proto as oxia_proto;
@@ -553,6 +554,20 @@ pub struct NotificationsOptions {
     /// reassignment) will not trigger a reconnection attempt.
     #[builder(default = false)]
     pub(crate) reconnect_on_error: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct SequenceUpdate {
+    pub highest_sequence_key: String,
+    pub shard: ShardId,
+}
+
+pub type SequenceUpdateStream = BoxStream<'static, Result<SequenceUpdate>>;
+
+#[derive(Clone, Debug)]
+pub enum SequenceUpdateRouting {
+    PartitionKey(String),
+    Shard(i64),
 }
 
 impl NotificationsOptions {
@@ -1647,6 +1662,7 @@ impl Client {
     }
 
     /// Create a notifications stream with default options.
+    #[inline]
     pub fn create_notifications_stream(&self) -> Result<NotificationsStream> {
         self.create_notifications_stream_with_options(NotificationsOptions::default())
     }
@@ -1662,6 +1678,73 @@ impl Client {
             Arc::clone(&shard_manager),
             options,
         ))
+    }
+
+    #[inline]
+    pub fn get_sequence_updates_shard(
+        &self,
+        key: impl Into<String>,
+        shard: i64,
+    ) -> impl Future<Output = Result<SequenceUpdateStream>> {
+        self.get_sequence_updates(key, SequenceUpdateRouting::Shard(shard))
+    }
+
+    #[inline]
+    pub fn get_sequence_updates_partition(
+        &self,
+        key: impl Into<String>,
+        partition: impl Into<String>,
+    ) -> impl Future<Output = Result<SequenceUpdateStream>> {
+        self.get_sequence_updates(key, SequenceUpdateRouting::PartitionKey(partition.into()))
+    }
+
+    #[inline]
+    pub fn get_sequence_updates(
+        &self,
+        key: impl Into<String>,
+        routing: SequenceUpdateRouting,
+    ) -> impl Future<Output = Result<SequenceUpdateStream>> {
+        self.get_sequence_updates_internal(key.into(), routing)
+    }
+
+    #[tracing::instrument(
+        target = "mauricebarnum_oxia_client",
+        name = "db.operation.get_sequence_updates",
+        skip(self, key),
+        fields(
+            db.system = metrics::DB_SYSTEM,
+            db.name = %self.config.namespace(),
+            db.operation = metrics::Operation::GetSequenceUpdates.as_str(),
+            db.oxia.shard_id = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        )
+    )]
+    async fn get_sequence_updates_internal(
+        &self,
+        key: String,
+        routing: SequenceUpdateRouting,
+    ) -> Result<SequenceUpdateStream> {
+        let start = metrics::operation_start();
+        let shard = match routing {
+            SequenceUpdateRouting::PartitionKey(pk) => self.get_shard(&pk),
+            SequenceUpdateRouting::Shard(s) => self.get_shard_by_id(s.into()),
+        };
+
+        let result = match shard {
+            Ok(shard) => {
+                tracing::Span::current().record("db.oxia.shard_id", i64::from(shard.id()));
+                shard.get_sequence_updates(key).await
+            }
+            Err(error) => Err(error),
+        };
+        metrics::record_operation_result(
+            &self.metrics,
+            metrics::Operation::GetSequenceUpdates,
+            metrics::result_kind,
+            start,
+            &result,
+        );
+        result.map(|stream| instrument_stream(stream, tracing::Span::current()).boxed())
     }
 }
 

--- a/client/src/metrics.rs
+++ b/client/src/metrics.rs
@@ -70,6 +70,7 @@ pub(crate) enum Operation {
     List,
     RangeScan,
     BatchGet,
+    GetSequenceUpdates,
 }
 
 impl Operation {
@@ -82,6 +83,7 @@ impl Operation {
             Self::List => "list",
             Self::RangeScan => "range_scan",
             Self::BatchGet => "batch_get",
+            Self::GetSequenceUpdates => "get_sequence_updates",
         }
     }
 }

--- a/client/src/shard.rs
+++ b/client/src/shard.rs
@@ -23,6 +23,7 @@ use arc_swap::ArcSwap;
 use bytes::Bytes;
 use futures_core::stream::Stream;
 use futures_util::FutureExt;
+use futures_util::TryStreamExt;
 use futures_util::stream::StreamExt;
 use mauricebarnum_oxia_common::proto as oxia_proto;
 use rand::SeedableRng;
@@ -59,6 +60,7 @@ use crate::RangeScanOptions;
 use crate::RangeScanResponse;
 use crate::Result;
 use crate::SecondaryIndex;
+use crate::SequenceUpdate;
 use crate::batch_get;
 use crate::config;
 use crate::create_grpc_client;
@@ -410,6 +412,35 @@ impl Client {
             self.invalidate_channel().await;
         }
         result
+    }
+
+    pub(crate) async fn get_sequence_updates(
+        &self,
+        key: String,
+    ) -> Result<impl Stream<Item = Result<SequenceUpdate>> + use<>> {
+        let req = oxia_proto::GetSequenceUpdatesRequest {
+            shard: self.data.shard_id.into(),
+            key,
+        };
+
+        let shard_id = self.data.shard_id;
+        let rsp_stream = self
+            .rpc(|mut grpc| async move { grpc.get_sequence_updates(req).await })
+            .await?
+            .into_inner();
+
+        Ok(rsp_stream
+            .filter_map(move |result| async move {
+                match result {
+                    Ok(r) if r.highest_sequence_key.is_empty() => None,
+                    Ok(r) => Some(Ok(SequenceUpdate {
+                        highest_sequence_key: r.highest_sequence_key,
+                        shard: shard_id,
+                    })),
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .map_err(Into::into))
     }
 }
 

--- a/client/tests/oxia_client_tests.rs
+++ b/client/tests/oxia_client_tests.rs
@@ -36,12 +36,17 @@ use mauricebarnum_oxia_client::OxiaError;
 use mauricebarnum_oxia_client::PutOptions;
 use mauricebarnum_oxia_client::RangeScanOptions;
 use mauricebarnum_oxia_client::SecondaryIndex;
+use mauricebarnum_oxia_client::SequenceUpdateRouting;
+use mauricebarnum_oxia_client::ShardId;
 use mauricebarnum_oxia_client::config;
 
 mod common;
 use common::TestResultExt;
 use common::non_zero;
 use tokio::time::timeout;
+use xxhash_rust::xxh3::xxh3_64;
+
+const SEQUENCE_TEST_SHARD_COUNT: u64 = 3;
 
 /// Helper function to create a test client
 async fn create_test_client_nshards(nshards: u32) -> Result<(common::TestServer, Client)> {
@@ -66,6 +71,21 @@ fn test_key(suffix: &str) -> String {
         chrono::Utc::now().timestamp_nanos_opt().unwrap(),
         suffix
     )
+}
+
+fn shard_for_key(key: &str, shard_count: u64) -> i64 {
+    let hash = xxh3_64(key.as_bytes()) & u64::from(u32::MAX);
+    i64::try_from((hash * shard_count) >> u32::BITS).expect("test shard id should fit in i64")
+}
+
+fn keys_on_different_shards(shard_count: u64) -> (String, String) {
+    let first = test_key("sequence-routing-prefix");
+    let first_shard = shard_for_key(&first, shard_count);
+    let second = (0..100)
+        .map(|suffix| test_key(&format!("sequence-routing-partition-{suffix}")))
+        .find(|key| shard_for_key(key, shard_count) != first_shard)
+        .expect("a key on another shard should be found");
+    (first, second)
 }
 
 #[test_log::test(tokio::test)]
@@ -385,6 +405,264 @@ async fn test_sequential_keys() -> Result<()> {
         .await?;
     assert!(get_result.is_some());
     assert_eq!(get_result.unwrap().value.unwrap().as_ref(), b"0");
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_sequence_updates_filters_empty_initial_response() -> Result<()> {
+    let (_server, client) = create_test_client().await?;
+    let key = test_key("sequence-updates-empty");
+    let subscriber = client.clone();
+    let subscription_key = key.clone();
+    let partition_key = key.clone();
+    let subscription = tokio::spawn(async move {
+        subscriber
+            .get_sequence_updates(
+                subscription_key,
+                SequenceUpdateRouting::PartitionKey(partition_key),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    let put_result = client
+        .put_with_options(
+            &key,
+            "value",
+            PutOptions::builder()
+                .partition_key(key.clone())
+                .sequence_key_deltas([1])
+                .build(),
+        )
+        .await?;
+    let expected_key = put_result.key.expect("sequential put should return a key");
+    let mut updates = timeout(Duration::from_secs(5), subscription).await???;
+    let update = timeout(Duration::from_secs(5), updates.next())
+        .await?
+        .expect("sequence update stream should remain open")?;
+
+    assert_eq!(update.highest_sequence_key, expected_key);
+    assert_eq!(update.shard, ShardId::new(0));
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_sequence_updates_converges_when_updates_are_collapsed() -> Result<()> {
+    let (_server, client) = create_test_client().await?;
+    let key = test_key("sequence-updates-collapsed");
+    let subscriber = client.clone();
+    let subscription_key = key.clone();
+    let partition_key = key.clone();
+    let subscription = tokio::spawn(async move {
+        subscriber
+            .get_sequence_updates(
+                subscription_key,
+                SequenceUpdateRouting::PartitionKey(partition_key),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    let mut expected_key = None;
+    for value in 0..8 {
+        let put_result = client
+            .put_with_options(
+                &key,
+                value.to_string(),
+                PutOptions::builder()
+                    .partition_key(key.clone())
+                    .sequence_key_deltas([1])
+                    .build(),
+            )
+            .await?;
+        expected_key = put_result.key;
+    }
+    let expected_key = expected_key.expect("sequential put should return a key");
+    let mut updates = timeout(Duration::from_secs(5), subscription).await???;
+
+    let observed_keys = timeout(Duration::from_secs(5), async {
+        let mut observed_keys = Vec::new();
+        loop {
+            let update = updates
+                .next()
+                .await
+                .expect("sequence update stream should remain open")?;
+            assert_eq!(update.shard, ShardId::new(0));
+            assert!(
+                update.highest_sequence_key <= expected_key,
+                "an update must not exceed the final generated key"
+            );
+
+            let reached_expected_key = update.highest_sequence_key == expected_key;
+            observed_keys.push(update.highest_sequence_key);
+            if reached_expected_key {
+                return Ok::<_, mauricebarnum_oxia_client::Error>(observed_keys);
+            }
+        }
+    })
+    .await??;
+
+    assert!(
+        observed_keys.windows(2).all(|keys| keys[0] < keys[1]),
+        "observed sequence updates should be strictly increasing: {observed_keys:?}"
+    );
+    assert_eq!(observed_keys.last(), Some(&expected_key));
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_sequence_updates_uses_partition_key_routing() -> Result<()> {
+    let (_server, client) = create_test_client_nshards(SEQUENCE_TEST_SHARD_COUNT as u32).await?;
+    let (key, partition_key) = keys_on_different_shards(SEQUENCE_TEST_SHARD_COUNT);
+    let expected_shard = ShardId::new(shard_for_key(&partition_key, SEQUENCE_TEST_SHARD_COUNT));
+
+    let incorrect_subscriber = client.clone();
+    let incorrect_key = key.clone();
+    let incorrect_partition_key = key.clone();
+    let incorrect_subscription = tokio::spawn(async move {
+        incorrect_subscriber
+            .get_sequence_updates(
+                incorrect_key,
+                SequenceUpdateRouting::PartitionKey(incorrect_partition_key),
+            )
+            .await
+    });
+    let subscriber = client.clone();
+    let subscription_key = key.clone();
+    let subscription_partition_key = partition_key.clone();
+    let subscription = tokio::spawn(async move {
+        subscriber
+            .get_sequence_updates(
+                subscription_key,
+                SequenceUpdateRouting::PartitionKey(subscription_partition_key),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    let put_result = client
+        .put_with_options(
+            &key,
+            "value",
+            PutOptions::builder()
+                .partition_key(partition_key)
+                .sequence_key_deltas([1])
+                .build(),
+        )
+        .await?;
+    let expected_key = put_result.key.expect("sequential put should return a key");
+    let mut updates = timeout(Duration::from_secs(5), subscription).await???;
+    let update = timeout(Duration::from_secs(5), updates.next())
+        .await?
+        .expect("sequence update stream should remain open")?;
+
+    assert_eq!(update.highest_sequence_key, expected_key);
+    assert_eq!(update.shard, expected_shard);
+
+    let incorrectly_routed_key = client
+        .put_with_options(
+            &key,
+            "incorrectly routed value",
+            PutOptions::builder()
+                .partition_key(key.clone())
+                .sequence_key_deltas([1])
+                .build(),
+        )
+        .await?
+        .key
+        .expect("sequential put should return a key");
+    let mut incorrectly_routed =
+        timeout(Duration::from_secs(5), incorrect_subscription).await???;
+    let incorrectly_routed_update = timeout(Duration::from_secs(5), incorrectly_routed.next())
+        .await?
+        .expect("sequence update stream should remain open")?;
+
+    assert_eq!(
+        incorrectly_routed_update.highest_sequence_key,
+        incorrectly_routed_key
+    );
+    assert_eq!(
+        incorrectly_routed_update.shard,
+        ShardId::new(shard_for_key(&key, SEQUENCE_TEST_SHARD_COUNT))
+    );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_sequence_updates_uses_shard_routing() -> Result<()> {
+    let (_server, client) = create_test_client_nshards(SEQUENCE_TEST_SHARD_COUNT as u32).await?;
+    let (key, partition_key) = keys_on_different_shards(SEQUENCE_TEST_SHARD_COUNT);
+    let expected_shard = shard_for_key(&partition_key, SEQUENCE_TEST_SHARD_COUNT);
+    let incorrect_shard = shard_for_key(&key, SEQUENCE_TEST_SHARD_COUNT);
+
+    let incorrect_subscriber = client.clone();
+    let incorrect_key = key.clone();
+    let incorrect_subscription = tokio::spawn(async move {
+        incorrect_subscriber
+            .get_sequence_updates(incorrect_key, SequenceUpdateRouting::Shard(incorrect_shard))
+            .await
+    });
+    let subscriber = client.clone();
+    let subscription_key = key.clone();
+    let subscription = tokio::spawn(async move {
+        subscriber
+            .get_sequence_updates(
+                subscription_key,
+                SequenceUpdateRouting::Shard(expected_shard),
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    let put_result = client
+        .put_with_options(
+            &key,
+            "value",
+            PutOptions::builder()
+                .partition_key(partition_key)
+                .sequence_key_deltas([1])
+                .build(),
+        )
+        .await?;
+    let expected_key = put_result.key.expect("sequential put should return a key");
+    let mut updates = timeout(Duration::from_secs(5), subscription).await???;
+    let update = timeout(Duration::from_secs(5), updates.next())
+        .await?
+        .expect("sequence update stream should remain open")?;
+
+    assert_eq!(update.highest_sequence_key, expected_key);
+    assert_eq!(update.shard, ShardId::new(expected_shard));
+
+    let incorrectly_routed_key = client
+        .put_with_options(
+            &key,
+            "incorrectly routed value",
+            PutOptions::builder()
+                .partition_key(key.clone())
+                .sequence_key_deltas([1])
+                .build(),
+        )
+        .await?
+        .key
+        .expect("sequential put should return a key");
+    let mut incorrectly_routed =
+        timeout(Duration::from_secs(5), incorrect_subscription).await???;
+    let incorrectly_routed_update = timeout(Duration::from_secs(5), incorrectly_routed.next())
+        .await?
+        .expect("sequence update stream should remain open")?;
+
+    assert_eq!(
+        incorrectly_routed_update.highest_sequence_key,
+        incorrectly_routed_key
+    );
+    assert_eq!(
+        incorrectly_routed_update.shard,
+        ShardId::new(incorrect_shard)
+    );
 
     Ok(())
 }

--- a/cmd/src/commands.rs
+++ b/cmd/src/commands.rs
@@ -24,6 +24,7 @@ mod list;
 mod notifications;
 mod put;
 mod range_scan;
+mod sequence_updates;
 mod shell;
 
 pub use batch_get::BatchGetCommand;
@@ -35,6 +36,7 @@ pub use list::ListCommand;
 pub use notifications::NotificationsCommand;
 pub use put::PutCommand;
 pub use range_scan::RangeScanCommand;
+pub use sequence_updates::SequenceUpdatesCommand;
 pub use shell::ShellCommand;
 
 #[async_trait]
@@ -74,6 +76,9 @@ pub enum Commands {
 
     /// Start a shell to run commands
     Shell(ShellCommand),
+
+    /// Get sequence updates for a key
+    SequenceUpdates(SequenceUpdatesCommand),
 }
 
 #[async_trait]
@@ -89,6 +94,7 @@ impl CommandRunnable for Commands {
             Self::Notifications(cmd) => cmd.run(ctx).await,
             Self::Put(cmd) => cmd.run(ctx).await,
             Self::RangeScan(cmd) => cmd.run(ctx).await,
+            Self::SequenceUpdates(cmd) => cmd.run(ctx).await,
             Self::Shell(cmd) => cmd.run(ctx).await,
         }
     }

--- a/cmd/src/commands/sequence_updates.rs
+++ b/cmd/src/commands/sequence_updates.rs
@@ -1,0 +1,71 @@
+// Copyright 2025-2026 Maurice S. Barnum
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::ArgGroup;
+use clap::Args;
+use futures_util::stream::StreamExt;
+use mauricebarnum_oxia_client::SequenceUpdateRouting;
+use tracing::trace;
+
+use super::CommandRunnable;
+
+#[derive(Args, Debug)]
+#[command(
+    group(
+        ArgGroup::new("target")
+            .args(["partition", "shard"])
+            .required(true)
+            .multiple(false)
+    )
+)]
+pub struct SequenceUpdatesCommand {
+    key: String,
+
+    /// Partition key to map shard
+    #[arg(short, long, conflicts_with("shard"))]
+    partition: Option<String>,
+
+    /// Shard to connect
+    #[arg(short, long, conflicts_with("partition"))]
+    shard: Option<i64>,
+}
+
+#[async_trait::async_trait]
+impl CommandRunnable for SequenceUpdatesCommand {
+    async fn run(self, ctx: crate::Context) -> anyhow::Result<()> {
+        trace!(?self, ?ctx, "params");
+
+        let routing = if let Some(k) = self.partition {
+            SequenceUpdateRouting::PartitionKey(k)
+        } else if let Some(s) = self.shard {
+            SequenceUpdateRouting::Shard(s)
+        } else {
+            panic!("partition or shard required")
+        };
+
+        let mut updates_stream = ctx
+            .client()
+            .await?
+            .get_sequence_updates(self.key, routing)
+            .await?;
+        trace!("sequence updates stream created");
+        while let Some(item) = updates_stream.next().await {
+            trace!(?item);
+            if let Ok(r) = item {
+                println!("shard={} seq={}", r.shard, r.highest_sequence_key);
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
- **clippy fix: unused `async` for async trait impl function with no `.await` statements**
- **clippy: unused import**
- **replace futures facade crate with futures-core and futures-util**
- **client: add get sequence updates API**
