### PR TITLE
cargo deny fix: update chacha20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
   ┌─ /Users/pixi/src/mauricebarnum/oxia-rust/update-deps/Cargo.lock:27:1
   │
27 │ chacha20 0.10.1 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
   │
   ├ chacha20 v0.10.1
     └── rand v0.10.2
         └── mauricebarnum-oxia-client v0.1.0
             └── mauricebarnum-oxia-cmd v0.1.0
