### PR TITLE
ci: split Dockerfile build stages

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,26 +6,33 @@ ARG RUST_VERSION=1.96.1
 ARG RUST_VERSION_EXTERNAL_TYPES=nightly-2026-03-20
 ARG GO_VERSION=1.26.5
 
-# ===== 1. Pull Official Images =====
-FROM rust:${RUST_VERSION} AS rust-official
+# ===== 1. Toolchain & Tool Preparers =====
+FROM rust:${RUST_VERSION}-slim AS rust-stable-toolchain
+RUN rustup component add clippy
+
 FROM golang:${GO_VERSION} AS go-official
 
-# ===== 2. Toolchain & Tool Preparer =====
-FROM rust-official AS toolchain-builder
-ARG RUST_VERSION_EXTERNAL_TYPES
-
-RUN rustup component add clippy && \
-    rustup toolchain install --profile minimal --allow-downgrade nightly && \
-    rustup component add --toolchain nightly miri rust-src && \
-    cargo +nightly miri setup --print-sysroot
-
-RUN rustup toolchain install "${RUST_VERSION_EXTERNAL_TYPES}" --profile minimal && \
-    cargo +"${RUST_VERSION_EXTERNAL_TYPES}" install cargo-check-external-types
-
+FROM rust-stable-toolchain AS cargo-bin-tools
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && \
     cargo binstall -y cargo-deny cargo-nextest sccache
 
-# ===== 3. OS Base Stage =====
+FROM rust-stable-toolchain AS rust-external-types-toolchain
+ARG RUST_VERSION_EXTERNAL_TYPES
+RUN rustup toolchain install "${RUST_VERSION_EXTERNAL_TYPES}" --profile minimal && \
+    cargo +"${RUST_VERSION_EXTERNAL_TYPES}" install cargo-check-external-types
+
+FROM rust-stable-toolchain AS rust-nightly-miri-toolchain
+RUN rustup toolchain install --profile minimal --allow-downgrade nightly && \
+    rustup component add --toolchain nightly miri rust-src && \
+    cargo +nightly miri setup --print-sysroot
+
+# ===== 2. OS Base Stage =====
 FROM ubuntu:24.04 AS os-base
 ARG CARGO_HOME
 ARG RUSTUP_HOME
@@ -41,18 +48,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# ===== 4. Go Builder =====
+# ===== 3. Go Builder =====
 FROM os-base AS go-builder
 COPY --from=go-official /usr/local/go /usr/local/go
 ENV PATH=/usr/local/go/bin:$PATH
 
-COPY ext/oxia /src
+COPY ext/oxia/cmd /src/cmd
 RUN --mount=type=cache,target=/tmp/gocache \
     GOPROXY=off GOCACHE=/tmp/gocache \
     go -C /src/cmd build -mod=vendor -o /tmp/oxia
 
-# ===== 5. Code Base Context Staging =====
-FROM os-base AS source-context
+# ===== 4. Tooling and Code Base Context Staging =====
+FROM os-base AS tooling-base
 ARG REPO_NAME=oxia-rust
 ARG CARGO_HOME
 ARG RUSTUP_HOME
@@ -66,17 +73,34 @@ ENV CARGO_HOME=${CARGO_HOME} \
     RUSTFLAGS="${RUSTFLAGS}" \
     RUSTC_WRAPPER="sccache" \
     SCCACHE_DIR="${HOME}/.cache/sccache" \
-    PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:/usr/local/go/bin:$PATH
+    PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:$PATH
 
-COPY --from=toolchain-builder /usr/local/cargo ${CARGO_HOME}
-COPY --from=toolchain-builder /usr/local/rustup ${RUSTUP_HOME}
-COPY --from=go-official /usr/local/go /usr/local/go
+COPY --from=rust-nightly-miri-toolchain /usr/local/rustup ${RUSTUP_HOME}
+COPY --from=rust-external-types-toolchain /usr/local/rustup ${RUSTUP_HOME}
+COPY --from=rust-nightly-miri-toolchain /usr/local/cargo ${CARGO_HOME}
+COPY --from=rust-external-types-toolchain /usr/local/cargo ${CARGO_HOME}
+COPY --from=cargo-bin-tools /usr/local/cargo ${CARGO_HOME}
 COPY --from=go-builder /tmp/oxia ${CARGO_HOME}/bin/oxia
 
 WORKDIR /__w/${REPO_NAME}/${REPO_NAME}
 
