### PR TITLE
ci: configure renovate to pin github actions to resolve SHA

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "ignorePaths": [
     "ext/oxia/**"


### PR DESCRIPTION
this addresses this type of complaint from codeql:

    Unpinned tag for a non-immutable Action in workflow or composite action
    Unpinned 3rd party Action 'Renovate' step Uses Step uses 'renovatebot/github-action' with ref 'v46.1.18', not a pinned commit hash
    CodeQL
