### PR TITLE
update to go1.27.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ ARG RUSTUP_HOME=/root/.rustup
 ARG HOME=/root
 ARG RUST_VERSION=1.98.0
 ARG RUST_VERSION_EXTERNAL_TYPES=nightly-2026-03-20
-ARG GO_VERSION=1.26.7
+ARG GO_VERSION=1.27.0
 
 # ===== 1. Toolchain & Tool Preparers =====
 FROM rust:${RUST_VERSION}-slim AS rust-stable-toolchain

--- a/ext/oxia/cmd/go.mod
+++ b/ext/oxia/cmd/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/cockroachdb/errors v1.12.0 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.6 // indirect
-	github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b // indirect
+	github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20250429170803-42689b6311bb // indirect
 	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/ext/oxia/cmd/go.sum
+++ b/ext/oxia/cmd/go.sum
@@ -102,6 +102,8 @@ github.com/cockroachdb/redact v1.1.6 h1:zXJBwDZ84xJNlHl1rMyCojqyIxv+7YUpQiJLQ7n4
 github.com/cockroachdb/redact v1.1.6/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b h1:VXvSNzmr8hMj8XTuY0PT9Ane9qZGul/p67vGYwl9BFI=
 github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
+github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258 h1:IJ+uNItEm0qx9FE2AgIc1PMsCUtk8nbSIzhQE1t5GWw=
+github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/tokenbucket v0.0.0-20250429170803-42689b6311bb h1:3bCgBvB8PbJVMX1ouCcSIxvsqKPYM7gs72o0zC76n9g=
 github.com/cockroachdb/tokenbucket v0.0.0-20250429170803-42689b6311bb/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/ext/oxia/cmd/vendor/github.com/cockroachdb/swiss/runtime_go1.20.go
+++ b/ext/oxia/cmd/vendor/github.com/cockroachdb/swiss/runtime_go1.20.go
@@ -17,12 +17,12 @@
 // bumping of the go versions supported by adjusting the build tags below. The
 // way go version tags work the tag for goX.Y will be declared for every
 // subsequent release. So go1.20 will be defined for go1.21, go1.22, etc. The
-// build tag "go1.20 && !go1.27" defines the range [go1.20, go1.27) (inclusive
-// on go1.20, exclusive on go1.27).
+// build tag "go1.20 && !go1.28" defines the range [go1.20, go1.28) (inclusive
+// on go1.20, exclusive on go1.28).
 
 // The untested_go_version flag enables building on any go version, intended
 // to ease testing against Go at tip.
-//go:build (go1.20 && !go1.27) || untested_go_version
+//go:build (go1.20 && !go1.28) || untested_go_version
 
 package swiss
 

--- a/ext/oxia/cmd/vendor/modules.txt
+++ b/ext/oxia/cmd/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/cockroachdb/redact/internal/markers
 github.com/cockroachdb/redact/internal/redact
 github.com/cockroachdb/redact/internal/rfmt
 github.com/cockroachdb/redact/internal/rfmt/fmtsort
-# github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b
+# github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258
 ## explicit; go 1.21
 github.com/cockroachdb/swiss
 # github.com/cockroachdb/tokenbucket v0.0.0-20250429170803-42689b6311bb


### PR DESCRIPTION
pull an update to github.com/cockroachdb/swiss for toolchain
compatibility