+FROM tooling-base AS cargo-fetch
+COPY Cargo.toml Cargo.lock ./
+COPY client/Cargo.toml client/Cargo.toml
+COPY cmd/Cargo.toml cmd/Cargo.toml
+COPY common/Cargo.toml common/Cargo.toml
+COPY oxia-bin-util/Cargo.toml oxia-bin-util/Cargo.toml
+RUN mkdir -p client/src client/benches cmd/src common/src oxia-bin-util/src && \
+    touch client/src/lib.rs \
+    client/benches/shard_lookup.rs \
+    client/benches/channel_pool.rs \
+    cmd/src/main.rs \
+    common/src/lib.rs \
+    oxia-bin-util/src/lib.rs && \
+    cargo fetch --locked
+
+FROM cargo-fetch AS source-context
 COPY . .
-RUN cargo fetch --locked
 
 # ===== 5a. Parallel Builder: CI Profile =====
 FROM source-context AS build-ci
@@ -108,6 +132,9 @@ RUN cargo +nightly clean \
     --target "$(rustc +nightly -vV | sed -n 's/^host: //p')" \
     --workspace
 
+FROM source-context AS final-cargo-home
+RUN rm -f "${CARGO_HOME}/bin/cargo-binstall"
+
 # ===== 6. Final Assembly (The Fan-In) =====
 FROM os-base AS final
 ARG CARGO_HOME
@@ -116,10 +143,8 @@ ARG HOME
 ARG RUSTFLAGS
 ARG RUST_VERSION_EXTERNAL_TYPES
 
-COPY --from=source-context ${CARGO_HOME} ${CARGO_HOME}
+COPY --from=final-cargo-home ${CARGO_HOME} ${CARGO_HOME}
 COPY --from=source-context ${RUSTUP_HOME} ${RUSTUP_HOME}
-COPY --from=source-context /usr/local/go /usr/local/go
-COPY --from=source-context ${CARGO_HOME}/bin/oxia ${CARGO_HOME}/bin/oxia
 
 ENV CARGO_HOME=${CARGO_HOME} \
     RUSTUP_HOME=${RUSTUP_HOME} \
@@ -129,7 +154,7 @@ ENV CARGO_HOME=${CARGO_HOME} \
     MIRI_SYSROOT=${HOME}/.cache/miri \
     RUST_VERSION_EXTERNAL_TYPES="${RUST_VERSION_EXTERNAL_TYPES}" \
     XDG_CACHE_HOME="${HOME}/.cache" \
-    PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:/usr/local/go/bin:$PATH
+    PATH=${CARGO_HOME}/bin:${RUSTUP_HOME}/bin:$PATH
 
 COPY build/cargo-config.toml ${CARGO_HOME}/config.toml
 

--- a/build/test-multiarch.sh
+++ b/build/test-multiarch.sh
@@ -20,7 +20,7 @@ echo "✅ Testing ARM64 build..."
 docker run --rm ${IMAGE_NAME}:${TAG}-arm64 sh -c "
     echo 'Architecture: \$(uname -m)'
     echo 'Rust: \$(rustc --version)'
-    echo 'Go: \$(go version)'
+    echo 'Oxia: \$(oxia --help >/dev/null && echo available)'
     echo 'Protoc: \$(protoc --version)'
     echo 'Cargo nextest: \$(cargo nextest --version)'
     echo 'Sccache: \$(sccache --version)'
@@ -35,7 +35,7 @@ echo "✅ Testing AMD64 build..."
 docker run --rm ${IMAGE_NAME}:${TAG}-amd64 sh -c "
     echo 'Architecture: \$(uname -m)'
     echo 'Rust: \$(rustc --version)'
-    echo 'Go: \$(go version)'
+    echo 'Oxia: \$(oxia --help >/dev/null && echo available)'
     echo 'Protoc: \$(protoc --version)'
     echo 'Cargo nextest: \$(cargo nextest --version)'
     echo 'Sccache: \$(sccache --version)'


### PR DESCRIPTION
Split the slim Rust image setup by cache volatility: stable clippy,
slim-image curl prerequisites, cargo binary tools, external-types, and
nightly/Miri now build in separate stages. Add a shared tooling-base
stage and a manifest-only cargo-fetch stage before the full source copy.

Copy only the prebuilt oxia binary into tooling-base and final instead
of carrying /usr/local/go through the Rust build image. Update the
multi-arch smoke test to verify oxia is available rather than checking
go version.

Created with assistance from Codex.
